### PR TITLE
fs: return correct size of symlink

### DIFF
--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -640,6 +640,9 @@ func (sf *statFile) updateStatUnlocked() ([]byte, error) {
 func entryToAttr(ino uint64, e metadata.Attr, out *fuse.Attr) fusefs.StableAttr {
 	out.Ino = ino
 	out.Size = uint64(e.Size)
+	if e.Mode&os.ModeSymlink != 0 {
+		out.Size = uint64(len(e.LinkName))
+	}
 	out.Blksize = blockSize
 	out.Blocks = out.Size / uint64(out.Blksize)
 	if out.Size%uint64(out.Blksize) > 0 {


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
This is a cherry pick of a fix on stargz snapshotter (https://github.com/containerd/stargz-snapshotter/pull/672), which ensures that `stat(2)` returns the correct file size for symbolic links.

*Testing performed:*
- `make test && make check && make integration` pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
