### PR TITLE
Remove null blobs from Soci Index

### DIFF
--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -217,10 +217,7 @@ func FetchSociArtifacts(ctx context.Context, imageRef, indexDigest string, store
 
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, blob := range index.Blobs {
-		if blob == nil {
-			continue
-		}
-		blob := *blob
+		blob := blob
 		eg.Go(func() error {
 			rc, local, err := fetcher.Fetch(ctx, blob)
 			if err != nil {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -209,10 +209,8 @@ func (fs *filesystem) fetchSociArtifacts(ctx context.Context, imageRef, indexDig
 
 func (fs *filesystem) populateImageLayerToSociMapping(sociIndex *soci.SociIndex) {
 	for _, desc := range sociIndex.Blobs {
-		if desc != nil {
-			ociDigest := desc.Annotations[soci.IndexAnnotationImageLayerDigest]
-			fs.imageLayerToSociDesc[ociDigest] = *desc
-		}
+		ociDigest := desc.Annotations[soci.IndexAnnotationImageLayerDigest]
+		fs.imageLayerToSociDesc[ociDigest] = desc
 	}
 }
 

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -106,22 +106,11 @@ func TestSociCreateSparseIndex(t *testing.T) {
 			}
 
 			blobs := sociIndex.Blobs
-			notNilBlobCount := 0
-			for _, b := range blobs {
-				if b != nil {
-					notNilBlobCount++
-				}
-			}
-			if notNilBlobCount != len(includedLayers) {
-				t.Fatalf("unexpected blob count; expected=%v, got=%v", len(includedLayers), notNilBlobCount)
+			if len(blobs) != len(includedLayers) {
+				t.Fatalf("unexpected blob count; expected=%v, got=%v", len(includedLayers), len(blobs))
 			}
 
 			for i, blob := range blobs {
-				if blob == nil {
-					continue
-				}
-				blob := *blob
-
 				blobContent := fetchContentFromPath(sh, blobStorePath+"/"+trimSha256Prefix(blob.Digest.String()))
 				blobSize := int64(len(blobContent))
 				blobDigest := digest.FromBytes(blobContent)
@@ -205,11 +194,6 @@ func TestSociCreate(t *testing.T) {
 			blobs := sociIndex.Blobs
 
 			for _, blob := range blobs {
-				if blob == nil {
-					continue
-				}
-				blob := *blob
-
 				blobContent := fetchContentFromPath(sh, blobStorePath+"/"+trimSha256Prefix(blob.Digest.String()))
 				blobSize := int64(len(blobContent))
 				blobDigest := digest.FromBytes(blobContent)

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -64,7 +64,7 @@ type SociIndex struct {
 	MediaType    string `json:"mediaType"`
 	ArtifactType string `json:"artifactType"`
 	// descriptors of ztocs
-	Blobs []*ocispec.Descriptor `json:"blobs,omitempty"`
+	Blobs []ocispec.Descriptor `json:"blobs,omitempty"`
 	// descriptor of image manifest
 	Subject ocispec.Descriptor `json:"subject,omitempty"`
 
@@ -172,6 +172,13 @@ func BuildSociIndex(ctx context.Context, cs content.Store, img images.Image, spa
 		return nil, err
 	}
 
+	ztocsDesc := make([]ocispec.Descriptor, 0, len(manifest.Layers))
+	for _, desc := range sociLayersDesc {
+		if desc != nil {
+			ztocsDesc = append(ztocsDesc, *desc)
+		}
+	}
+
 	annotations := map[string]string{
 		IndexAnnotationBuildToolIdentifier: config.buildToolIdentifier,
 		IndexAnnotationBuildToolVersion:    config.buildToolVersion,
@@ -180,7 +187,7 @@ func BuildSociIndex(ctx context.Context, cs content.Store, img images.Image, spa
 	sociIndex := SociIndex{
 		MediaType:    sociIndexMediaType,
 		ArtifactType: SociIndexArtifactType,
-		Blobs:        sociLayersDesc,
+		Blobs:        ztocsDesc,
 		Subject: ocispec.Descriptor{
 			MediaType:   imgManifestDesc.MediaType,
 			Digest:      imgManifestDesc.Digest,


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
This change removes the null values from Blobs section in Soci Index. This is done to allow the artifact representing sparse index to be pushed to the oras compatible registry, since null values for blobs are not supported (see https://github.com/oras-project/artifacts-spec/pull/114 for more details).

*Testing*
1. `make test && make check` pass
2. Deployed `soci` and `soci-snapshotter-grpc` on ec2 instance and ran the following test:
```
$ sudo out/soci create $ECR_IMAGE --min-layer-size 1000000
layer sha256:732a85e47ea26ecfafcb5e32f67bcbcea5d086695b149cdce6622fbd2a1c5749 -> ztoc skipped
layer sha256:21d12291db9292eb88f40cf52a4aa02d3c146eb8ed31751fc48d3618132859e8 -> ztoc skipped
layer sha256:dc83ff718436b3d76d75f63322a71beda5b2873cc37e18c776ed51a3e75b0812 -> ztoc skipped
layer sha256:c495acdd851fee4e4d3afd1f5b60e19de412e10684d83a7326550d58d41ea366 -> ztoc skipped
layer sha256:a61734a929ee8d1a4f484805054a02fd6cbce0644e321abb9045aa5932e5e7b9 -> ztoc skipped
layer sha256:9ff68fb88cd1bbfdf6d216ca21bacda24cbcb3b3fada604041fa65c243e0d521 -> ztoc skipped
layer sha256:00d1e2dae37ca901c9a1fe33de97503419a7663ee5d4a59b06f1982445abf8a5 -> ztoc skipped
layer sha256:9b4c116ad467b4226ab6fbe0106fef7eeb89b25ada82e45f34bc34a2f4c3930c -> ztoc skipped
layer sha256:9ab866e83c917b29f2d42bb88ed6053f8126edc9c652f260bc55836e3df6f7e1 -> ztoc skipped
layer sha256:6e96dec02e36f2282f604cfec8321e7c2fa1dabdf9749151408ad3255b818dce -> ztoc skipped
layer sha256:220ce72386def5f6243b8fd59464093bea56cba085a411750009409716e6f9f4 -> ztoc skipped
layer sha256:94e5defd60cff6434a1e72108d8a44006f81df9587892940e1e0da67037e2461 -> ztoc sha256:7d2b957de50fb50aadc7e2a2ac5d4cca79fc1e6fbe11431d46948f0e4ec00dee
layer sha256:0d7c7197c21e4f65b90fcc1e42482841f0a0596f1dcaa258369d383bc051cd96 -> ztoc sha256:73e59b13c029950f947ea754d92861ae5e7c4e2ce2a4e5eea247ac05bf532efe
layer sha256:13eb6c151345e6120dfca4f9bf52f6f9cc6f47893257f511a847e03a4e9f013b -> ztoc sha256:4627b099c86e9b85ef2e4349ea9856e7cdd4eefcc01bd40ff658ef70f7bff994
layer sha256:b58ed164af39db2e8446eaafab5869a0fd49a61ee68d8f751f1526dc3c4ec20d -> ztoc sha256:cccf13f23eb39386d95466a9d0a641a8b1789325517d4a189a71b1415c28cc65
layer sha256:b70d52650bc9e718ab64ebe6c4e013f154e1552be8b4da7c79d650452360efd0 -> ztoc sha256:c524610cfdfd0d58abf93a833db951b8ac871abe9c823009b30611fd4af79ed1
layer sha256:461246efe0a75316d99afdbf348f7063b57b0caeee8daab775f1f08152ea36f4 -> ztoc sha256:cf57dc51ab6c5e3f66392d1787d7507586c75e440dedb370b0b9ecf66229d952
layer sha256:62c455a2624a5689ea8aabac5aa06809930d30d1d5e834ce3c6988a186c90ea6 -> ztoc sha256:378699d9928035bb99c2fe3c62a4b344e42d806732d33702fdfdb9fb47531333
$ sudo out/soci push $ECR_IMAGE --user "$CR_USER:$CR_PASS"
skipped artifact with digest: sha256:378699d9928035bb99c2fe3c62a4b344e42d806732d33702fdfdb9fb47531333
skipped artifact with digest: sha256:cf57dc51ab6c5e3f66392d1787d7507586c75e440dedb370b0b9ecf66229d952
skipped artifact with digest: sha256:cccf13f23eb39386d95466a9d0a641a8b1789325517d4a189a71b1415c28cc65
skipped artifact with digest: sha256:73e59b13c029950f947ea754d92861ae5e7c4e2ce2a4e5eea247ac05bf532efe
skipped artifact with digest: sha256:4627b099c86e9b85ef2e4349ea9856e7cdd4eefcc01bd40ff658ef70f7bff994
skipped artifact with digest: sha256:7d2b957de50fb50aadc7e2a2ac5d4cca79fc1e6fbe11431d46948f0e4ec00dee
skipped artifact with digest: sha256:c524610cfdfd0d58abf93a833db951b8ac871abe9c823009b30611fd4af79ed1
skipped artifact with digest: sha256:6c727df3cf7391b3961d83acd1eb1858d1e7e16d80cef2ce1d8fa26e8804ff04
pushing artifact with digest: sha256:0d0c14b7eebf1d9704537f4dd089a7b6ec435e94778567b9d53b97e17fa7509e
successfully pushed artifact with digest: sha256:0d0c14b7eebf1d9704537f4dd089a7b6ec435e94778567b9d53b97e17fa7509e

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
