### PR TITLE
Remove zTOC from metadata db

### DIFF
--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -213,7 +213,7 @@ type file struct {
 func (sf *file) ReadAt(p []byte, offset int64) (int, error) {
 	uncompFileSize := sf.fr.GetUncompressedFileSize()
 	if soci.FileSize(offset) >= uncompFileSize {
-		return 0, fmt.Errorf("invalid offset")
+		return 0, io.EOF
 	}
 	expectedSize := uncompFileSize - soci.FileSize(offset)
 	if expectedSize > soci.FileSize(len(p)) {

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -390,7 +390,7 @@ func (m *SpanManager) uncompressSpan(s *span, compressedBuf []byte) ([]byte, err
 	bytes := make([]byte, uncompSize)
 
 	// Theoretically, a span can be empty. If that happens, just return an empty buffer.
-        if uncompSize == 0 {
+	if uncompSize == 0 {
 		return bytes, nil
 	}
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -92,7 +92,6 @@ type Reader interface {
 type File interface {
 	GetUncompressedFileSize() soci.FileSize
 	GetUncompressedOffset() soci.FileSize
-	ReadAt(p []byte, off int64) (n int, err error)
 }
 
 type Options struct {


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
This change removes zTOC data from metadata.db. It also touches unit tests, especially in `fs/reader` and `fs/layer` folders, to correct them and plug in the right implementation of `metadata reader` and `fs/reader`.

*Testing*
1. `make test && make check` pass
2. `make integration` passes except for artifact generation consistency test, which will be fixed in the next patch
3. Deployed `soci-cli` and `soci-snapshotter-grpc` to an EC2 instance and executed the sample container workloads with SOCI for `rabbitmq` and `drupal` and saw successful execution.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
