### PR TITLE
Fix race condition in ztoc.ExtractFile

### DIFF
--- a/soci/ztoc.go
+++ b/soci/ztoc.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/opencontainers/go-digest"
@@ -130,6 +131,7 @@ func ExtractFile(r *io.SectionReader, config *FileExtractConfig) ([]byte, error)
 
 	buf := make([]byte, bufSize)
 	eg, _ := errgroup.WithContext(context.Background())
+	var mu sync.Mutex
 
 	// Fetch all span data in parallel
 	for i = 0; i < numSpans; i++ {
@@ -140,6 +142,8 @@ func ExtractFile(r *io.SectionReader, config *FileExtractConfig) ([]byte, error)
 			if j == 0 && firstSpanHasBits {
 				rangeStart--
 			}
+			mu.Lock()
+			defer mu.Unlock()
 			n, err := r.ReadAt(buf[rangeStart-start:rangeEnd-start+1], int64(rangeStart)) // need to convert rangeStart to int64 to use in ReadAt
 			if err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*
#79 

*Description of changes:*
Reading to buffer in `ztoc.ExtractFile` is now guarded by mutex. The reason the race condition was happening is due to the fact that two or more intersecting ranges of the slice can be written simultaneously. The single mutex should be OK for that case, since all the data accessed via `ztoc.ExtractFile` is local. For remote data, the span manager is used with more sophisticated locking.

*Testing performed:*
- `make test` pass with Go 1.19
- `make test && make check && make integration` pass with the current configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
