### PR TITLE
t.Fatal() doesn't take printf-like specifiers

### DIFF
--- a/fs/layer/prefetcher_test.go
+++ b/fs/layer/prefetcher_test.go
@@ -40,7 +40,7 @@ func TestPrefetcher(t *testing.T) {
 	}
 	ztoc, r, err := soci.BuildZtocReader(tarEntries, gzip.BestCompression, int64(spanSize))
 	if err != nil {
-		t.Fatal("failed to create ztoc: %w", err)
+		t.Fatalf("failed to create ztoc: %v", err)
 	}
 
 	spanCache := cache.NewMemoryCache()
@@ -50,7 +50,7 @@ func TestPrefetcher(t *testing.T) {
 
 	err = prefetcher.prefetch()
 	if err != nil {
-		t.Fatal("prefetch failed: %w", err)
+		t.Fatalf("prefetch failed: %v", err)
 	}
 }
 

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -303,10 +303,10 @@ func (m *SpanManager) getSpanFromCache(spanId string, offset, size soci.FileSize
 }
 
 func (m *SpanManager) verifySpanContents(compressedData []byte, id soci.SpanId) error {
-	actualDigest := digest.FromBytes(compressedData)
-	expectedDigest := m.ztoc.ZtocInfo.SpanDigests[id]
-	if actualDigest != expectedDigest {
-		return ErrIncorrectSpanDigest
+	actual := digest.FromBytes(compressedData)
+	expected := m.ztoc.ZtocInfo.SpanDigests[id]
+	if actual != expected {
+		return fmt.Errorf("expected %v but got %v: %w", expected, actual, ErrIncorrectSpanDigest)
 	}
 	return nil
 }


### PR DESCRIPTION
It has to be Fatalf() and %w is only for Errorf.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
