### PR TITLE
Don't create soci directory on `soci create`

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -17,8 +17,6 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/awslabs/soci-snapshotter/fs/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/containerd/containerd/cmd/ctr/commands"
@@ -57,11 +55,6 @@ var CreateCommand = cli.Command{
 		srcRef := cliContext.Args().Get(0)
 		if srcRef == "" {
 			return errors.New("source image needs to be specified")
-		}
-
-		err := os.MkdirAll(config.SociIndexDirectory, 0755)
-		if err != nil {
-			return err
 		}
 
 		client, ctx, cancel, err := commands.NewClient(cliContext)

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -45,9 +45,6 @@ const (
 	// TargetSociIndexDigestLabel is a snapshot label key that contains the soci index digest
 	TargetSociIndexDigestLabel = "com.amazon.soci/remote/soci.index.digest"
 
-	// Local directory where SOCI indexes are stored
-	SociIndexDirectory = "soci/"
-
 	// Default path to OCI-compliant CAS
 	SociContentStorePath = "/var/lib/soci-snapshotter-grpc/content/"
 

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -23,9 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 
-	"github.com/awslabs/soci-snapshotter/fs/config"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
@@ -255,7 +253,7 @@ func buildSociLayer(ctx context.Context, cs content.Store, desc ocispec.Descript
 		Digest:         ztocDesc.Digest.String(),
 		OriginalDigest: desc.Digest.String(),
 		Type:           ArtifactEntryTypeLayer,
-		Location:       path.Join(config.SociIndexDirectory, desc.Digest.String()),
+		Location:       desc.Digest.String(),
 	}
 	err = writeArtifactEntry(entry)
 	if err != nil {
@@ -324,7 +322,7 @@ func WriteSociIndex(ctx context.Context, indexWithMetadata IndexWithMetadata, st
 		ImageDigest:    indexWithMetadata.ImageDigest.String(),
 		Platform:       platforms.Format(indexWithMetadata.Platform),
 		Type:           ArtifactEntryTypeIndex,
-		Location:       path.Join(config.SociIndexDirectory, indexWithMetadata.Index.Subject.Digest.String()),
+		Location:       indexWithMetadata.Index.Subject.Digest.String(),
 		Size:           size,
 	}
 	return writeArtifactEntry(entry)


### PR DESCRIPTION
Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*

*Description of changes:*
This commit removes the creation of a `soci/` directory on `soci
create`, since it is a remnant of the old artifacts store, and not
needed anymore.

The creation of the directory interferes with `soci create`, since the renamed `soci` binary conflicts with the CLI's attempt to create a `soci` directory. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
