### PR TITLE
Remove `FirstSpanHasBits` from `FileMetadata`

### DIFF
--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -80,7 +80,6 @@ var getFileCommand = cli.Command{
 			UncompressedOffset: fileMetadata.UncompressedOffset,
 			SpanStart:          fileMetadata.SpanStart,
 			SpanEnd:            fileMetadata.SpanEnd,
-			FirstSpanHasBits:   fileMetadata.FirstSpanHasBits,
 			IndexByteData:      ztoc.IndexByteData,
 			CompressedFileSize: ztoc.CompressedFileSize,
 			MaxSpanId:          ztoc.MaxSpanId,

--- a/metadata/db/db.go
+++ b/metadata/db/db.go
@@ -72,8 +72,6 @@ import (
 //         - uncompressedOffset : <varint>  : the offset in the uncompressed data, where the node is stored.
 //         - spanStart : <varint>           : the first span for the data.
 //         - spanEnd : <varint>             : the last span for the data.
-//         - firstSpanHasBits : <varint>    : flag for if there is partial uncompressed data that is stored in the previous byte.
-
 var (
 	bucketKeyFilesystems = []byte("filesystems")
 
@@ -99,7 +97,6 @@ var (
 	bucketKeyUncompressedOffset = []byte("uncompressedOffset")
 	bucketKeySpanStart          = []byte("spanStart")
 	bucketKeySpanEnd            = []byte("spanEnd")
-	bucketKeyFirstSpanHasBits   = []byte("firstSpanHasBits")
 )
 
 type childEntry struct {
@@ -112,7 +109,6 @@ type metadataEntry struct {
 	UncompressedOffset soci.FileSize
 	SpanStart          soci.SpanId
 	SpanEnd            soci.SpanId
-	FirstSpanHasBits   string
 }
 
 func getNodes(tx *bolt.Tx, fsID string) (*bolt.Bucket, error) {
@@ -365,9 +361,6 @@ func writeMetadataEntry(md *bolt.Bucket, m *metadataEntry) error {
 	}
 	if err := putSpanID(md, bucketKeySpanEnd, m.SpanEnd); err != nil {
 		return errors.Wrapf(err, "failed to set SpanEnd value %d", m.SpanEnd)
-	}
-	if err := md.Put(bucketKeyFirstSpanHasBits, []byte(m.FirstSpanHasBits)); err != nil {
-		return errors.Wrapf(err, "failed to set SpanEnd value %s", m.FirstSpanHasBits)
 	}
 	return nil
 }

--- a/metadata/db/reader.go
+++ b/metadata/db/reader.go
@@ -42,7 +42,6 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -258,7 +257,6 @@ func (r *reader) initNodes(ztoc *soci.Ztoc) error {
 				md[id].UncompressedOffset = ent.UncompressedOffset
 				md[id].SpanStart = ent.SpanStart
 				md[id].SpanEnd = ent.SpanEnd
-				md[id].FirstSpanHasBits = strconv.FormatBool(ent.FirstSpanHasBits)
 			}
 		}
 		return nil

--- a/soci/ztoc_builder.go
+++ b/soci/ztoc_builder.go
@@ -219,14 +219,6 @@ func getGzipFileMetadata(gzipFile string, index *C.struct_gzip_index) ([]FileMet
 			return nil, 0, fmt.Errorf("cannot get the span indices for file with start and end offset: %d, %d; gzip error: %v", start, end, ret)
 		}
 
-		var hasBits bool
-		ret = C.has_bits(index, C.int(indexStart))
-		if ret == 0 {
-			hasBits = false
-		} else {
-			hasBits = true
-		}
-
 		fileType, err := getType(hdr)
 		if err != nil {
 			return nil, 0, err
@@ -239,7 +231,6 @@ func getGzipFileMetadata(gzipFile string, index *C.struct_gzip_index) ([]FileMet
 			UncompressedSize:   FileSize(hdr.Size),
 			SpanStart:          indexStart,
 			SpanEnd:            indexEnd,
-			FirstSpanHasBits:   hasBits,
 			Linkname:           hdr.Linkname,
 			Mode:               hdr.Mode,
 			UID:                hdr.Uid,

--- a/soci/ztoc_test.go
+++ b/soci/ztoc_test.go
@@ -109,7 +109,6 @@ func TestDecompress(t *testing.T) {
 					UncompressedOffset: m.UncompressedOffset,
 					SpanStart:          m.SpanStart,
 					SpanEnd:            m.SpanEnd,
-					FirstSpanHasBits:   m.FirstSpanHasBits,
 					IndexByteData:      ztoc.IndexByteData,
 					CompressedFileSize: ztoc.CompressedFileSize,
 					MaxSpanId:          ztoc.MaxSpanId,
@@ -427,8 +426,8 @@ func TestWriteZtoc(t *testing.T) {
 			uncompressedFileSize: 2500000,
 			maxSpanID:            3,
 			buildTool:            "AWS SOCI CLI",
-			expDigest:            "sha256:4a2322b19c52ff5756b07bbc301e19ca9e95df6c017ababc7690bec03c3c8f25",
-			expSize:              455,
+			expDigest:            "sha256:8981c1a338a2600b5079588e09b639755c71c69bc4c099aedc68519d6fbf79fb",
+			expSize:              439,
 		},
 	}
 


### PR DESCRIPTION
The `FirstSpanHasBits` indicates whether the first span the file is present has partially uncompressed data in the previous byte (i.e. bits != 0). The field can be computed at runtime using
`C.has_bits`. This commit removes the field from `FileMetadata`.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*
#67 

*Testing performed:*
`make && make check && make test && make integration`

Manually running containers using the snapshotter. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
