### PR TITLE
Update `make check-dco` commit range

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ check-ltag:
 
 # the very first auto-commit doesn't have a DCO and the first real commit has a slightly different format. Exclude those when doing the check.
 check-dco:
-	$(shell go env GOPATH)/bin/git-validation -run DCO -range c5989e95ccd8dede6f39c7197a9db97131ac257b..HEAD
+	$(shell go env GOPATH)/bin/git-validation -run DCO -range 1628d6eac6cb9383f9538d0bb85de8a007b4f9a3..HEAD
 
 install-check-tools:
 	@curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.45.2


### PR DESCRIPTION


Signed-off-by: Kern Walster <walster@amazon.com>

*Description of changes:*

Commit #1628d6e was merged into main without DCO. This will break all
future commits because `make check-dco` will fail.

Commit #6a819dc fixed this, but it referenced a commit in the PR which
was rebased when merged, so the commit SHA changed.

This change starts the check just after #1628d6e

*Testing performed:*
```
make check
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
