### PR TITLE
Add --debug flag to dump HTTP requests/responses

### DIFF
--- a/cmd/soci/main.go
+++ b/cmd/soci/main.go
@@ -71,6 +71,10 @@ func main() {
 			Name:  "timeout",
 			Usage: "timeout for commands",
 		},
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "enable debug output",
+		},
 	}
 
 	app.Commands = []cli.Command{


### PR DESCRIPTION
Since ORAS is relatively new, there may be some edge cases and/or
confusing behaviors.

This commit adds --debug flag that dumps HTTP requests/responses.
We could add some other verbose logging to the flag later.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing performed:*

`http req` and `http res` are coming from this flag.

```
% sudo ./out/soci --debug push -u username:$password repos.example.com/socitest:al2
http req HEAD https://repos.example.com/v2/socitest/manifests/sha256:6a118da7905df0ea032272087725703b61f5f77b341fe0d2d7750afd17910ea2
http res 200 OK
skipped artifact with digest: sha256:6a118da7905df0ea032272087725703b61f5f77b341fe0d2d7750afd17910ea2
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
