### PR TITLE
Fix the size of span content returned from cache

### DIFF
--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -364,7 +364,7 @@ func (m *SpanManager) resolveSpanFromCache(s *span, offsetStart, size soci.FileS
 		if err != nil {
 			return nil, err
 		}
-		return bytes.NewReader(uncompSpanBuf[offsetStart:]), nil
+		return bytes.NewReader(uncompSpanBuf[offsetStart:offsetStart+size]), nil
 	}
 	return nil, ErrSpanNotAvailable
 }


### PR DESCRIPTION
resolveSpanFromCache should return the span content of requested size not
the content from offset to the end of the span.

Signed-off-by: Hanyue Liang <hanliang@amazon.com>

*Issue #, if available: resolveSpanFromCache returns span content that is more than needed. It should return the span starting from the offset with the given size, not from the offset to the end of the span. Sometimes we see this error message for on-demand fetch:

> "error":"file.Read: unexpected copied data size for on-demand fetch. read = 4096, expected = 446"

*Description of changes: 
1. fixed the offsets of the span buffer returned for resolveSpanFromCache
2. updated the related Span Manager test

*Testing performed: make test, make integration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
