### PR TITLE
Apply difference when decompressing layers

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -61,6 +61,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/task"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes/docker"
 	metrics "github.com/docker/go-metrics"
@@ -221,7 +222,7 @@ func (fs *filesystem) populateImageLayerToSociMapping(sociIndex *soci.Index) {
 	}
 }
 
-func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels map[string]string) error {
+func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
 	imageRef, ok := labels[source.TargetRefLabel]
 	if !ok {
 		return fmt.Errorf("unable to get image ref from labels")
@@ -250,7 +251,7 @@ func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels 
 	}
 	unpacker := NewLayerUnpacker(fetcher, archive)
 	desc := s.Target
-	err = unpacker.Unpack(ctx, desc, mountpoint)
+	err = unpacker.Unpack(ctx, desc, mountpoint, mounts)
 	if err != nil {
 		return fmt.Errorf("cannot unpack the layer: %w", err)
 	}

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -434,7 +434,7 @@ func (fs *bindFs) Unmount(ctx context.Context, mountpoint string) error {
 	return syscall.Unmount(mountpoint, 0)
 }
 
-func (fs *bindFs) MountLocal(ctx context.Context, mountpoint string, labels map[string]string) error {
+func (fs *bindFs) MountLocal(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
 	if _, ok := labels[brokenLabel]; ok {
 		fs.broken[mountpoint] = true
 	}
@@ -460,7 +460,7 @@ func (fs *dummyFs) Unmount(ctx context.Context, mountpoint string) error {
 	return fmt.Errorf("dummy")
 }
 
-func (fs *dummyFs) MountLocal(ctx context.Context, mountpoint string, labels map[string]string) error {
+func (fs *dummyFs) MountLocal(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
 	return fmt.Errorf("dummy")
 }
 


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
When layers were decompressed by the snapshotter, the diff did not apply, which resulted in abnormal behavior, e.g. with drupal image, when using sparse index, the output of the startup workflow would look like: `AH00534: apache2: Configuration error: More than one MPM loaded.`. This PR fixed this by ensuring that when the `archive.Apply` applies the decompressed stream to the mount dir, it takes into account parent layers.

*Testing performed:*
1. `make test && make check && make integration`
2. Executed workflow on drupal image with index built for min-layer-size 1MiB and observed:
```
$mounts
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
fusectl on /sys/fs/fuse/connections type fusectl (rw,relatime)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/3/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/5/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/8/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/10/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/14/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/18/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
$ sudo soci-snapshotter/out/soci run --snapshotter=soci --net-host $IMAGE container-id 2>&1
[Wed Sep 14 16:13:24.926840 2022] [mpm_prefork:notice] [pid 1] AH00163: Apache/2.4.54 (Debian) PHP/8.0.21 configured -- resuming normal operations
[Wed Sep 14 16:13:24.926890 2022] [core:notice] [pid 1] AH00094: Command line: 'apache2 -D FOREGROUND'
```
3. Performed similar tests with the following images: rethinkdb, rabbitmq, tomcat, redis

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
