### PR TITLE
Incapsulate indexer in a separate Go component

### DIFF
--- a/c/indexer.c
+++ b/c/indexer.c
@@ -448,27 +448,6 @@ int generate_index(const char* filepath, offset_t span, struct gzip_index** inde
     return ret;
 }
 
-int span_indices_for_file(struct gzip_index* index, offset_t start, offset_t end, void* is, void* ie)
-{
-    if (index == NULL)
-    {
-        return 0;
-    }
-
-    uint32_t* index_start = is;
-    uint32_t* index_end = ie;
-
-    *index_start = pt_index_from_ucmp_offset(index, start);
-    *index_end = pt_index_from_ucmp_offset(index, end);
-
-    if (*index_start == -1 || *index_end == -1)
-    {
-        return 0;
-    }
-
-    return 1;
-}
-
 int pt_index_from_ucmp_offset(struct gzip_index* index, offset_t off)
 {
     if (index == NULL)

--- a/c/indexer.h
+++ b/c/indexer.h
@@ -98,11 +98,6 @@ int has_bits(struct gzip_index* index, int point_index);
 offset_t get_ucomp_off(struct gzip_index* index, int point_index);
 offset_t get_comp_off(struct gzip_index* index, int point_index);
 
-/* Given a file's uncompressed start and end offset, returns the spans which
-    contains those offsets
-*/
-int span_indices_for_file(struct gzip_index* index, offset_t start, offset_t end, void* index_start, void* index_end);
-
 /* Subroutines to convert index to/from a binary blob */
 
 /* Get size of blob given an index */

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -82,7 +82,7 @@ var getFileCommand = cli.Command{
 			SpanEnd:            fileMetadata.SpanEnd,
 			IndexByteData:      ztoc.IndexByteData,
 			CompressedFileSize: ztoc.CompressedFileSize,
-			MaxSpanId:          ztoc.MaxSpanId,
+			MaxSpanID:          ztoc.MaxSpanID,
 		}
 
 		data, err := soci.ExtractFile(io.NewSectionReader(layerReader, 0, int64(ztoc.CompressedFileSize)), &extractConfig)

--- a/fs/layer/prefetcher.go
+++ b/fs/layer/prefetcher.go
@@ -38,7 +38,7 @@ func newPrefetcher(r *io.SectionReader, spanManager *spanmanager.SpanManager) *p
 }
 
 func (p *prefetcher) prefetch() error {
-	var spanID soci.SpanId
+	var spanID soci.SpanID
 	for {
 		err := p.spanManager.ResolveSpan(spanID, p.r)
 		if errors.Is(err, spanmanager.ErrExceedMaxSpan) {

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -39,7 +39,7 @@ func TestSpanManager(t *testing.T) {
 	fileName := "span-manager-test"
 	testCases := []struct {
 		name          string
-		maxSpans      soci.SpanId
+		maxSpans      soci.SpanID
 		sectionReader *io.SectionReader
 		expectedError error
 	}{
@@ -105,8 +105,8 @@ func TestSpanManager(t *testing.T) {
 			}
 
 			// Test resolving all spans
-			var i soci.SpanId
-			for i = 0; i <= ztoc.MaxSpanId; i++ {
+			var i soci.SpanID
+			for i = 0; i <= ztoc.MaxSpanID; i++ {
 				err := m.ResolveSpan(i, r)
 				if err != nil {
 					t.Fatalf("error resolving span %d. error: %v", i, err)
@@ -114,7 +114,7 @@ func TestSpanManager(t *testing.T) {
 			}
 
 			// Test ResolveSpan returning ErrExceedMaxSpan for span id larger than max span id
-			resolveSpanErr := m.ResolveSpan(ztoc.MaxSpanId+1, r)
+			resolveSpanErr := m.ResolveSpan(ztoc.MaxSpanID+1, r)
 			if !errors.Is(resolveSpanErr, ErrExceedMaxSpan) {
 				t.Fatalf("failed returning ErrExceedMaxSpan for span id larger than max span id")
 			}
@@ -136,7 +136,7 @@ func TestSpanManagerCache(t *testing.T) {
 	defer cache.Close()
 	m := New(ztoc, r, cache)
 	spanID := 0
-	err = m.ResolveSpan(soci.SpanId(spanID), r)
+	err = m.ResolveSpan(soci.SpanID(spanID), r)
 	if err != nil {
 		t.Fatalf("failed to resolve span 0: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestStateTransition(t *testing.T) {
 	m := New(ztoc, r, cache)
 
 	// check initial span states
-	for i := uint32(0); i <= uint32(ztoc.MaxSpanId); i++ {
+	for i := uint32(0); i <= uint32(ztoc.MaxSpanID); i++ {
 		state := m.spans[i].state.Load().(spanState)
 		if state != unrequested {
 			t.Fatalf("failed initializing span states to Unrequested")
@@ -201,7 +201,7 @@ func TestStateTransition(t *testing.T) {
 
 	testCases := []struct {
 		name       string
-		spanID     soci.SpanId
+		spanID     soci.SpanID
 		isPrefetch bool
 	}{
 		{
@@ -216,12 +216,12 @@ func TestStateTransition(t *testing.T) {
 		},
 		{
 			name:       "max span - prefetch",
-			spanID:     m.ztoc.MaxSpanId,
+			spanID:     m.ztoc.MaxSpanID,
 			isPrefetch: true,
 		},
 		{
 			name:       "max span - on demand fetch",
-			spanID:     m.ztoc.MaxSpanId,
+			spanID:     m.ztoc.MaxSpanID,
 			isPrefetch: false,
 		},
 	}

--- a/metadata/db/db.go
+++ b/metadata/db/db.go
@@ -107,8 +107,8 @@ type childEntry struct {
 type metadataEntry struct {
 	children           map[string]childEntry
 	UncompressedOffset soci.FileSize
-	SpanStart          soci.SpanId
-	SpanEnd            soci.SpanId
+	SpanStart          soci.SpanID
+	SpanEnd            soci.SpanID
 }
 
 func getNodes(tx *bolt.Tx, fsID string) (*bolt.Bucket, error) {
@@ -369,7 +369,7 @@ func putFileSize(b *bolt.Bucket, k []byte, v soci.FileSize) error {
 	return putInt(b, k, int64(v))
 }
 
-func putSpanID(b *bolt.Bucket, k []byte, v soci.SpanId) error {
+func putSpanID(b *bolt.Bucket, k []byte, v soci.SpanID) error {
 	return putInt(b, k, int64(v))
 }
 

--- a/soci/gzip_index.go
+++ b/soci/gzip_index.go
@@ -1,0 +1,141 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package soci
+
+// #cgo CFLAGS: -I${SRCDIR}/../c/
+// #cgo LDFLAGS: -L${SRCDIR}/../out -lindexer -lz
+// #include "indexer.h"
+// #include <stdlib.h>
+// #include <stdint.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+type GzipIndex struct {
+	index *C.struct_gzip_index
+}
+
+// NewGzipIndex creates a new instance of `GzipIndex` from index byte blob on zTOC.
+func NewGzipIndex(indexData []byte) (*GzipIndex, error) {
+	index := C.blob_to_index(unsafe.Pointer(&indexData[0]))
+	if index == nil {
+		return nil, fmt.Errorf("cannot convert blob to gzip_index")
+	}
+	return &GzipIndex{
+		index: index,
+	}, nil
+}
+
+// NewGzipIndexFromFile creates a new instance of `GzipIndex` given gzip file name and span size.
+func NewGzipIndexFromFile(gzipFile string, spanSize int64) (*GzipIndex, error) {
+	cstr := C.CString(gzipFile)
+	defer C.free(unsafe.Pointer(cstr))
+
+	var index *C.struct_gzip_index
+	ret := C.generate_index(cstr, C.off_t(spanSize), &index)
+	if int(ret) < 0 {
+		return nil, fmt.Errorf("could not generate gzip index. gzip error: %v", ret)
+	}
+
+	return &GzipIndex{
+		index: index,
+	}, nil
+}
+
+// Close calls `C.free` on the pointer to `C.struct_gzip_index`.
+func (i *GzipIndex) Close() {
+	if i.index != nil {
+		C.free(unsafe.Pointer(i.index))
+	}
+}
+
+// Bytes returns the byte slice containing the index.
+func (i *GzipIndex) Bytes() ([]byte, error) {
+	blobSize := C.get_blob_size(i.index)
+	bytes := make([]byte, uint64(blobSize))
+	if bytes == nil {
+		return nil, fmt.Errorf("could not allocate byte array of size %d", blobSize)
+	}
+
+	ret := C.index_to_blob(i.index, unsafe.Pointer(&bytes[0]))
+	if int(ret) <= 0 {
+		return nil, fmt.Errorf("could not serialize gzip index to byte array; gzip error: %v", ret)
+	}
+	return bytes, nil
+}
+
+// MaxSpanID returns the max span ID.
+func (i *GzipIndex) MaxSpanID() SpanID {
+	return SpanID(i.index.have - 1)
+}
+
+// UncompressedOffsetToSpanID returns the ID of the span containing the data pointed by uncompressed offset.
+func (i *GzipIndex) UncompressedOffsetToSpanID(offset FileSize) SpanID {
+	return SpanID(C.pt_index_from_ucmp_offset(i.index, C.long(offset)))
+}
+
+// HasBits wraps `C.has_bits` and returns true if any data is contained in the previous span.
+func (i *GzipIndex) HasBits(spanID SpanID) bool {
+	return C.has_bits(i.index, C.int(spanID)) != 0
+}
+
+// SpanIDToCompressedOffset wraps `C.get_comp_off` and returns the offset for the span in the compressed stream.
+func (i *GzipIndex) SpanIDToCompressedOffset(spanID SpanID) FileSize {
+	return FileSize(C.get_comp_off(i.index, C.int(spanID)))
+}
+
+// SpanIDToUncompressedOffset wraps `C.get_uncomp_off` and returns the offset for the span in the uncompressed stream.
+func (i *GzipIndex) SpanIDToUncompressedOffset(spanID SpanID) FileSize {
+	return FileSize(C.get_ucomp_off(i.index, C.int(spanID)))
+}
+
+// ExtractDataFromBuffer wraps the call to `C.extract_data_from_buffer`, which takes in the compressed bytes
+// and returns the decompressed bytes.
+func (i *GzipIndex) ExtractDataFromBuffer(compressedBuf []byte, uncompressedSize, uncompressedOffset FileSize, spanID SpanID) ([]byte, error) {
+	bytes := make([]byte, uncompressedSize)
+	ret := C.extract_data_from_buffer(
+		unsafe.Pointer(&compressedBuf[0]),
+		C.off_t(len(compressedBuf)),
+		i.index,
+		C.off_t(uncompressedOffset),
+		unsafe.Pointer(&bytes[0]),
+		C.off_t(uncompressedSize),
+		C.int(spanID),
+	)
+	if ret <= 0 {
+		return bytes, fmt.Errorf("error extracting data; return code: %v", ret)
+	}
+
+	return bytes, nil
+}
+
+// ExtractData wraps `C.extract_data` and returns the decompressed bytes given the name of the .tar.gz file,
+// offset and the size in uncompressed stream.
+func (i *GzipIndex) ExtractData(fileName string, uncompressedSize, uncompressedOffset FileSize) ([]byte, error) {
+	cstr := C.CString(fileName)
+	defer C.free(unsafe.Pointer(cstr))
+	bytes := make([]byte, uncompressedSize)
+	ret := C.extract_data(cstr, i.index, C.off_t(uncompressedOffset), unsafe.Pointer(&bytes[0]), C.int(uncompressedSize))
+	if ret <= 0 {
+		return nil, fmt.Errorf("unable to extract data; return code = %v", ret)
+	}
+
+	return bytes, nil
+}

--- a/soci/ztoc.go
+++ b/soci/ztoc.go
@@ -16,17 +16,11 @@
 
 package soci
 
-// #include "indexer.h"
-// #include <stdlib.h>
-// #include <stdio.h>
-import "C"
-
 import (
 	"context"
 	"fmt"
 	"io"
 	"time"
-	"unsafe"
 
 	"github.com/opencontainers/go-digest"
 	"golang.org/x/sync/errgroup"
@@ -35,16 +29,16 @@ import (
 // FileSize will hold any file size and offset values
 type FileSize int64
 
-// SpanId will hold any span related values (SpanId, MaxSpanId, SpanStart, SpanEnd, etc)
-type SpanId int32
+// SpanID will hold any span related values (SpanID, MaxSpanID, SpanStart, SpanEnd, etc)
+type SpanID int32
 
 type FileMetadata struct {
 	Name               string
 	Type               string
 	UncompressedOffset FileSize
 	UncompressedSize   FileSize
-	SpanStart          SpanId
-	SpanEnd            SpanId
+	SpanStart          SpanID
+	SpanEnd            SpanID
 	Linkname           string // Target name of link (valid for TypeLink or TypeSymlink)
 	Mode               int64  // Permission and mode bits
 	UID                int    // User ID of owner
@@ -67,7 +61,7 @@ type Ztoc struct {
 
 	CompressedFileSize   FileSize
 	UncompressedFileSize FileSize
-	MaxSpanId            SpanId //The total number of spans in Ztoc - 1
+	MaxSpanID            SpanID //The total number of spans in Ztoc - 1
 	ZtocInfo             ztocInfo
 	IndexByteData        []byte
 }
@@ -79,18 +73,18 @@ type ztocInfo struct {
 type FileExtractConfig struct {
 	UncompressedSize   FileSize
 	UncompressedOffset FileSize
-	SpanStart          SpanId
-	SpanEnd            SpanId
+	SpanStart          SpanID
+	SpanEnd            SpanID
 	IndexByteData      []byte
 	CompressedFileSize FileSize
-	MaxSpanId          SpanId
+	MaxSpanID          SpanID
 }
 
 type MetadataEntry struct {
 	UncompressedSize   FileSize
 	UncompressedOffset FileSize
-	SpanStart          SpanId
-	SpanEnd            SpanId
+	SpanStart          SpanID
+	SpanEnd            SpanID
 }
 
 func ExtractFile(r *io.SectionReader, config *FileExtractConfig) ([]byte, error) {
@@ -101,23 +95,23 @@ func ExtractFile(r *io.SectionReader, config *FileExtractConfig) ([]byte, error)
 
 	numSpans := config.SpanEnd - config.SpanStart + 1
 
-	index := C.blob_to_index(unsafe.Pointer(&config.IndexByteData[0]))
-
-	if index == nil {
-		return bytes, fmt.Errorf("cannot convert blob to gzip_index")
+	gzipIndex, err := NewGzipIndex(config.IndexByteData)
+	if err != nil {
+		return bytes, nil
 	}
-	defer C.free_index(index)
+	defer gzipIndex.Close()
+
 	var bufSize FileSize
 	starts := make([]FileSize, numSpans)
 	ends := make([]FileSize, numSpans)
 
-	var i SpanId
+	var i SpanID
 	for i = 0; i < numSpans; i++ {
-		starts[i] = FileSize(C.get_comp_off(index, C.int(i+config.SpanStart)))
-		if i+config.SpanStart == config.MaxSpanId {
+		starts[i] = gzipIndex.SpanIDToCompressedOffset(i + config.SpanStart)
+		if i+config.SpanStart == config.MaxSpanID {
 			ends[i] = config.CompressedFileSize - 1
 		} else {
-			ends[i] = FileSize(C.get_comp_off(index, C.int(i+1+config.SpanStart)))
+			ends[i] = gzipIndex.SpanIDToCompressedOffset(i + 1 + config.SpanStart)
 		}
 		bufSize += (ends[i] - starts[i] + 1)
 	}
@@ -126,10 +120,10 @@ func ExtractFile(r *io.SectionReader, config *FileExtractConfig) ([]byte, error)
 
 	// It the first span the file is present in has partially uncompressed data,
 	// fetch the previous byte too.
-	firstSpanHasBits := C.has_bits(index, C.int(config.SpanStart)) != 0
+	firstSpanHasBits := gzipIndex.HasBits(config.SpanStart)
 	if firstSpanHasBits {
-		bufSize += 1
-		start -= 1
+		bufSize++
+		start--
 	}
 
 	buf := make([]byte, bufSize)
@@ -142,7 +136,7 @@ func ExtractFile(r *io.SectionReader, config *FileExtractConfig) ([]byte, error)
 			rangeStart := starts[j]
 			rangeEnd := ends[j]
 			if j == 0 && firstSpanHasBits {
-				rangeStart -= 1
+				rangeStart--
 			}
 			n, err := r.ReadAt(buf[rangeStart-start:rangeEnd-start+1], int64(rangeStart)) // need to convert rangeStart to int64 to use in ReadAt
 			if err != nil {
@@ -160,9 +154,9 @@ func ExtractFile(r *io.SectionReader, config *FileExtractConfig) ([]byte, error)
 		return bytes, err
 	}
 
-	ret := C.extract_data_from_buffer(unsafe.Pointer(&buf[0]), C.off_t(len(buf)), index, C.off_t(config.UncompressedOffset), unsafe.Pointer(&bytes[0]), C.off_t(config.UncompressedSize), C.int(config.SpanStart))
-	if ret <= 0 {
-		return bytes, fmt.Errorf("error extracting data; return code: %v", ret)
+	bytes, err = gzipIndex.ExtractDataFromBuffer(buf, config.UncompressedSize, config.UncompressedOffset, config.SpanStart)
+	if err != nil {
+		return nil, err
 	}
 
 	return bytes, nil
@@ -196,22 +190,15 @@ func ExtractFromTarGz(gz string, ztoc *Ztoc, text string) (string, error) {
 		return "", nil
 	}
 
-	cstr := C.CString(gz)
-	defer C.free(unsafe.Pointer(cstr))
-
-	index := C.blob_to_index(unsafe.Pointer(&ztoc.IndexByteData[0]))
-
-	if index == nil {
-		return "", fmt.Errorf("cannot convert blob to gzip_index")
+	gzipIndex, err := NewGzipIndex(ztoc.IndexByteData)
+	if err != nil {
+		return "", err
 	}
+	defer gzipIndex.Close()
 
-	defer C.free_index(index)
-
-	bytes := make([]byte, entry.UncompressedSize)
-	ret := C.extract_data(cstr, index, C.off_t(entry.UncompressedOffset), unsafe.Pointer(&bytes[0]), C.int(entry.UncompressedSize))
-
-	if ret <= 0 {
-		return "", fmt.Errorf("unable to extract data; return code = %v", ret)
+	bytes, err := gzipIndex.ExtractData(gz, entry.UncompressedSize, entry.UncompressedOffset)
+	if err != nil {
+		return "", err
 	}
 
 	return string(bytes), nil

--- a/soci/ztoc_getter.go
+++ b/soci/ztoc_getter.go
@@ -66,8 +66,8 @@ func flatbufToZtoc(flatbuffer []byte) *Ztoc {
 		me.Type = string(metadataEntry.Type())
 		me.UncompressedOffset = FileSize(metadataEntry.UncompressedOffset())
 		me.UncompressedSize = FileSize(metadataEntry.UncompressedSize())
-		me.SpanStart = SpanId(metadataEntry.SpanStart())
-		me.SpanEnd = SpanId(metadataEntry.SpanEnd())
+		me.SpanStart = SpanID(metadataEntry.SpanStart())
+		me.SpanEnd = SpanID(metadataEntry.SpanEnd())
 		me.Linkname = string(metadataEntry.Linkname())
 		me.Mode = metadataEntry.Mode()
 		me.UID = int(metadataEntry.Uid())
@@ -93,7 +93,7 @@ func flatbufToZtoc(flatbuffer []byte) *Ztoc {
 
 	compressionInfo := new(ztoc_flatbuffers.CompressionInfo)
 	ztocFlatbuf.CompressionInfo(compressionInfo)
-	ztoc.MaxSpanId = SpanId(compressionInfo.MaxSpanId())
+	ztoc.MaxSpanID = SpanID(compressionInfo.MaxSpanId())
 	ztoc.ZtocInfo.SpanDigests = make([]digest.Digest, compressionInfo.SpanDigestsLength())
 	for i := 0; i < compressionInfo.SpanDigestsLength(); i++ {
 		dgst, _ := digest.Parse(string(compressionInfo.SpanDigests(i)))

--- a/soci/ztoc_test.go
+++ b/soci/ztoc_test.go
@@ -111,7 +111,7 @@ func TestDecompress(t *testing.T) {
 					SpanEnd:            m.SpanEnd,
 					IndexByteData:      ztoc.IndexByteData,
 					CompressedFileSize: ztoc.CompressedFileSize,
-					MaxSpanId:          ztoc.MaxSpanId,
+					MaxSpanID:          ztoc.MaxSpanID,
 				}
 				configs[m.Name] = extractConfig
 			}
@@ -220,8 +220,8 @@ func TestZtocGenerationConsistency(t *testing.T) {
 			if ztoc1.CompressedFileSize != ztoc2.CompressedFileSize {
 				t.Fatalf("ztoc1.CompressedFileSize should be equal to ztoc2.CompressedFileSize")
 			}
-			if ztoc1.MaxSpanId != ztoc2.MaxSpanId {
-				t.Fatalf("ztoc1.MaxSpanId should be equal to ztoc2.MaxSpanId")
+			if ztoc1.MaxSpanID != ztoc2.MaxSpanID {
+				t.Fatalf("ztoc1.MaxSpanID should be equal to ztoc2.MaxSpanID")
 			}
 			if ztoc1.Version != ztoc2.Version {
 				t.Fatalf("ztoc1.IndexByteData should be equal to ztoc2.IndexByteData")
@@ -522,8 +522,8 @@ func TestZtocSerialization(t *testing.T) {
 			if readZtoc.CompressedFileSize != createdZtoc.CompressedFileSize {
 				t.Fatalf("readZtoc.CompressedFileSize should be equal to createdZtoc.CompressedFileSize")
 			}
-			if readZtoc.MaxSpanId != createdZtoc.MaxSpanId {
-				t.Fatalf("readZtoc.MaxSpanId should be equal to createdZtoc.MaxSpanId")
+			if readZtoc.MaxSpanID != createdZtoc.MaxSpanID {
+				t.Fatalf("readZtoc.MaxSpanID should be equal to createdZtoc.MaxSpanID")
 			}
 
 			if len(readZtoc.Metadata) != len(createdZtoc.Metadata) {
@@ -611,7 +611,7 @@ func TestWriteZtoc(t *testing.T) {
 		metadata             []FileMetadata
 		compressedFileSize   FileSize
 		uncompressedFileSize FileSize
-		maxSpanID            SpanId
+		maxSpanID            SpanID
 		buildTool            string
 		expDigest            string
 		expSize              int64
@@ -638,7 +638,7 @@ func TestWriteZtoc(t *testing.T) {
 				Metadata:             tc.metadata,
 				CompressedFileSize:   tc.compressedFileSize,
 				UncompressedFileSize: tc.uncompressedFileSize,
-				MaxSpanId:            tc.maxSpanID,
+				MaxSpanID:            tc.maxSpanID,
 				BuildToolIdentifier:  tc.buildTool,
 			}
 


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
This change introduces the `GzipIndexer` component, which incapsulates the interaction with C indexer component. After this change is merged, the Go code must only talk to indexer through `GzipIndexer`.

This change also adds small fixes pointed by linter after removing `import "C"` in span manager and ztoc building logic.

Note: this is the re-submission of https://github.com/awslabs/soci-snapshotter/pull/71, since the feature branch got diverged and merge commit has become unavoidable.

*Testing performed:*
- `make test && make check && make integration` pass.
- deployed snapshotter and cli to an EC2 instance and created an index and ran container workload in lazy loading mode for `rabbitmq`, `drupal`, `tomcat` images and observed successful execution to ready line.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
