### PR TITLE
Disable failing integration test

### DIFF
--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -121,10 +121,15 @@ func TestOptimizeConsistentSociArtifact(t *testing.T) {
 			name:           "soci artifact is consistently built for ubuntu",
 			containerImage: "ubuntu:latest",
 		},
-		{
-			name:           "soci artifact is consistently built for rethinkdb",
-			containerImage: "nginx:latest",
-		},
+		/*
+			The following test is disabled for now, since it randomly fails due to
+			the way gob encodes FileMetadata.Xattrs.
+			TODO(rdpsin): Re-enable this test once gob is no longer used to encode FileMetadata.
+			{
+				name:           "soci artifact is consistently built for nginx",
+				containerImage: "nginx:latest",
+			},
+		*/
 		{
 			name:           "soci artifact is consistently built for drupal",
 			containerImage: "alpine:latest",


### PR DESCRIPTION
This commit disables the nginx:latest test in
TestOptimizeConsistentSociArtifact due to the way gob encodes
FileMetadata.Xattrs. It will be re-enabled once we move away from gob.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing performed:*
`make && make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
