### PR TITLE
Incapsulate indexer in a separate Go component

### DIFF
--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -83,7 +83,7 @@ var getFileCommand = cli.Command{
 			FirstSpanHasBits:   fileMetadata.FirstSpanHasBits,
 			IndexByteData:      ztoc.IndexByteData,
 			CompressedFileSize: ztoc.CompressedFileSize,
-			MaxSpanId:          ztoc.MaxSpanId,
+			MaxSpanID:          ztoc.MaxSpanID,
 		}
 
 		data, err := soci.ExtractFile(io.NewSectionReader(layerReader, 0, int64(ztoc.CompressedFileSize)), &extractConfig)

--- a/fs/layer/prefetcher.go
+++ b/fs/layer/prefetcher.go
@@ -38,7 +38,7 @@ func newPrefetcher(r *io.SectionReader, spanManager *spanmanager.SpanManager) *p
 }
 
 func (p *prefetcher) prefetch() error {
-	var spanID soci.SpanId
+	var spanID soci.SpanID
 	for {
 		err := p.spanManager.ResolveSpan(spanID, p.r)
 		if errors.Is(err, spanmanager.ErrExceedMaxSpan) {

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -16,13 +16,6 @@
 
 package spanmanager
 
-// #cgo CFLAGS: -I${SRCDIR}/../../c/
-// #cgo LDFLAGS: -L${SRCDIR}/../../out -lindexer -lz
-// #include "indexer.h"
-// #include <stdlib.h>
-// #include <stdio.h>
-import "C"
-
 import (
 	"bytes"
 	"context"
@@ -33,7 +26,6 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
-	"unsafe"
 
 	"github.com/awslabs/soci-snapshotter/cache"
 	"github.com/awslabs/soci-snapshotter/soci"
@@ -70,7 +62,7 @@ var (
 )
 
 type span struct {
-	id                soci.SpanId
+	id                soci.SpanID
 	startCompOffset   soci.FileSize
 	endCompOffset     soci.FileSize
 	startUncompOffset soci.FileSize
@@ -101,7 +93,7 @@ func (s *span) validateStateTransition(newState spanState) error {
 type SpanManager struct {
 	cache    cache.BlobCache
 	cacheOpt []cache.Option
-	index    *C.struct_gzip_index
+	index    *soci.GzipIndexer
 	r        *io.SectionReader // reader for contents of the spans managed by SpanManager
 	spans    []*span
 	ztoc     *soci.Ztoc
@@ -109,9 +101,9 @@ type SpanManager struct {
 
 type spanInfo struct {
 	// starting span id of the requested contents
-	spanStart soci.SpanId
+	spanStart soci.SpanID
 	// ending span id of the requested contents
-	spanEnd soci.SpanId
+	spanEnd soci.SpanID
 	// start offsets of the requested contents within the spans
 	startOffInSpan []soci.FileSize
 	// end offsets the requested contents within the spans
@@ -121,8 +113,12 @@ type spanInfo struct {
 }
 
 func New(ztoc *soci.Ztoc, r *io.SectionReader, cache cache.BlobCache, cacheOpt ...cache.Option) *SpanManager {
-	index := C.blob_to_index(unsafe.Pointer(&ztoc.IndexByteData[0]))
-	spans := make([]*span, ztoc.MaxSpanId+1)
+	//index := C.blob_to_index(unsafe.Pointer(&ztoc.IndexByteData[0]))
+	index, err := soci.NewGzipIndexer(ztoc.IndexByteData)
+	if err != nil {
+		return nil
+	}
+	spans := make([]*span, ztoc.MaxSpanID+1)
 	m := &SpanManager{
 		cache:    cache,
 		cacheOpt: cacheOpt,
@@ -133,6 +129,7 @@ func New(ztoc *soci.Ztoc, r *io.SectionReader, cache cache.BlobCache, cacheOpt .
 	}
 	m.buildAllSpans()
 	runtime.SetFinalizer(m, func(m *SpanManager) {
+		index.Close()
 		m.Close()
 	})
 
@@ -142,17 +139,18 @@ func New(ztoc *soci.Ztoc, r *io.SectionReader, cache cache.BlobCache, cacheOpt .
 func (m *SpanManager) buildAllSpans() {
 	m.spans[0] = &span{
 		id:                0,
-		startCompOffset:   soci.FileSize(C.get_comp_off(m.index, C.int(0))),
+		startCompOffset:   m.index.GetCompressedOffset(soci.SpanID(0)),
 		endCompOffset:     m.getEndCompressedOffset(0),
-		startUncompOffset: soci.FileSize(C.get_ucomp_off(m.index, C.int(0))),
+		startUncompOffset: m.index.GetUncompressedOffset(soci.SpanID(0)),
 		endUncompOffset:   m.getEndUncompressedOffset(0),
 	}
 	m.spans[0].state.Store(unrequested)
-	var i soci.SpanId
-	for i = 1; i <= m.ztoc.MaxSpanId; i++ {
+	var i soci.SpanID
+	for i = 1; i <= m.ztoc.MaxSpanID; i++ {
 		startCompOffset := m.spans[i-1].endCompOffset
-		if C.has_bits(m.index, C.int(i)) != 0 {
-			startCompOffset -= 1
+		hasBits := m.index.HasBits(i)
+		if hasBits {
+			startCompOffset--
 		}
 		s := span{
 			id:                i,
@@ -166,18 +164,18 @@ func (m *SpanManager) buildAllSpans() {
 	}
 }
 
-func (m *SpanManager) ResolveSpan(spanId soci.SpanId, r *io.SectionReader) error {
-	if spanId > m.ztoc.MaxSpanId {
+func (m *SpanManager) ResolveSpan(spanID soci.SpanID, r *io.SectionReader) error {
+	if spanID > m.ztoc.MaxSpanID {
 		return ErrExceedMaxSpan
 	}
 
 	// Check if the span exists in the cache
-	s := m.spans[spanId]
+	s := m.spans[spanID]
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	state := s.state.Load().(spanState)
 	if state == uncompressed {
-		id := strconv.Itoa(int(spanId))
+		id := strconv.Itoa(int(spanID))
 		_, err := m.cache.Get(id)
 		if err == nil {
 			// The span is already in cache.
@@ -186,7 +184,7 @@ func (m *SpanManager) ResolveSpan(spanId soci.SpanId, r *io.SectionReader) error
 	}
 
 	// The span is not available in cache. Fetch the span and add it to cache
-	_, err := m.fetchAndCacheSpan(spanId, r, true)
+	_, err := m.fetchAndCacheSpan(spanID, r, true)
 	if err != nil {
 		return err
 	}
@@ -202,13 +200,13 @@ func (m *SpanManager) GetContents(offsetStart, offsetEnd soci.FileSize) (io.Read
 	spanReaders := make([]io.Reader, numSpans)
 
 	eg, _ := errgroup.WithContext(context.Background())
-	var i soci.SpanId
+	var i soci.SpanID
 	for i = 0; i < numSpans; i++ {
 		j := i
 		eg.Go(func() error {
 			spanContentSize := si.endOffInSpan[j] - si.startOffInSpan[j]
-			spanId := j + si.spanStart
-			r, err := m.GetSpanContent(spanId, si.startOffInSpan[j], si.endOffInSpan[j], spanContentSize)
+			spanID := j + si.spanStart
+			r, err := m.GetSpanContent(spanID, si.startOffInSpan[j], si.endOffInSpan[j], spanContentSize)
 			if err != nil {
 				return err
 			}
@@ -225,8 +223,8 @@ func (m *SpanManager) GetContents(offsetStart, offsetEnd soci.FileSize) (io.Read
 
 // getSpanInfo returns spanInfo from the offsets of the requested file
 func (m *SpanManager) getSpanInfo(offsetStart, offsetEnd soci.FileSize) *spanInfo {
-	spanStart := soci.SpanId(C.pt_index_from_ucmp_offset(m.index, C.long(offsetStart)))
-	spanEnd := soci.SpanId(C.pt_index_from_ucmp_offset(m.index, C.long(offsetEnd)))
+	spanStart := m.index.GetSpanIDByUncompressedOffset(offsetStart)
+	spanEnd := m.index.GetSpanIDByUncompressedOffset(offsetEnd)
 	numSpans := spanEnd - spanStart + 1
 	start := make([]soci.FileSize, numSpans)
 	end := make([]soci.FileSize, numSpans)
@@ -258,9 +256,9 @@ func (m *SpanManager) getSpanInfo(offsetStart, offsetEnd soci.FileSize) *spanInf
 	return &spanInfo
 }
 
-func (m *SpanManager) GetSpanContent(spanId soci.SpanId, offsetStart, offsetEnd, size soci.FileSize) (io.Reader, error) {
+func (m *SpanManager) GetSpanContent(spanID soci.SpanID, offsetStart, offsetEnd, size soci.FileSize) (io.Reader, error) {
 	// Check if we can resolve the span from the cache
-	s := m.spans[spanId]
+	s := m.spans[spanID]
 	r, err := m.resolveSpanFromCache(s, offsetStart, size)
 	if err == nil {
 		return r, nil
@@ -279,7 +277,7 @@ func (m *SpanManager) GetSpanContent(spanId soci.SpanId, offsetStart, offsetEnd,
 		// if the span exists in the cache but resolveSpanFromCache fails, return the error to caller
 		return nil, err
 	}
-	uncompBuf, err := m.fetchAndCacheSpan(spanId, m.r, false)
+	uncompBuf, err := m.fetchAndCacheSpan(spanID, m.r, false)
 	if err != nil {
 		return nil, err
 	}
@@ -290,8 +288,8 @@ func (m *SpanManager) GetSpanContent(spanId soci.SpanId, offsetStart, offsetEnd,
 
 // getSpanFromCache returns the reader for the contents of the span stored in the cache.
 // offset is the offset of the requested contents within the span. size is the size of the requested contents.
-func (m *SpanManager) getSpanFromCache(spanId string, offset, size soci.FileSize) (io.Reader, error) {
-	r, err := m.cache.Get(spanId)
+func (m *SpanManager) getSpanFromCache(spanID string, offset, size soci.FileSize) (io.Reader, error) {
+	r, err := m.cache.Get(spanID)
 	if err != nil {
 		return nil, ErrSpanNotAvailable
 	}
@@ -302,7 +300,7 @@ func (m *SpanManager) getSpanFromCache(spanId string, offset, size soci.FileSize
 		nil
 }
 
-func (m *SpanManager) verifySpanContents(compressedData []byte, id soci.SpanId) error {
+func (m *SpanManager) verifySpanContents(compressedData []byte, id soci.SpanID) error {
 	actual := digest.FromBytes(compressedData)
 	expected := m.ztoc.ZtocInfo.SpanDigests[id]
 	if actual != expected {
@@ -312,8 +310,8 @@ func (m *SpanManager) verifySpanContents(compressedData []byte, id soci.SpanId) 
 }
 
 // addSpanToCache adds contents of the span to the cache.
-func (m *SpanManager) addSpanToCache(spanId string, contents []byte, opts ...cache.Option) {
-	if w, err := m.cache.Add(spanId, opts...); err == nil {
+func (m *SpanManager) addSpanToCache(spanID string, contents []byte, opts ...cache.Option) {
+	if w, err := m.cache.Add(spanID, opts...); err == nil {
 		if n, err := w.Write(contents); err != nil || n != len(contents) {
 			w.Abort()
 		} else {
@@ -364,13 +362,13 @@ func (m *SpanManager) resolveSpanFromCache(s *span, offsetStart, size soci.FileS
 		if err != nil {
 			return nil, err
 		}
-		return bytes.NewReader(uncompSpanBuf[offsetStart:offsetStart+size]), nil
+		return bytes.NewReader(uncompSpanBuf[offsetStart : offsetStart+size]), nil
 	}
 	return nil, ErrSpanNotAvailable
 }
 
-func (m *SpanManager) fetchSpan(buf []byte, spanId soci.SpanId, r *io.SectionReader) error {
-	s := m.spans[spanId]
+func (m *SpanManager) fetchSpan(buf []byte, spanID soci.SpanID, r *io.SectionReader) error {
+	s := m.spans[spanID]
 	err := s.setState(requested)
 	if err != nil {
 		return err
@@ -387,30 +385,28 @@ func (m *SpanManager) fetchSpan(buf []byte, spanId soci.SpanId, r *io.SectionRea
 
 func (m *SpanManager) uncompressSpan(s *span, compressedBuf []byte) ([]byte, error) {
 	uncompSize := s.endUncompOffset - s.startUncompOffset
-	bytes := make([]byte, uncompSize)
-
-	// Theoretically, a span can be empty. If that happens, just return an empty buffer.
+	// Theoretically, a span can be empty. If that happens, just return nil.
 	if uncompSize == 0 {
-		return bytes, nil
+		return nil, nil
 	}
 
-	ret := C.extract_data_from_buffer(unsafe.Pointer(&compressedBuf[0]), C.off_t(len(compressedBuf)), m.index, C.off_t(s.startUncompOffset), unsafe.Pointer(&bytes[0]), C.off_t(uncompSize), C.int(s.id))
-	if ret <= 0 {
-		return bytes, fmt.Errorf("error extracting data; return code: %v", ret)
+	bytes, err := m.index.ExtractDataFromBuffer(compressedBuf, uncompSize, s.startUncompOffset, s.id)
+	if err != nil {
+		return nil, err
 	}
 	return bytes, nil
 }
 
-func (m *SpanManager) fetchAndCacheSpan(spanId soci.SpanId, r *io.SectionReader, isPrefetch bool) ([]byte, error) {
-	s := m.spans[spanId]
+func (m *SpanManager) fetchAndCacheSpan(spanID soci.SpanID, r *io.SectionReader, isPrefetch bool) ([]byte, error) {
+	s := m.spans[spanID]
 	compressedSize := s.endCompOffset - s.startCompOffset
 	compressedBuf := make([]byte, compressedSize)
-	err := m.fetchSpan(compressedBuf, spanId, r)
+	err := m.fetchSpan(compressedBuf, spanID, r)
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
 
-	if err := m.verifySpanContents(compressedBuf, spanId); err != nil {
+	if err := m.verifySpanContents(compressedBuf, spanID); err != nil {
 		return nil, err
 	}
 	err = s.setState(fetched)
@@ -418,51 +414,49 @@ func (m *SpanManager) fetchAndCacheSpan(spanId soci.SpanId, r *io.SectionReader,
 		return nil, err
 	}
 
-	id := strconv.Itoa(int(spanId))
+	id := strconv.Itoa(int(spanID))
 	if isPrefetch {
 		m.addSpanToCache(id, compressedBuf, m.cacheOpt...)
 		if err != nil {
 			return nil, err
-		} else {
-			return nil, nil
 		}
-	} else {
-		uncompSpanBuf, err := m.uncompressSpan(s, compressedBuf)
-		if err != nil {
-			return nil, err
-		}
-
-		// Cache the content of the whole span
-		m.addSpanToCache(id, uncompSpanBuf, m.cacheOpt...)
-		err = s.setState(uncompressed)
-		if err != nil {
-			return nil, err
-		}
-		return uncompSpanBuf, nil
+		return nil, nil
 	}
+
+	uncompSpanBuf, err := m.uncompressSpan(s, compressedBuf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the content of the whole span
+	m.addSpanToCache(id, uncompSpanBuf, m.cacheOpt...)
+	err = s.setState(uncompressed)
+	if err != nil {
+		return nil, err
+	}
+	return uncompSpanBuf, nil
 }
 
-func (m *SpanManager) getEndCompressedOffset(spanId soci.SpanId) soci.FileSize {
+func (m *SpanManager) getEndCompressedOffset(spanID soci.SpanID) soci.FileSize {
 	var end soci.FileSize
-	if spanId == m.ztoc.MaxSpanId {
+	if spanID == m.ztoc.MaxSpanID {
 		end = m.ztoc.CompressedFileSize
 	} else {
-		end = soci.FileSize(C.get_comp_off(m.index, C.int(1+int(spanId))))
+		end = m.index.GetCompressedOffset(spanID + 1)
 	}
 	return end
 }
 
-func (m *SpanManager) getEndUncompressedOffset(spanId soci.SpanId) soci.FileSize {
+func (m *SpanManager) getEndUncompressedOffset(spanID soci.SpanID) soci.FileSize {
 	var end soci.FileSize
-	if spanId == m.ztoc.MaxSpanId {
+	if spanID == m.ztoc.MaxSpanID {
 		end = m.ztoc.UncompressedFileSize
 	} else {
-		end = soci.FileSize(C.get_ucomp_off(m.index, C.int(1+int(spanId))))
+		end = m.index.GetUncompressedOffset(spanID + 1)
 	}
 	return end
 }
 
 func (m *SpanManager) Close() {
-	C.free_index(m.index)
 	m.cache.Close()
 }

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -39,7 +39,7 @@ func TestSpanManager(t *testing.T) {
 	fileName := "span-manager-test"
 	testCases := []struct {
 		name          string
-		maxSpans      soci.SpanId
+		maxSpans      soci.SpanID
 		sectionReader *io.SectionReader
 		expectedError error
 	}{
@@ -105,8 +105,8 @@ func TestSpanManager(t *testing.T) {
 			}
 
 			// Test resolving all spans
-			var i soci.SpanId
-			for i = 0; i <= ztoc.MaxSpanId; i++ {
+			var i soci.SpanID
+			for i = 0; i <= ztoc.MaxSpanID; i++ {
 				err := m.ResolveSpan(i, r)
 				if err != nil {
 					t.Fatalf("error resolving span %d. error: %v", i, err)
@@ -114,7 +114,7 @@ func TestSpanManager(t *testing.T) {
 			}
 
 			// Test ResolveSpan returning ErrExceedMaxSpan for span id larger than max span id
-			resolveSpanErr := m.ResolveSpan(ztoc.MaxSpanId+1, r)
+			resolveSpanErr := m.ResolveSpan(ztoc.MaxSpanID+1, r)
 			if !errors.Is(resolveSpanErr, ErrExceedMaxSpan) {
 				t.Fatalf("failed returning ErrExceedMaxSpan for span id larger than max span id")
 			}
@@ -136,7 +136,7 @@ func TestSpanManagerCache(t *testing.T) {
 	defer cache.Close()
 	m := New(ztoc, r, cache)
 	spanID := 0
-	err = m.ResolveSpan(soci.SpanId(spanID), r)
+	err = m.ResolveSpan(soci.SpanID(spanID), r)
 	if err != nil {
 		t.Fatalf("failed to resolve span 0: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestStateTransition(t *testing.T) {
 	m := New(ztoc, r, cache)
 
 	// check initial span states
-	for i := uint32(0); i <= uint32(ztoc.MaxSpanId); i++ {
+	for i := uint32(0); i <= uint32(ztoc.MaxSpanID); i++ {
 		state := m.spans[i].state.Load().(spanState)
 		if state != unrequested {
 			t.Fatalf("failed initializing span states to Unrequested")
@@ -201,7 +201,7 @@ func TestStateTransition(t *testing.T) {
 
 	testCases := []struct {
 		name       string
-		spanID     soci.SpanId
+		spanID     soci.SpanID
 		isPrefetch bool
 	}{
 		{
@@ -216,12 +216,12 @@ func TestStateTransition(t *testing.T) {
 		},
 		{
 			name:       "max span - prefetch",
-			spanID:     m.ztoc.MaxSpanId,
+			spanID:     m.ztoc.MaxSpanID,
 			isPrefetch: true,
 		},
 		{
 			name:       "max span - on demand fetch",
-			spanID:     m.ztoc.MaxSpanId,
+			spanID:     m.ztoc.MaxSpanID,
 			isPrefetch: false,
 		},
 	}

--- a/metadata/db/db.go
+++ b/metadata/db/db.go
@@ -110,8 +110,8 @@ type childEntry struct {
 type metadataEntry struct {
 	children           map[string]childEntry
 	UncompressedOffset soci.FileSize
-	SpanStart          soci.SpanId
-	SpanEnd            soci.SpanId
+	SpanStart          soci.SpanID
+	SpanEnd            soci.SpanID
 	FirstSpanHasBits   string
 }
 
@@ -376,7 +376,7 @@ func putFileSize(b *bolt.Bucket, k []byte, v soci.FileSize) error {
 	return putInt(b, k, int64(v))
 }
 
-func putSpanID(b *bolt.Bucket, k []byte, v soci.SpanId) error {
+func putSpanID(b *bolt.Bucket, k []byte, v soci.SpanID) error {
 	return putInt(b, k, int64(v))
 }
 

--- a/soci/gzip_indexer.go
+++ b/soci/gzip_indexer.go
@@ -1,0 +1,147 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package soci
+
+// #cgo CFLAGS: -I${SRCDIR}/../c/
+// #cgo LDFLAGS: -L${SRCDIR}/../out -lindexer -lz
+// #include "indexer.h"
+// #include <stdlib.h>
+// #include <stdint.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+type GzipIndexer struct {
+	index *C.struct_gzip_index
+}
+
+// GenerateIndex wraps `C.generate_index` and should be used for index generation instead of relying on C code.
+// Returns the byte slice containing the `gzip_index`.
+func GenerateIndex(gzipFile string, spanSize int64) ([]byte, error) {
+	cstr := C.CString(gzipFile)
+	defer C.free(unsafe.Pointer(cstr))
+
+	var index *C.struct_gzip_index
+	ret := C.generate_index(cstr, C.off_t(spanSize), &index)
+	if int(ret) < 0 {
+		return nil, fmt.Errorf("could not generate gzip index. gzip error: %v", ret)
+	}
+	defer C.free(unsafe.Pointer(index))
+
+	blobSize := C.get_blob_size(index)
+	bytes := make([]byte, uint64(blobSize))
+	if bytes == nil {
+		return nil, fmt.Errorf("could not allocate byte array of size %d", blobSize)
+	}
+
+	ret = C.index_to_blob(index, unsafe.Pointer(&bytes[0]))
+	if int(ret) <= 0 {
+		return nil, fmt.Errorf("could not serialize gzip index to byte array; gzip error: %v", ret)
+	}
+
+	return bytes, nil
+}
+
+// Close calls `C.free` on the pointer to `C.struct_gzip_index`.
+func (i *GzipIndexer) Close() {
+	if i.index != nil {
+		C.free(unsafe.Pointer(i.index))
+	}
+}
+
+// GetMaxSpanID returns the max span ID.
+func (i *GzipIndexer) GetMaxSpanID() SpanID {
+	return SpanID(i.index.have - 1)
+}
+
+// GetSpanIDByUncompressedOffset returns the ID of the span containing the data pointed by uncompressed offset.
+func (i *GzipIndexer) GetSpanIDByUncompressedOffset(offset FileSize) SpanID {
+	return SpanID(C.pt_index_from_ucmp_offset(i.index, C.long(offset)))
+}
+
+// HasBits wraps `C.has_bits` and returns true if any data is contained in the previous span.
+func (i *GzipIndexer) HasBits(spanID SpanID) bool {
+	return C.has_bits(i.index, C.int(spanID)) != 0
+}
+
+// GetCompressedOffset wraps `C.get_comp_off` and returns the offset for the span in the compressed stream.
+func (i *GzipIndexer) GetCompressedOffset(spanID SpanID) FileSize {
+	return FileSize(C.get_comp_off(i.index, C.int(spanID)))
+}
+
+// GetUncompressedOffset wraps `C.get_uncomp_off` and returns the offset for the span in the uncompressed stream.
+func (i *GzipIndexer) GetUncompressedOffset(spanID SpanID) FileSize {
+	return FileSize(C.get_ucomp_off(i.index, C.int(spanID)))
+}
+
+// ExtractDataFromBuffer wraps the call to `C.extract_data_from_buffer`, which takes in the compressed bytes
+// and returns the decompressed bytes.
+func (i *GzipIndexer) ExtractDataFromBuffer(compressedBuf []byte, uncompressedSize, uncompressedOffset FileSize, spanID SpanID) ([]byte, error) {
+	bytes := make([]byte, uncompressedSize)
+	ret := C.extract_data_from_buffer(
+		unsafe.Pointer(&compressedBuf[0]),
+		C.off_t(len(compressedBuf)),
+		i.index,
+		C.off_t(uncompressedOffset),
+		unsafe.Pointer(&bytes[0]),
+		C.off_t(uncompressedSize),
+		C.int(spanID),
+	)
+	if ret <= 0 {
+		return bytes, fmt.Errorf("error extracting data; return code: %v", ret)
+	}
+
+	return bytes, nil
+}
+
+// ExtractData wraps `C.extract_data` and returns the decompressed bytes given the name of the .tar.gz file,
+// offset and the size in uncompressed stream.
+func (i *GzipIndexer) ExtractData(fileName string, uncompressedSize, uncompressedOffset FileSize) ([]byte, error) {
+	cstr := C.CString(fileName)
+	defer C.free(unsafe.Pointer(cstr))
+	bytes := make([]byte, uncompressedSize)
+	ret := C.extract_data(cstr, i.index, C.off_t(uncompressedOffset), unsafe.Pointer(&bytes[0]), C.int(uncompressedSize))
+	if ret <= 0 {
+		return nil, fmt.Errorf("unable to extract data; return code = %v", ret)
+	}
+
+	return bytes, nil
+}
+
+// GetSpanIndicesForFile wraps `C.span_indices_for_file` and returns IDs of starting and ending given start and end offsets.
+func (i *GzipIndexer) GetSpanIndicesForFile(startOffset, endOffset FileSize) (SpanID, SpanID, error) {
+	var indexStart SpanID
+	var indexEnd SpanID
+	ret := C.span_indices_for_file(i.index, C.off_t(startOffset), C.off_t(endOffset), unsafe.Pointer(&indexStart), unsafe.Pointer(&indexEnd))
+	if int(ret) <= 0 {
+		return 0, 0, fmt.Errorf("cannot get the span indices for file with start and end offset: %d, %d; gzip error: %v", startOffset, endOffset, ret)
+	}
+	return indexStart, indexEnd, nil
+}
+
+func NewGzipIndexer(indexData []byte) (*GzipIndexer, error) {
+	index := C.blob_to_index(unsafe.Pointer(&indexData[0]))
+	if index == nil {
+		return nil, fmt.Errorf("cannot convert blob to gzip_index")
+	}
+	return &GzipIndexer{
+		index: index,
+	}, nil
+}

--- a/soci/ztoc_test.go
+++ b/soci/ztoc_test.go
@@ -112,7 +112,7 @@ func TestDecompress(t *testing.T) {
 					FirstSpanHasBits:   m.FirstSpanHasBits,
 					IndexByteData:      ztoc.IndexByteData,
 					CompressedFileSize: ztoc.CompressedFileSize,
-					MaxSpanId:          ztoc.MaxSpanId,
+					MaxSpanID:          ztoc.MaxSpanID,
 				}
 				configs[m.Name] = extractConfig
 			}
@@ -221,7 +221,7 @@ func TestZtocGenerationConsistency(t *testing.T) {
 			if ztoc1.CompressedFileSize != ztoc2.CompressedFileSize {
 				t.Fatalf("ztoc1.CompressedFileSize should be equal to ztoc2.CompressedFileSize")
 			}
-			if ztoc1.MaxSpanId != ztoc2.MaxSpanId {
+			if ztoc1.MaxSpanID != ztoc2.MaxSpanID {
 				t.Fatalf("ztoc1.MaxSpanId should be equal to ztoc2.MaxSpanId")
 			}
 			if ztoc1.Version != ztoc2.Version {
@@ -413,7 +413,7 @@ func TestWriteZtoc(t *testing.T) {
 		metadata             []FileMetadata
 		compressedFileSize   FileSize
 		uncompressedFileSize FileSize
-		maxSpanID            SpanId
+		maxSpanID            SpanID
 		buildTool            string
 		expDigest            string
 		expSize              int64
@@ -440,7 +440,7 @@ func TestWriteZtoc(t *testing.T) {
 				Metadata:             tc.metadata,
 				CompressedFileSize:   tc.compressedFileSize,
 				UncompressedFileSize: tc.uncompressedFileSize,
-				MaxSpanId:            tc.maxSpanID,
+				MaxSpanID:            tc.maxSpanID,
 				BuildToolIdentifier:  tc.buildTool,
 			}
 


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
This change introduces the `GzipIndexer` component, which incapsulates the interaction with C indexer component. After this change is merged, the Go code must only talk to indexer through GzipIndexer.

This change also adds small fixes pointed by linter after removing `import "C"` in span manager and ztoc building logic.

*Testing performed:*
- `make test && make check && make integration` pass.
- deployed snapshotter and cli to an EC2 instance and created an index and ran container workload in lazy loading mode for `rabbitmq`, `drupal`, `tomcat` images and observed successful execution to ready line.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
