### PR TITLE
Remove dubious Makefile actions for `check-flatc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,6 @@ flatc:
 	flatc -o $(CURDIR)/soci/fbs -g $(CURDIR)/soci/fbs/ztoc.fbs
 
 check-flatc: flatc ## check if protobufs needs to be generated again
-	@echo "$(WHALE) $@"
-	@test -z "$$(git status --short | grep ".go" | tee /dev/stderr)" || \
-		((git diff | cat) && \
-		(echo "$(ONI) please run 'make flatc' when making changes to fbs files" && false))
 
 # "check-lint" depends "pre-build". out/libindexer.a seems needed to process cgo directives
 check-lint: pre-build


### PR DESCRIPTION
*Description of changes:*

What we want this rule to do is update the machine-generated code if necessary. What it was doing was that plus also failing the build if any other files were staged or unstaged. That's funny, but it causes `make check` to fail, which is less funny.

*Testing performed:*

1. Make a trivial change: `sed -i 's/Soci/SOCI/' version/version.go`
2. Run check:
```
$ make check-flatc
flatc -o /local/home/wsm/src/awslabs/soci-snapshotter/soci/fbs -g /local/home/wsm/src/awslabs/soci-snapshotter/soci/fbs/ztoc.fbs
 check-flatc
 M version/version.go
diff --git a/version/version.go b/version/version.go
index bb54b5b..75abb0b 100644
--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 /*
-   Copyright The Soci Snapshotter Authors.
+   Copyright The SOCI Snapshotter Authors.

    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
 please run 'make flatc' when making changes to fbs files
make: *** [check-flatc] Error 1
```

With this fix applied:

```
$ g s --short
 M version/version.go
$ make check-flatc
flatc -o /local/home/wsm/src/wmesard/soci/soci/fbs -g /local/home/wsm/src/wmesard/soci/soci/fbs/ztoc.fbs
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
