### PR TITLE
Plumb plain-http flag through

### DIFF
--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -109,6 +109,9 @@ if they are available in the snapshotter's local content store.
 			}, nil
 		}
 
+		dst.Client = authClient
+		dst.PlainHTTP = cliContext.Bool("plain-http")
+
 		debug := cliContext.GlobalBool("debug")
 		if debug {
 			dst.Client = &debugClient{client: authClient}


### PR DESCRIPTION
Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

As part of simplifying the learning process we want to enable registries without TLS certification to be used.  containerd does this via a --plain-http flag.  The soci cli does not have this plumbed through yet.  Currently when we try to use the `--plain-http` flag it simply ignores it : 

```
sudo ./soci push --plain-http localhost:5000/test
soci: error pushing graph to remote: Head "https://localhost:5000/v2/test/manifests/sha256:b6281c9d2502217f8b1c879737ba766429af3fb020aa9f9ffa89f80002d537aa": http: server gave HTTP response to HTTPS client
```
This change passes the flag through to the [oras repo object](https://github.com/oras-project/oras-go/blob/064752f3088e5df9aaa1ff1848fca81016b4cd0d/registry/remote/repository.go#L72).

Afterwards we see that the plain-http call works
```
sudo ./soci push --plain-http localhost:5000/test
skipped artifact with digest: sha256:f29312a3a32fe06760178a356f8ddaa59cd7d65b29ea097b59852f42599fd673
skipped artifact with digest: sha256:7a3882c7c443c949582709e076210af6aeaaf47c5f375acc3a52e79c5116786e
skipped artifact with digest: sha256:f466106a549093a1dd41089b087f8b36fa776cdf48726ffc7afb154687c31c3a
skipped artifact with digest: sha256:34141c90431ec6e26925f961c2c5f3ce6c1f2ea47d6c6ff2fb586ed08fcb83c7
skipped artifact with digest: sha256:5e93439bf1df1e2544595c1d672664aff49150eab5867fefd27b1d466266932b
skipped artifact with digest: sha256:5fe3aaf813b29dd7bd4c8cdb27716e68d1d673e8c51055ba07fd0b52152490b2
skipped artifact with digest: sha256:6b612357f7d02e15b7beddf606ac868a9f0d288d75a7fd9a859c7f6e674d599d
skipped artifact with digest: sha256:c26190118089ca3976454047a19e3a316439edbd4d6b346efbc11a1f1c49c64b
skipped artifact with digest: sha256:f6061ac53c34f215066f271e37874cb9c023ed6e21caeed9d4926c32222978d4
skipped artifact with digest: sha256:d47bcc06ee48f65556022e3b640bc76ceb372203ac876ff67598298b967b2fce
pushing artifact with digest: sha256:b6281c9d2502217f8b1c879737ba766429af3fb020aa9f9ffa89f80002d537aa
soci: error pushing graph to remote: PUT "http://localhost:5000/v2/test/manifests/sha256:b6281c9d2502217f8b1c879737ba766429af3fb020aa9f9ffa89f80002d537aa": unexpected status code 400: manifest invalid: manifest invalid
```

**NOTE** : There is still something going on, but that will be dealt with in a future CR as it does not appear to involve the http vs https issue.

*Description of changes:*
One liner to just pass the boolean flag into the destination repo.  thanks to @kzys  and @Kern--  for identifying this change.

*Testing performed:*
Manually tested as per above

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
