### PR TITLE
Add soci index info command

### DIFF
--- a/cmd/soci/commands/index/index.go
+++ b/cmd/soci/commands/index/index.go
@@ -23,5 +23,6 @@ var Command = cli.Command{
 	Usage: "manage indices",
 	Subcommands: []cli.Command{
 		listCommand,
+		infoCommand,
 	},
 }

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -1,0 +1,56 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package index
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli"
+	"oras.land/oras-go/v2/content/oci"
+)
+
+var infoCommand = cli.Command{
+	Name:        "info",
+	Description: "get detailed info about an index",
+	ArgsUsage:   "<digest>",
+	Action: func(cliContext *cli.Context) error {
+		digest, err := digest.Parse(cliContext.Args().First())
+		if err != nil {
+			return err
+		}
+		storage, err := oci.New(config.SociContentStorePath)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), cliContext.GlobalDuration("timeout"))
+		defer cancel()
+		reader, err := storage.Fetch(ctx, v1.Descriptor{Digest: digest})
+		if err != nil {
+			return err
+		}
+		defer reader.Close()
+
+		_, err = io.Copy(os.Stdout, reader)
+		return err
+
+	},
+}


### PR DESCRIPTION
Signed-off-by: Kern Walster <walster@amazon.com>

*Description of changes:*
Adds `soci index info` to get the content of a soci index by digest.

E.g.
```
$ sudo ./out/soci index info sha256:7ce6400e2dd1adc92fd17dccb60697ea20ce99876969a79124888227b8c3b07f
{"mediaType":"application/vnd.cncf.oras.artifact.manifest.v1+json","artifactType":"application/vnd.amazon.soci.index.v1+json","blobs":[{"mediaType":"application/zstd","digest":"sha256:d20f947a6ae167d7974c07fa4df8967abf243cef5832eff264b8d82f1184e4c2","size":20844,"annotations":{"com.amazon.soci.image-layer-digest":"sha256:3cb635b06aa273034d7080e0242e4b6628c59347d6ddefff019bfd82f45aa7d5","com.amazon.soci.image-layer-mediaType":"application/vnd.oci.image.layer.v1.tar+gzip"}}],"subject":{"mediaType":"application/vnd.docker.distribution.manifest.v2+json","digest":"sha256:50e44504ea4f19f141118a8a8868e6c5bb9856efa33f2183f5ccea7ac62aacc9","size":527},"annotations":{"com.amazon.soci.build-tool-identifier":"AWS SOCI CLI","com.amazon.soci.build-tool-version":"0.1"}}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
