### PR TITLE
Integer fields in gzip_index are serialized independently to endianness

### DIFF
--- a/c/indexer.h
+++ b/c/indexer.h
@@ -43,6 +43,7 @@
 #ifndef INDEXER_H
 #define INDEXER_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -73,8 +74,8 @@ struct gzip_index_point
 
 struct gzip_index 
 {
-    int have;           /* number of list entries filled in */
-    int size;           /* number of list entries allocated */
+    int32_t have;           /* number of list entries filled in */
+    int32_t size;           /* number of list entries allocated */
     struct gzip_index_point *list; /* allocated list */
     offset_t span_size;
 };
@@ -103,6 +104,8 @@ offset_t get_comp_off(struct gzip_index* index, int point_index);
 /* Get size of blob given an index */
 unsigned get_blob_size(struct gzip_index* index);
 
+int32_t get_max_span_id(struct gzip_index* index);
+
 /* Converts index to blob
    Returns the size of the buffer on success
    This function assumes that the buffer is large enough already
@@ -112,5 +115,14 @@ int index_to_blob(struct gzip_index* index, void* buf);
 struct gzip_index* blob_to_index(void* buf);
 
 void free_index(struct gzip_index *index);
+
+/* Convert integer types to little endian and vice versa.
+   This is needed to keep index consistent across multiple architectures, ensuring that
+   all integer fields will be stored in little endian.
+*/
+offset_t store_offset(offset_t source);
+offset_t decode_offset(offset_t source);
+int32_t encode_int32(int32_t source);
+int32_t decode_int32(int32_t source);
 
 #endif // INDEXER_H

--- a/soci/gzip_index.go
+++ b/soci/gzip_index.go
@@ -83,7 +83,7 @@ func (i *GzipIndex) Bytes() ([]byte, error) {
 
 // MaxSpanID returns the max span ID.
 func (i *GzipIndex) MaxSpanID() SpanID {
-	return SpanID(i.index.have - 1)
+	return SpanID(C.get_max_span_id(i.index))
 }
 
 // UncompressedOffsetToSpanID returns the ID of the span containing the data pointed by uncompressed offset.


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
`gzip_index`'s `have`, `size` and `span_size` as well as `gzip_index_point`'s `in`, `out` fields are converted to Big Endian representations for serialization and are converted back to the hosts architecture upon consumption. This ensures that `IndexByteData` byte sequence is consistent across multiple architectures.

*Testing performed:*
- `make test && make check && make integration` pass
- deployed `soci` and `soci-snapshotter-grpc` to EC2 instance and ran container workload for `rabbitmq` in lazy loading mode and got successful execution.

All the layers on rabbitmq were lazily loaded.
```
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
fusectl on /sys/fs/fuse/connections type fusectl (rw,relatime)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/2/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/3/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/4/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/5/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/6/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/7/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/8/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/9/fs type fuse.rawBridge (rw,nodev,relatime,user_id=0,group_id=0,allow_other)
```

The workload completed successfully.
```
2022-09-27 18:23:09.431972+00:00 [info] <0.779.0> started TCP listener on [::]:5672
 completed with 3 plugins.
2022-09-27 18:23:09.647003+00:00 [info] <0.708.0> Server startup complete; 3 plugins started.
2022-09-27 18:23:09.647003+00:00 [info] <0.708.0>  * rabbitmq_prometheus
2022-09-27 18:23:09.647003+00:00 [info] <0.708.0>  * rabbitmq_web_dispatch
2022-09-27 18:23:09.647003+00:00 [info] <0.708.0>  * rabbitmq_management_agent
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
