### PR TITLE
Use either "trusted.overlay.opaque" or "user.overlay.opaque"

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -82,9 +82,10 @@ const (
 type Option func(*options)
 
 type options struct {
-	getSources      source.GetSources
-	resolveHandlers map[string]remote.Handler
-	metadataStore   metadata.Store
+	getSources        source.GetSources
+	resolveHandlers   map[string]remote.Handler
+	metadataStore     metadata.Store
+	overlayOpaqueType layer.OverlayOpaqueType
 }
 
 func WithGetSources(s source.GetSources) Option {
@@ -105,6 +106,12 @@ func WithResolveHandler(name string, handler remote.Handler) Option {
 func WithMetadataStore(metadataStore metadata.Store) Option {
 	return func(opts *options) {
 		opts.metadataStore = metadataStore
+	}
+}
+
+func WithOverlayOpaqueType(overlayOpaqueType layer.OverlayOpaqueType) Option {
+	return func(opts *options) {
+		opts.overlayOpaqueType = overlayOpaqueType
 	}
 }
 
@@ -143,7 +150,7 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snapshot.F
 	}
 
 	tm := task.NewBackgroundTaskManager(maxConcurrency, 5*time.Second)
-	r, err := layer.NewResolver(root, tm, cfg, fsOpts.resolveHandlers, metadataStore, store)
+	r, err := layer.NewResolver(root, tm, cfg, fsOpts.resolveHandlers, metadataStore, store, fsOpts.overlayOpaqueType)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to setup resolver")
 	}

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -132,10 +132,12 @@ type Resolver struct {
 	config                config.Config
 	metadataStore         metadata.Store
 	artifactStore         content.Storage
+	overlayOpaqueType     OverlayOpaqueType
 }
 
 // NewResolver returns a new layer resolver.
-func NewResolver(root string, backgroundTaskManager *task.BackgroundTaskManager, cfg config.Config, resolveHandlers map[string]remote.Handler, metadataStore metadata.Store, artifactStore content.Storage) (*Resolver, error) {
+func NewResolver(root string, backgroundTaskManager *task.BackgroundTaskManager, cfg config.Config, resolveHandlers map[string]remote.Handler,
+	metadataStore metadata.Store, artifactStore content.Storage, overlayOpaqueType OverlayOpaqueType) (*Resolver, error) {
 	resolveResultEntry := cfg.ResolveResultEntry
 	if resolveResultEntry == 0 {
 		resolveResultEntry = defaultResolveResultEntry
@@ -177,6 +179,7 @@ func NewResolver(root string, backgroundTaskManager *task.BackgroundTaskManager,
 		resolveLock:           new(namedmutex.NamedMutex),
 		metadataStore:         metadataStore,
 		artifactStore:         artifactStore,
+		overlayOpaqueType:     overlayOpaqueType,
 	}, nil
 }
 
@@ -521,7 +524,7 @@ func (l *layer) RootNode(baseInode uint32) (fusefs.InodeEmbedder, error) {
 	if l.r == nil {
 		return nil, fmt.Errorf("layer hasn't been verified yet")
 	}
-	return newNode(l.desc.Digest, l.r, l.blob, baseInode)
+	return newNode(l.desc.Digest, l.r, l.blob, baseInode, l.resolver.overlayOpaqueType)
 }
 
 func (l *layer) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, error) {

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -74,19 +74,36 @@ const (
 	stateDirMode      = syscall.S_IFDIR | 0500 // dr-x------
 )
 
-var opaqueXattrs = []string{"trusted.overlay.opaque", "user.overlay.opaque"}
+type OverlayOpaqueType int
 
-func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseInode uint32) (fusefs.InodeEmbedder, error) {
+const (
+	OverlayOpaqueAll OverlayOpaqueType = iota
+	OverlayOpaqueTrusted
+	OverlayOpaqueUser
+)
+
+var opaqueXattrs = map[OverlayOpaqueType][]string{
+	OverlayOpaqueAll:     {"trusted.overlay.opaque", "user.overlay.opaque"},
+	OverlayOpaqueTrusted: {"trusted.overlay.opaque"},
+	OverlayOpaqueUser:    {"user.overlay.opaque"},
+}
+
+func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseInode uint32, opaque OverlayOpaqueType) (fusefs.InodeEmbedder, error) {
 	rootID := r.Metadata().RootID()
 	rootAttr, err := r.Metadata().GetAttr(rootID)
 	if err != nil {
 		return nil, err
 	}
+	opq, ok := opaqueXattrs[opaque]
+	if !ok {
+		return nil, fmt.Errorf("unknown overlay opaque type")
+	}
 	ffs := &fs{
-		r:           r,
-		layerDigest: layerDgst,
-		baseInode:   baseInode,
-		rootID:      rootID,
+		r:            r,
+		layerDigest:  layerDgst,
+		baseInode:    baseInode,
+		rootID:       rootID,
+		opaqueXattrs: opq,
 	}
 	ffs.s = ffs.newState(layerDgst, blob)
 	return &node{
@@ -98,11 +115,12 @@ func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseIno
 
 // fs contains global metadata used by nodes
 type fs struct {
-	r           reader.Reader
-	s           *state
-	layerDigest digest.Digest
-	baseInode   uint32
-	rootID      uint32
+	r            reader.Reader
+	s            *state
+	layerDigest  digest.Digest
+	baseInode    uint32
+	rootID       uint32
+	opaqueXattrs []string
 }
 
 func (fs *fs) inodeOfState() uint64 {
@@ -338,7 +356,7 @@ var _ = (fusefs.NodeGetxattrer)((*node)(nil))
 func (n *node) Getxattr(ctx context.Context, attr string, dest []byte) (uint32, syscall.Errno) {
 	ent := n.attr
 	opq := n.isOpaque()
-	for _, opaqueXattr := range opaqueXattrs {
+	for _, opaqueXattr := range n.fs.opaqueXattrs {
 		if attr == opaqueXattr && opq {
 			// This node is an opaque directory so give overlayfs-compliant indicator.
 			if len(dest) < len(opaqueXattrValue) {
@@ -364,7 +382,7 @@ func (n *node) Listxattr(ctx context.Context, dest []byte) (uint32, syscall.Errn
 	var attrs []byte
 	if opq {
 		// This node is an opaque directory so add overlayfs-compliant indicator.
-		for _, opaqueXattr := range opaqueXattrs {
+		for _, opaqueXattr := range n.fs.opaqueXattrs {
 			attrs = append(attrs, []byte(opaqueXattr+"\x00")...)
 		}
 	}


### PR DESCRIPTION
This is a cherrypick of https://github.com/containerd/stargz-snapshotter/pull/681
We are trying to keep the common code in sync.

*Testing performed:*

`make && make check && make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
