### PR TITLE
indexer uses int64_t instead of off_t

### DIFF
--- a/c/indexer.c
+++ b/c/indexer.c
@@ -59,7 +59,7 @@ void free_index(struct gzip_index *index)
 /* Add an entry to the access point list.  If out of memory, deallocate the
    existing list and return NULL. */
 static struct gzip_index *addpoint(struct gzip_index *index, uint8_t bits,
-    off_t in, off_t out, unsigned left, unsigned char *window)
+    offset_t in, offset_t out, unsigned left, unsigned char *window)
 {
     struct gzip_index_point *next;
 
@@ -105,11 +105,11 @@ static struct gzip_index *addpoint(struct gzip_index *index, uint8_t bits,
 
 
 /* Pretty much the same as from zran.c */
-int generate_index_fp(FILE* in, off_t span, struct gzip_index** idx)
+int generate_index_fp(FILE* in, offset_t span, struct gzip_index** idx)
 {
     int ret;
-    off_t totin, totout;        /* our own total counters to avoid 4GB limit */
-    off_t last;                 /* totout value of last access point */
+    offset_t totin, totout;        /* our own total counters to avoid 4GB limit */
+    offset_t last;                 /* totout value of last access point */
     struct gzip_index *index;       /* access points being generated */
     z_stream strm;
     unsigned char input[CHUNK];
@@ -220,12 +220,12 @@ static uint8_t get_bits(struct gzip_index* index, int point_index)
     return index->list[point_index].bits;
 }
 
-off_t get_ucomp_off(struct gzip_index* index, int point_index)
+offset_t get_ucomp_off(struct gzip_index* index, int point_index)
 {
     return index->list[point_index].out;
 }
 
-off_t get_comp_off(struct gzip_index* index, int point_index)
+offset_t get_comp_off(struct gzip_index* index, int point_index)
 {
     return index->list[point_index].in;
 }
@@ -236,7 +236,7 @@ static int min(int lhs, int rhs)
 }
 
 // This is the same as extract_data_fp, but instead of a file, it decompresses data from a buffer which contains the exact data to decompress 
-int extract_data_from_buffer(void* d, off_t datalen, struct gzip_index* index, off_t offset, void* buffer, off_t len, int first_point_index)
+int extract_data_from_buffer(void* d, offset_t datalen, struct gzip_index* index, offset_t offset, void* buffer, offset_t len, int first_point_index)
 {
     int ret, skip;
     z_stream strm;
@@ -322,7 +322,7 @@ int extract_data_from_buffer(void* d, off_t datalen, struct gzip_index* index, o
 }
 
 
-int extract_data_fp(FILE *in, struct gzip_index *index, off_t offset, void *buffer, int len)
+int extract_data_fp(FILE *in, struct gzip_index *index, offset_t offset, void *buffer, int len)
 {
     int ret, skip;
     z_stream strm;
@@ -423,7 +423,7 @@ int extract_data_fp(FILE *in, struct gzip_index *index, off_t offset, void *buff
     return ret;
 }
 
-int extract_data(const char* file, struct gzip_index* index, off_t offset, void* buf, int len)
+int extract_data(const char* file, struct gzip_index* index, offset_t offset, void* buf, int len)
 {
     FILE* fp = fopen(file, "rb");
     if (fp == NULL) 
@@ -436,7 +436,7 @@ int extract_data(const char* file, struct gzip_index* index, off_t offset, void*
     return ret;
 }
 
-int generate_index(const char* filepath, off_t span, struct gzip_index** index)
+int generate_index(const char* filepath, offset_t span, struct gzip_index** index)
 {
     FILE* fp = fopen(filepath, "rb");
     if (fp == NULL)
@@ -448,7 +448,7 @@ int generate_index(const char* filepath, off_t span, struct gzip_index** index)
     return ret;
 }
 
-int span_indices_for_file(struct gzip_index* index, off_t start, off_t end, void* is, void* ie)
+int span_indices_for_file(struct gzip_index* index, offset_t start, offset_t end, void* is, void* ie)
 {
     if (index == NULL)
     {
@@ -469,7 +469,7 @@ int span_indices_for_file(struct gzip_index* index, off_t start, off_t end, void
     return 1;
 }
 
-int pt_index_from_ucmp_offset(struct gzip_index* index, off_t off)
+int pt_index_from_ucmp_offset(struct gzip_index* index, offset_t off)
 {
     if (index == NULL)
     {
@@ -561,7 +561,7 @@ struct gzip_index* blob_to_index(void* buf)
     }
 
     unsigned size;
-    off_t span_size;
+    offset_t span_size;
 
     uchar* cur = buf;
     memcpy(&size, cur, 4);

--- a/c/indexer.h
+++ b/c/indexer.h
@@ -50,6 +50,7 @@
 #include <zlib.h>
 
 typedef unsigned char uchar;
+typedef int64_t offset_t;
 
 /* Since gzip is compressed with 32 KiB window size, WINDOW_SIZE is fixed */
 #define WINSIZE 32768U
@@ -64,8 +65,8 @@ enum
 
 struct gzip_index_point
 {
-    off_t out;          /* corresponding offset in uncompressed data */
-    off_t in;           /* offset in input file of first full byte */
+    offset_t out;          /* corresponding offset in uncompressed data */
+    offset_t in;           /* offset in input file of first full byte */
     uint8_t bits;           /* number of bits (1-7) from byte at in - 1, or 0 */
     unsigned char window[WINSIZE];  /* preceding 32K of uncompressed data */    
 };
@@ -75,32 +76,32 @@ struct gzip_index
     int have;           /* number of list entries filled in */
     int size;           /* number of list entries allocated */
     struct gzip_index_point *list; /* allocated list */
-    off_t span_size;
+    offset_t span_size;
 };
 
 
 /* Get the index number of the point in the gzip index where
    the uncompressed offset is present 
 */
-int pt_index_from_ucmp_offset(struct gzip_index* index, off_t off);
+int pt_index_from_ucmp_offset(struct gzip_index* index, offset_t off);
 
-int generate_index_fp(FILE* fp, off_t span, struct gzip_index** index);
-int generate_index(const char* filepath, off_t span, struct gzip_index** index);
+int generate_index_fp(FILE* fp, offset_t span, struct gzip_index** index);
+int generate_index(const char* filepath, offset_t span, struct gzip_index** index);
 
 // TODO: Improve this
-int extract_data_from_buffer(void* d, off_t datalen, struct gzip_index* index, off_t offset, void* buffer, off_t len, int first_point_index);
-int extract_data_fp(FILE *in, struct gzip_index *index, off_t offset, void *buf, int len);
-int extract_data(const char* file, struct gzip_index* index, off_t offset, void* buf, int len);
+int extract_data_from_buffer(void* d, offset_t datalen, struct gzip_index* index, offset_t offset, void* buffer, offset_t len, int first_point_index);
+int extract_data_fp(FILE *in, struct gzip_index *index, offset_t offset, void *buf, int len);
+int extract_data(const char* file, struct gzip_index* index, offset_t offset, void* buf, int len);
 
 
 int has_bits(struct gzip_index* index, int point_index);
-off_t get_ucomp_off(struct gzip_index* index, int point_index);
-off_t get_comp_off(struct gzip_index* index, int point_index);
+offset_t get_ucomp_off(struct gzip_index* index, int point_index);
+offset_t get_comp_off(struct gzip_index* index, int point_index);
 
 /* Given a file's uncompressed start and end offset, returns the spans which
     contains those offsets
 */
-int span_indices_for_file(struct gzip_index* index, off_t start, off_t end, void* index_start, void* index_end);
+int span_indices_for_file(struct gzip_index* index, offset_t start, offset_t end, void* index_start, void* index_end);
 
 /* Subroutines to convert index to/from a binary blob */
 


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
`off_t` type in indexer.c is not platform agnostic. To improve that, the new type `offset_t` is defined, which is set to `int64_t`, so it's always 64 bits. This change is the part of the effort to make the decompression dictionary part of zTOC platform agnostic.

*Testing performed:*
- `make test && make check && make integration` pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
