### PR TITLE
Check last 20 commits in `make check-dco`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 20
+          # check-dco will check the last 20 commits, but commit ranges
+          # exclude the start commit in the result, but need that commit
+          # in order to calculate the range. i.e. HEAD~20..HEAD includes
+          # 20 commits, but including HEAD it needs 21 commits.
+          fetch-depth: 21
       - run: make install-check-tools
       - run: make check-ltag
       - run: make check-dco

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ check-ltag:
 
 # the very first auto-commit doesn't have a DCO and the first real commit has a slightly different format. Exclude those when doing the check.
 check-dco:
-	$(shell go env GOPATH)/bin/git-validation -run DCO -range 1628d6eac6cb9383f9538d0bb85de8a007b4f9a3..HEAD
+	$(shell go env GOPATH)/bin/git-validation -run DCO -range HEAD~20..HEAD
 
 install-check-tools:
 	@curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.45.2


### PR DESCRIPTION

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*
Closes https://github.com/awslabs/soci-snapshotter/issues/6

*Description of changes:*
Rather than checking for the DCO sign of in every commit in the repository, we only check a subset. Ideally, this would be only the new commits in each PR, however that number is unknowable, so therefore we just choose 20 somewhat arbitrarily.

Before this commit, we had a couple commits merged into main that were either missing the DCO sign off or had an incorrect format, so we hardcoded the start of the range. Now that we have more commits, we can safely switch back to checking just the last 20.


*Testing performed:*
`make check`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
