### PR TITLE
Add `soci ztoc list` command

### DIFF
--- a/cmd/soci/commands/ztoc/list.go
+++ b/cmd/soci/commands/ztoc/list.go
@@ -1,0 +1,61 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ztoc
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/urfave/cli"
+)
+
+var listCommand = cli.Command{
+	Name:        "list",
+	Description: "list ztocs",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "digest",
+			Usage: "filter ztocs by digest",
+		},
+	},
+	Action: func(cliContext *cli.Context) error {
+		db, err := soci.NewDB()
+		if err != nil {
+			return err
+		}
+		digest := cliContext.String("digest")
+
+		var artifacts []*soci.ArtifactEntry
+		db.Walk(func(ae *soci.ArtifactEntry) error {
+			if ae.Type == soci.ArtifactEntryTypeLayer &&
+				(digest == "" || ae.Digest == digest) {
+				artifacts = append(artifacts, ae)
+			}
+			return nil
+		})
+
+		writer := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
+		writer.Write([]byte("DIGEST\tSIZE\tLAYER DIGEST\t\n"))
+		for _, artifact := range artifacts {
+			writer.Write([]byte(fmt.Sprintf("%s\t%d\t%s\t\n", artifact.Digest, artifact.Size, artifact.OriginalDigest)))
+		}
+		writer.Flush()
+		return nil
+	},
+}

--- a/cmd/soci/commands/ztoc/ztoc.go
+++ b/cmd/soci/commands/ztoc/ztoc.go
@@ -24,5 +24,6 @@ var Command = cli.Command{
 	Subcommands: []cli.Command{
 		infoCommand,
 		getFileCommand,
+		listCommand,
 	},
 }


### PR DESCRIPTION

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
This change adds `soci ztoc list` to get a full list of zTOCs that the soci cli is aware of. The main purpose for this command is to inspect the state of the SOCI artifact DB, for example, to confirm that a specific zTOC is in the DB.

*Testing performed:*
Manual testing:
```
$ sudo ./out/soci ztoc list
DIGEST                                                                     SIZE     LAYER DIGEST                                                               
sha256:3038eb20acfde160f329f806a57a1ba2b4c006cdddc3865d550766210953fd2d    29899    sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49    
sha256:3e19a9256d9a0dbdd449849f4656267feb90b976b7dd852c940745de61001459    562      sha256:62ee210c7bd0f3533e005041f5fae6ca2c761a0345acde7c3ab5710477490aa0    
sha256:617cb01cdcea794b9c79f583d76baf44d04f57141f6040ca805081a33044f3d3    606      sha256:ed205af28a420b37f9c59c56fe9fa9b8e0e44e267de65a56c5123ac82cf5c755    
sha256:77dde3fbc7a1a7e824b1337198391676fe93b464ba497c304e568a27b557e46d    4365     sha256:0e91ca3e9822cc4288400bfd9503641eef92c55b2eed9c6f4b78e4039e5e51b1    
sha256:822e153b89265a704f0cb6b95fc61d2cf35543b9f84daa9d94054e61202c8aaf    583      sha256:3ccbdc2d3a2da473ca39da296c7b75e350fe5386f9fd3e35f468e7a2b15d6912    
sha256:a11977eaf581daec63f5ed29fd98abd89da24adcabe39abb5baff2479b2148ae    4370     sha256:50783e0dfb64b73019e973e7bce2c0d5a882301b781327ca153b876ad758dbd3    
sha256:e14b01c431a93462bf12501d28e1e6ac246c25a03b89575d91ba613dfdfaa8ff    4349     sha256:98b2487441371387528fef89ca035cf0051e29f19f2ddc6d7a6d8f905c8f660b    
sha256:ee0f7decfd645ef06f22c995dbba579328714310461667d641c9b6855cbfbe91    4361     sha256:73d35a519aaefd4427043e2c64184916d855cc76204abdab963d202daad5924d    
sha256:fe29e2dec2b9cae400f2afaa59c0dc3064d82194356dc690bc7a50ee246be39e    559      sha256:8395093cb35f845209ac21bb042bb46a79f2b5290cf2a6cf3518d102340f0a67    
```
```
$ sudo ./out/soci ztoc list --digest sha256:3038eb20acfde160f329f806a57a1ba2b4c006cdddc3865d550766210953fd2d
DIGEST                                                                     SIZE     LAYER DIGEST                                                               
sha256:3038eb20acfde160f329f806a57a1ba2b4c006cdddc3865d550766210953fd2d    29899    sha256:213ec9aee27d8be045c6a92b7eac22c9a64b44558193775a1a7f626352392b49 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
