### PR TITLE
Go1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG CONTAINERD_VERSION=v1.6.4
 ARG RUNC_VERSION=v1.1.1
 ARG NERDCTL_VERSION=0.19.0
 
-FROM golang:1.18-buster AS golang-base
+FROM golang:1.19-buster AS golang-base
 
 FROM golang-base AS containerd-snapshotter-base
 ARG CONTAINERD_VERSION

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ check-dco:
 	$(shell go env GOPATH)/bin/git-validation -run DCO -range HEAD~20..HEAD
 
 install-check-tools:
-	@curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.45.2
+	@curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.49.0
 	go install github.com/kunalkushwaha/ltag@v0.2.3
 	go install github.com/vbatts/git-validation@v1.1.0
 

--- a/fs/client.go
+++ b/fs/client.go
@@ -31,21 +31,21 @@ var (
 	ErrNoReferrers = errors.New("no existing referrers")
 )
 
-/// Determines which index will be selected from a list of index descriptors
+// Determines which index will be selected from a list of index descriptors
 type IndexSelectionPolicy func([]ocispec.Descriptor) (ocispec.Descriptor, error)
 
 func SelectFirstPolicy(descs []ocispec.Descriptor) (ocispec.Descriptor, error) {
 	return descs[0], nil
 }
 
-/// Responsible for making Referrers API calls to remote registry to fetch list of referrers.
+// Responsible for making Referrers API calls to remote registry to fetch list of referrers.
 type ReferrersClient interface {
 	/// Takes in an manifest descriptor and IndexSelectionPolicy and returns a single artifact descriptor.
 	/// Returns an error (ErrNoReferrers) if the manifest descriptor has no referrers.
 	SelectReferrer(context.Context, ocispec.Descriptor, IndexSelectionPolicy) (ocispec.Descriptor, error)
 }
 
-/// Interface for oras-go's Repository.Referrers call, for mocking
+// Interface for oras-go's Repository.Referrers call, for mocking
 type ORASReferrersCaller interface {
 	Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []artifactsspec.Descriptor) error) error
 }

--- a/metadata/db/db.go
+++ b/metadata/db/db.go
@@ -72,6 +72,7 @@ import (
 //         - uncompressedOffset : <varint>  : the offset in the uncompressed data, where the node is stored.
 //         - spanStart : <varint>           : the first span for the data.
 //         - spanEnd : <varint>             : the last span for the data.
+
 var (
 	bucketKeyFilesystems = []byte("filesystems")
 

--- a/soci/testutils.go
+++ b/soci/testutils.go
@@ -49,10 +49,10 @@ type gzipIndexPoint struct {
 }
 
 type gzipIndex struct {
-	have      uint64           /* number of list entries filled in */
-	size      uint64           /* number of list entries allocated */
-	list      []gzipIndexPoint /* allocated list */
-	span_size uint64
+	have     uint64           /* number of list entries filled in */
+	size     uint64           /* number of list entries allocated */
+	list     []gzipIndexPoint /* allocated list */
+	spanSize uint64
 }
 
 type TempDirMaker interface {
@@ -88,10 +88,10 @@ func unmarshalGzipIndex(blob byte) (*gzipIndex, error) {
 	}
 
 	return &gzipIndex{
-		have:      uint64(index.have),
-		size:      uint64(index.size),
-		span_size: uint64(index.span_size),
-		list:      list,
+		have:     uint64(index.have),
+		size:     uint64(index.size),
+		spanSize: uint64(index.span_size),
+		list:     list,
 	}, nil
 }
 

--- a/soci/ztoc_test.go
+++ b/soci/ztoc_test.go
@@ -255,8 +255,8 @@ func TestZtocGenerationConsistency(t *testing.T) {
 					t.Fatalf("index1.size=%d must be equal to index2.size=%d", index1.size, index2.size)
 				}
 
-				if index1.span_size != index2.span_size {
-					t.Fatalf("index1.span_size=%d must be equal to index2.span_size=%d", index1.span_size, index2.span_size)
+				if index1.spanSize != index2.spanSize {
+					t.Fatalf("index1.span_size=%d must be equal to index2.span_size=%d", index1.spanSize, index2.spanSize)
 				}
 
 				if len(index1.list) != len(index2.list) {


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
After #88 we can safely start using Go1.19 and therefore we can move our tests to run with Go1.19.
This change updates the base image used for integration tests as well as updates the version for `golangci-lint` to 1.49.0.
Also this change fixes a few formatting issues found by the new linter.

*Testing performed:*
- `make test && make check && make integration` pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
