### PR TITLE
[soci-snapshotter-grpc] Add containerd address as an option

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -85,12 +85,12 @@ const (
 )
 
 var (
-	address      = flag.String("address", defaultAddress, "address for the snapshotter's GRPC server")
-	configPath   = flag.String("config", defaultConfigPath, "path to the configuration file")
-	logLevel     = flag.String("log-level", defaultLogLevel.String(), "set the logging level [trace, debug, info, warn, error, fatal, panic]")
-	rootDir      = flag.String("root", defaultRootDir, "path to the root directory for this snapshotter")
+	address             = flag.String("address", defaultAddress, "address for the snapshotter's GRPC server")
+	configPath          = flag.String("config", defaultConfigPath, "path to the configuration file")
+	logLevel            = flag.String("log-level", defaultLogLevel.String(), "set the logging level [trace, debug, info, warn, error, fatal, panic]")
+	rootDir             = flag.String("root", defaultRootDir, "path to the root directory for this snapshotter")
 	imageServiceAddress = flag.String("image-service-address", defaultImageServiceAddress, "address for the containerd server")
-	printVersion = flag.Bool("version", false, "print the version")
+	printVersion        = flag.Bool("version", false, "print the version")
 )
 
 type snapshotterConfig struct {
@@ -160,7 +160,6 @@ func main() {
 		credsFuncs = append(credsFuncs, kubeconfig.NewKubeconfigKeychain(ctx, opts...))
 	}
 	if config.Config.CRIKeychainConfig.EnableKeychain {
-                fmt.Printf("connecting to %s", imageServiceAddress)
 		// connects to the backend CRI service (defaults to containerd socket)
 		criAddr := *imageServiceAddress
 		if cp := config.CRIKeychainConfig.ImageServicePath; cp != "" {

--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -89,6 +89,7 @@ var (
 	configPath   = flag.String("config", defaultConfigPath, "path to the configuration file")
 	logLevel     = flag.String("log-level", defaultLogLevel.String(), "set the logging level [trace, debug, info, warn, error, fatal, panic]")
 	rootDir      = flag.String("root", defaultRootDir, "path to the root directory for this snapshotter")
+	imageServiceAddress = flag.String("image-service-address", defaultImageServiceAddress, "address for the containerd server")
 	printVersion = flag.Bool("version", false, "print the version")
 )
 
@@ -159,8 +160,9 @@ func main() {
 		credsFuncs = append(credsFuncs, kubeconfig.NewKubeconfigKeychain(ctx, opts...))
 	}
 	if config.Config.CRIKeychainConfig.EnableKeychain {
+                fmt.Printf("connecting to %s", imageServiceAddress)
 		// connects to the backend CRI service (defaults to containerd socket)
-		criAddr := defaultImageServiceAddress
+		criAddr := *imageServiceAddress
 		if cp := config.CRIKeychainConfig.ImageServicePath; cp != "" {
 			criAddr = cp
 		}


### PR DESCRIPTION
*Description of changes:*
Adds an option to the **soci-snapshotter-grpc** to select the containerd server to use.  Follows existing convention.  This unblocks further manual and automated testing capabilities as it allows non-default instances of contained and soci-snapshotter-grpc to interact

*Testing performed:*
`make && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
