### PR TITLE
Update default span size to 4MiB

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -42,8 +42,8 @@ var CreateCommand = cli.Command{
 	Flags: []cli.Flag{
 		cli.Int64Flag{
 			Name:  "span-size",
-			Usage: "span size of index. Default is 1 MiB",
-			Value: 1 << 20,
+			Usage: "span size of index. Default is 4 MiB",
+			Value: 1 << 22,
 		},
 		cli.Int64Flag{
 			Name:  "min-layer-size",


### PR DESCRIPTION
*Description of changes:*
Early benchmarks show that setting the default span size as 4MiB
performs better than the current default of 1MiB.

Also updated the `TestSociCreateSparseIndex` integration test since it
was failing.

[Span Size Raw Data.pdf](https://github.com/awslabs/soci-snapshotter/files/9383251/Span.Size.Raw.Data.pdf)



*Testing performed:*
- `make && make check && make test && make integration`
- Manual testing: Able to run containers using the new default value. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
