### PR TITLE
Fix flaky prefetcher unit tests

### DIFF
--- a/c/indexer.c
+++ b/c/indexer.c
@@ -590,6 +590,7 @@ struct gzip_index* blob_to_index(void* buf)
         cur += 8;
         memcpy(&pt->out, cur, 8);
         cur += 8;
+        memset(&pt->bits, 0, sizeof(int));
         memcpy(&pt->bits, cur, 1);
         cur += 1;
         memcpy(&pt->window, cur, WINSIZE);

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -224,16 +224,16 @@ func TestStateTransition(t *testing.T) {
 			if tc.isPrefetch {
 				err := m.ResolveSpan(tc.spanID, r)
 				if err != nil {
-					t.Fatalf("failed resolving the span for prefetch")
+					t.Fatalf("failed resolving the span for prefetch: %v", err)
 				}
 				state := s.state.Load().(spanState)
 				if state != fetched {
 					t.Fatalf("failed transitioning to Fetched state")
 				}
 			} else {
-				_, err := m.GetSpanContent(tc.spanID, 0, s.endUncompOffset, s.endUncompOffset-s.startUncompOffset)
+				_, err := m.GetSpanContent(tc.spanID, 0, s.endUncompOffset-s.startUncompOffset, s.endUncompOffset-s.startUncompOffset)
 				if err != nil {
-					t.Fatalf("failed getting the span for on-demand fetch")
+					t.Fatalf("failed getting the span for on-demand fetch: %v", err)
 				}
 				state := s.state.Load().(spanState)
 				if state != uncompressed {


### PR DESCRIPTION
The prefetcher unit tests were failing because of uninitialized garbage
data when deserializing the dictionaries from the binary blob.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*
Fixes https://github.com/awslabs/soci-snapshotter/issues/24

*Description of changes:*

*Testing performed:*

Before :

```
$ for i in {0..100}; do go clean -testcache; go test ./...; echo $?; done | grep 1 | wc -l
17
```

After:

```
$ for i in {0..100}; do go clean -testcache; go test ./...; echo $?; done | grep 1 | wc -l
0
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
