### PR TITLE
Add add-ltag make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,13 @@ VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 GO_LD_FLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) $(GO_EXTRA_LDFLAGS)'
 SOCI_SNAPSHOTTER_PROJECT_ROOT ?= $(shell pwd)
+LTAG_TEMPLATE_FLAG=-t ./.headers
 
 CMD=soci-snapshotter-grpc soci
 
 CMD_BINARIES=$(addprefix $(OUTDIR)/,$(CMD))
 
-.PHONY: all build pre-build check check-ltag check-dco check-lint install-check-tools install install-zlib uninstall clean test integration
+.PHONY: all build pre-build check check-ltag check-dco check-lint install-check-tools add-ltag install install-zlib uninstall clean test integration
 
 all: build
 
@@ -65,7 +66,7 @@ check-lint: pre-build
 	cd ./cmd ; GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
 
 check-ltag:
-	$(shell go env GOPATH)/bin/ltag -t ./.headers -check -v || (echo "The files listed above are missing a licence header"; exit 1)
+	$(shell go env GOPATH)/bin/ltag $(LTAG_TEMPLATE_FLAG) -check -v || (echo "The files listed above are missing a licence header. Please run make add-ltag"; exit 1)
 
 # the very first auto-commit doesn't have a DCO and the first real commit has a slightly different format. Exclude those when doing the check.
 check-dco:
@@ -84,6 +85,9 @@ install:
 uninstall:
 	@echo "$@"
 	@rm -f $(addprefix $(CMD_DESTDIR)/bin/,$(notdir $(CMD_BINARIES)))
+
+add-ltag:
+	$(shell go env GOPATH)/bin/ltag $(LTAG_TEMPLATE_FLAG) -v
 
 clean:
 	rm -rf $(OUTDIR)


### PR DESCRIPTION
Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*

N/A

*Description of changes:*

As part of PR validation, we use ltag to verify that all go files in the
project have our license header. If files are missing the header, ltag
fails the check and outputs the list of files that need to be updated.

Before this change, the make rule gave no indication about what exactly
was missing or how to fix it, forcing contributors to dig through either
our code or makefile or both to find out. Once the contributor knew what
to do, it wasn't obvious that there might be a way to add the header
other than manually copy-pasting it into each new file.

Since ltag has the ability to add the header directly, this change adds
`make add-ltag` to add the header to the files that are missing them as
well as mentions this target in the error message from `make
check-ltag`.

*Testing performed:*
Manual testing:
1. Remove the license header from a go file
2. Run `make check-ltag` to verify that it correctly detects the missing header
3. Run `make add-ltag` to add the header back
4. Run `git diff` to verify that adding the header returned the file to its original state

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
