### PR TITLE
Ztoc format is consistent with fbs

### DIFF
--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -76,16 +76,16 @@ var getFileCommand = cli.Command{
 			return err
 		}
 		extractConfig := soci.FileExtractConfig{
-			UncompressedSize:   fileMetadata.UncompressedSize,
-			UncompressedOffset: fileMetadata.UncompressedOffset,
-			SpanStart:          fileMetadata.SpanStart,
-			SpanEnd:            fileMetadata.SpanEnd,
-			IndexByteData:      ztoc.IndexByteData,
-			CompressedFileSize: ztoc.CompressedFileSize,
-			MaxSpanID:          ztoc.MaxSpanID,
+			UncompressedSize:      fileMetadata.UncompressedSize,
+			UncompressedOffset:    fileMetadata.UncompressedOffset,
+			SpanStart:             fileMetadata.SpanStart,
+			SpanEnd:               fileMetadata.SpanEnd,
+			IndexByteData:         ztoc.CompressionInfo.IndexByteData,
+			CompressedArchiveSize: ztoc.CompressedArchiveSize,
+			MaxSpanID:             ztoc.CompressionInfo.MaxSpanID,
 		}
 
-		data, err := soci.ExtractFile(io.NewSectionReader(layerReader, 0, int64(ztoc.CompressedFileSize)), &extractConfig)
+		data, err := soci.ExtractFile(io.NewSectionReader(layerReader, 0, int64(ztoc.CompressedArchiveSize)), &extractConfig)
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -55,7 +55,7 @@ var infoCommand = cli.Command{
 		fmt.Printf("version: %s\n", ztoc.Version)
 		fmt.Printf("build tool: %s\n\n\n", ztoc.BuildToolIdentifier)
 
-		for _, v := range ztoc.Metadata {
+		for _, v := range ztoc.TOC.Metadata {
 			fmt.Printf("filename: %s, offset: %d, size: %d, span_start: %d, span_end: %d\n", v.Name, v.UncompressedOffset, v.UncompressedSize, v.SpanStart, v.SpanEnd)
 		}
 		return nil

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -307,7 +307,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 	// log ztoc info
 	log.G(context.Background()).WithFields(logrus.Fields{
 		"layer_sha":      desc.Digest,
-		"files_in_layer": len(ztoc.Metadata),
+		"files_in_layer": len(ztoc.TOC.Metadata),
 	}).Debugf("[Resolver.Resolve] downloaded layer ZTOC")
 	// continue with resolving the layer presuming we handle ZTOC
 	// ztoc will belong to a layer

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -106,7 +106,7 @@ func TestSpanManager(t *testing.T) {
 
 			// Test resolving all spans
 			var i soci.SpanID
-			for i = 0; i <= ztoc.MaxSpanID; i++ {
+			for i = 0; i <= ztoc.CompressionInfo.MaxSpanID; i++ {
 				err := m.ResolveSpan(i, r)
 				if err != nil {
 					t.Fatalf("error resolving span %d. error: %v", i, err)
@@ -114,7 +114,7 @@ func TestSpanManager(t *testing.T) {
 			}
 
 			// Test ResolveSpan returning ErrExceedMaxSpan for span id larger than max span id
-			resolveSpanErr := m.ResolveSpan(ztoc.MaxSpanID+1, r)
+			resolveSpanErr := m.ResolveSpan(ztoc.CompressionInfo.MaxSpanID+1, r)
 			if !errors.Is(resolveSpanErr, ErrExceedMaxSpan) {
 				t.Fatalf("failed returning ErrExceedMaxSpan for span id larger than max span id")
 			}
@@ -192,7 +192,7 @@ func TestStateTransition(t *testing.T) {
 	m := New(ztoc, r, cache)
 
 	// check initial span states
-	for i := uint32(0); i <= uint32(ztoc.MaxSpanID); i++ {
+	for i := uint32(0); i <= uint32(ztoc.CompressionInfo.MaxSpanID); i++ {
 		state := m.spans[i].state.Load().(spanState)
 		if state != unrequested {
 			t.Fatalf("failed initializing span states to Unrequested")
@@ -216,12 +216,12 @@ func TestStateTransition(t *testing.T) {
 		},
 		{
 			name:       "max span - prefetch",
-			spanID:     m.ztoc.MaxSpanID,
+			spanID:     m.ztoc.CompressionInfo.MaxSpanID,
 			isPrefetch: true,
 		},
 		{
 			name:       "max span - on demand fetch",
-			spanID:     m.ztoc.MaxSpanID,
+			spanID:     m.ztoc.CompressionInfo.MaxSpanID,
 			isPrefetch: false,
 		},
 	}

--- a/metadata/db/reader.go
+++ b/metadata/db/reader.go
@@ -188,7 +188,7 @@ func (r *reader) initNodes(ztoc *soci.Ztoc) error {
 		}
 		nodes.FillPercent = 1.0 // we only do sequential write to this bucket
 		var attr metadata.Attr
-		for _, ent := range ztoc.Metadata {
+		for _, ent := range ztoc.TOC.Metadata {
 			var id uint32
 			var b *bolt.Bucket
 			ent.Name = cleanEntryName(ent.Name)


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*
#75 

*Description of changes:*
Ztoc struct is modified to be consistent with the flatbuffers schema defined in `ztoc.fbs`.

*Testing performed:*
- `make test & make check & make integration` pass
- deployed `soci` and `soci-snapshotter-grpc` to the ec2 instance and successfully executed `rabbitmq` container workload in lazy loading mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
