### PR TITLE
Added `soci index rm` command

### DIFF
--- a/cmd/soci/commands/index/index.go
+++ b/cmd/soci/commands/index/index.go
@@ -24,5 +24,6 @@ var Command = cli.Command{
 	Subcommands: []cli.Command{
 		listCommand,
 		infoCommand,
+		rmCommand,
 	},
 }

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -30,6 +30,7 @@ import (
 
 var infoCommand = cli.Command{
 	Name:        "info",
+	Usage:       "display an index",
 	Description: "get detailed info about an index",
 	ArgsUsage:   "<digest>",
 	Action: func(cliContext *cli.Context) error {

--- a/cmd/soci/commands/index/rm.go
+++ b/cmd/soci/commands/index/rm.go
@@ -1,0 +1,73 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package index
+
+import (
+	"fmt"
+
+	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/urfave/cli"
+)
+
+var rmCommand = cli.Command{
+	Name:        "remove",
+	Aliases:     []string{"rm"},
+	Usage:       "remove indices",
+	Description: "remove an index from local db",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "ref",
+			Usage: "only remove indices that are associated with a specific image ref",
+		},
+	},
+	Action: func(cliContext *cli.Context) error {
+		args := cliContext.Args()
+		ref := cliContext.String("ref")
+
+		if len(args) != 0 && ref != "" {
+			return fmt.Errorf("please provide either index digests or image ref, but not both")
+		}
+
+		db, err := soci.NewDB()
+		if err != nil {
+			return err
+		}
+		if ref == "" {
+			for _, desc := range args {
+				err := db.RemoveArtifactEntryByIndexDigest(desc)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			client, ctx, cancel, err := commands.NewClient(cliContext)
+			if err != nil {
+				return err
+			}
+			defer cancel()
+
+			is := client.ImageService()
+			img, err := is.Get(ctx, ref)
+			if err != nil {
+				return err
+			}
+			return db.RemoveArtifactEntryByImageDigest(img.Target.Digest.String())
+		}
+		return nil
+	},
+}

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -346,6 +346,7 @@ func buildSociLayer(ctx context.Context, cs content.Store, desc ocispec.Descript
 		OriginalDigest: desc.Digest.String(),
 		Type:           ArtifactEntryTypeLayer,
 		Location:       desc.Digest.String(),
+		MediaType:      SociLayerMediaType,
 	}
 	err = writeArtifactEntry(entry)
 	if err != nil {


### PR DESCRIPTION
This commit adds a `soci index rm` command. It only deletes the artifact entry in the artifact db, but does not delete any blobs.

Users can now use `soci index rm <digest>`, or `soci index rm --ref <image ref>`.

Added a `quiet` flag to `soci index list` that only prints the index digests. This allows users to delete all indexes, using `soci index rm $(soci index ls -q)`.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*
Fixes #70 

*Description of changes:*

*Testing performed:*

`make && make check && make test && make integration`

1) `rm` using a single index digest

```
% sudo ./soci index ls                                
DIGEST                                                                     SIZE    IMAGE REF                            PLATFORM       ORAS ARTIFACT
sha256:523987d21136ad6f2ab4d55b376314362ffc654aad91ed061e42f3afc788759a    3493    docker.io/library/rabbitmq:latest    linux/amd64    false    
sha256:e52d32fe8701a56ea635350edae9dd4c6062944239954cd4b8b3ac7d74ece966    759     docker.io/library/alpine:latest      linux/amd64    false   

% sudo ./soci index rm sha256:523987d21136ad6f2ab4d55b376314362ffc654aad91ed061e42f3afc788759a

% sudo ./soci index ls                                                                        
DIGEST                                                                     SIZE    IMAGE REF                          PLATFORM       ORAS ARTIFACT
sha256:e52d32fe8701a56ea635350edae9dd4c6062944239954cd4b8b3ac7d74ece966    759     docker.io/library/alpine:latest    linux/amd64    false    
```

2) `rm` using image ref

```
% sudo ./soci index ls
DIGEST                                                                     SIZE    IMAGE REF                            PLATFORM       ORAS ARTIFACT
sha256:426b626f79d86f83244a6adced6764d6f6554f87670a4a090e90bfc6ee0e175a    3494    docker.io/library/rabbitmq:latest    linux/amd64    false    
sha256:523987d21136ad6f2ab4d55b376314362ffc654aad91ed061e42f3afc788759a    3493    docker.io/library/rabbitmq:latest    linux/amd64    false    
sha256:e52d32fe8701a56ea635350edae9dd4c6062944239954cd4b8b3ac7d74ece966    759     docker.io/library/alpine:latest      linux/amd64    false    

% sudo ./soci index rm --ref docker.io/library/rabbitmq:latest

% sudo ./soci index ls                                                                        
DIGEST                                                                     SIZE    IMAGE REF                          PLATFORM       ORAS ARTIFACT
sha256:e52d32fe8701a56ea635350edae9dd4c6062944239954cd4b8b3ac7d74ece966    759     docker.io/library/alpine:latest    linux/amd64    false    
```

3) `rm` everything

```
% sudo ./soci index ls                                                    
DIGEST                                                                     SIZE    IMAGE REF                            PLATFORM       ORAS ARTIFACT
sha256:426b626f79d86f83244a6adced6764d6f6554f87670a4a090e90bfc6ee0e175a    3494    docker.io/library/rabbitmq:latest    linux/amd64    false    
sha256:523987d21136ad6f2ab4d55b376314362ffc654aad91ed061e42f3afc788759a    3493    docker.io/library/rabbitmq:latest    linux/amd64    false    
sha256:e52d32fe8701a56ea635350edae9dd4c6062944239954cd4b8b3ac7d74ece966    759     docker.io/library/alpine:latest      linux/amd64    false    

% sudo ./soci index rm $(sudo ./soci index ls -q)

%  % sudo ./soci index ls                           
DIGEST    SIZE    IMAGE REF    PLATFORM    ORAS ARTIFACT
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
