### PR TITLE
Move CI checks to new job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,20 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 20
+      - run: make install-check-tools
+      - run: make check-ltag
+      - run: make check-dco
+      - run: make check-lint
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
       - run: make
       - run: make test
-      - run: make install-check-tools
-      - run: make check
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CMD=soci-snapshotter-grpc soci
 
 CMD_BINARIES=$(addprefix $(OUTDIR)/,$(CMD))
 
-.PHONY: all build pre-build check check-ltag check-dco install-check-tools install install-zlib uninstall clean test integration
+.PHONY: all build pre-build check check-ltag check-dco check-lint install-check-tools install install-zlib uninstall clean test integration
 
 all: build
 
@@ -57,8 +57,10 @@ install-zlib:
 	@rm -rf zlib-1.2.12
 	@rm -f zlib-1.2.12.tar.gz
 
-# "check" depends "build". out/libindexer.a seems needed to process cgo directives
-check: build check-ltag check-dco
+check: check-ltag check-dco check-lint
+
+# "check-lint" depends "pre-build". out/libindexer.a seems needed to process cgo directives
+check-lint: pre-build
 	GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
 	cd ./cmd ; GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
 


### PR DESCRIPTION
Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
This change moves CI checks to a separate job so that its more obvious
whether a CI failure is due to a build/test issue or a policy issue. It
also makes CI fail faster when there are policy issues.

*Testing performed:*
`make check` 

The workflow can be verified in my fork:
https://github.com/Kern--/soci-snapshotter/actions/runs/2913977728

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
