### PR TITLE
Fix flaky prefetcher unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ check-ltag:
 
 # the very first auto-commit doesn't have a DCO and the first real commit has a slightly different format. Exclude those when doing the check.
 check-dco:
-	$(shell go env GOPATH)/bin/git-validation -run DCO -range 1374574271f4f14126c1d33735339f765f44f0a0..HEAD
+	$(shell go env GOPATH)/bin/git-validation -run DCO -range c5989e95ccd8dede6f39c7197a9db97131ac257b..HEAD
 
 install-check-tools:
 	@curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.45.2

--- a/c/indexer.c
+++ b/c/indexer.c
@@ -590,6 +590,7 @@ struct gzip_index* blob_to_index(void* buf)
         cur += 8;
         memcpy(&pt->out, cur, 8);
         cur += 8;
+        memset(&pt->bits, 0, sizeof(int));
         memcpy(&pt->bits, cur, 1);
         cur += 1;
         memcpy(&pt->window, cur, WINSIZE);

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -224,16 +224,16 @@ func TestStateTransition(t *testing.T) {
 			if tc.isPrefetch {
 				err := m.ResolveSpan(tc.spanID, r)
 				if err != nil {
-					t.Fatalf("failed resolving the span for prefetch")
+					t.Fatalf("failed resolving the span for prefetch: %v", err)
 				}
 				state := s.state.Load().(spanState)
 				if state != fetched {
 					t.Fatalf("failed transitioning to Fetched state")
 				}
 			} else {
-				_, err := m.GetSpanContent(tc.spanID, 0, s.endUncompOffset, s.endUncompOffset-s.startUncompOffset)
+				_, err := m.GetSpanContent(tc.spanID, 0, s.endUncompOffset-s.startUncompOffset, s.endUncompOffset-s.startUncompOffset)
 				if err != nil {
-					t.Fatalf("failed getting the span for on-demand fetch")
+					t.Fatalf("failed getting the span for on-demand fetch: %v", err)
 				}
 				state := s.state.Load().(spanState)
 				if state != uncompressed {


### PR DESCRIPTION
*Issue #, if available:*
Fixes #24 

*Description of changes:*
- Fixed prefetcher unit tests failure. It was caused by garbage data during de-serialization of index data from binary blob.
- Updated `make check-dco` to start from commit c5989e95c. 

*Testing performed:*

Before:

```
$ for i in {0..100}; go clean -testcache; go test ./...; echo $?; done | grep 1 | wc -l
21
```

After:

```
$ for i in {0..100}; go clean -testcache; go test ./...; echo $?; done | grep 1 | wc -l
0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
