### PR TITLE
Improve the naming consistency around two zTOC concepts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@
 CMD_DESTDIR ?= /usr/local
 GO111MODULE_VALUE=auto
 OUTDIR ?= $(CURDIR)/out
-UTIL_CFLAGS=-I${CURDIR}/c -L${OUTDIR} -lindexer -lz
-UTIL_LDFLAGS=-L${OUTDIR} -lindexer -lz
+UTIL_CFLAGS=-I${CURDIR}/c -L${OUTDIR} -lzinfo -lz
+UTIL_LDFLAGS=-L${OUTDIR} -lzinfo -lz
 PKG=github.com/awslabs/soci-snapshotter
 VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
@@ -48,9 +48,9 @@ soci: FORCE
 pre-build:
 	rm -rf ${OUTDIR}
 	@mkdir -p ${OUTDIR}
-	@gcc -c c/indexer.c -o ${OUTDIR}/indexer.o -O3 -Wall -Werror
-	@ar rvs ${OUTDIR}/libindexer.a ${OUTDIR}/indexer.o
-	@rm -f ${OUTDIR}/indexer.o
+	@gcc -c c/zinfo.c -o ${OUTDIR}/zinfo.o -O3 -Wall -Werror
+	@ar rvs ${OUTDIR}/libzinfo.a ${OUTDIR}/zinfo.o
+	@rm -f ${OUTDIR}/zinfo.o
 
 install-cmake:
 	@wget https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1-Linux-x86_64.sh -O cmake.sh
@@ -84,7 +84,7 @@ check-flatc:
 	diff -qr $(TMPDIR)/ztoc $(CURDIR)/soci/fbs/ztoc || (printf "\n\nThe Ztoc schema seems to be modified. Please run 'make flatc' to re-generate Go files\n\n"; exit 1)
 	rm -rf $(TMPDIR)
 
-# "check-lint" depends "pre-build". out/libindexer.a seems needed to process cgo directives
+# "check-lint" depends "pre-build". out/libzinfo.a seems needed to process cgo directives
 check-lint: pre-build
 	GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
 	cd ./cmd ; GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run

--- a/c/zinfo.h
+++ b/c/zinfo.h
@@ -40,8 +40,8 @@
   from the original.
 */
 
-#ifndef INDEXER_H
-#define INDEXER_H
+#ifndef ZINFO_H
+#define ZINFO_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -58,13 +58,13 @@ typedef int64_t offset_t;
 
 enum 
 {
-    GZIP_INDEXER_OK = 0,
-    GZIP_INDEXER_FILE_NOT_FOUND = -80,
-    GZIP_INDEXER_INDEX_NULL = -81,
-    GZIP_INDEXER_CANNOT_ALLOC = -82,
+    GZIP_ZINFO_OK = 0,
+    GZIP_ZINFO_FILE_NOT_FOUND = -80,
+    GZIP_ZINFO_INDEX_NULL = -81,
+    GZIP_ZINFO_CANNOT_ALLOC = -82,
 };
 
-struct gzip_index_point
+struct gzip_checkpoint
 {
     offset_t out;          /* corresponding offset in uncompressed data */
     offset_t in;           /* offset in input file of first full byte */
@@ -72,11 +72,11 @@ struct gzip_index_point
     unsigned char window[WINSIZE];  /* preceding 32K of uncompressed data */    
 };
 
-struct gzip_index 
+struct gzip_zinfo 
 {
     int32_t have;           /* number of list entries filled in */
     int32_t size;           /* number of list entries allocated */
-    struct gzip_index_point *list; /* allocated list */
+    struct gzip_checkpoint *list; /* allocated list */
     offset_t span_size;
 };
 
@@ -84,37 +84,37 @@ struct gzip_index
 /* Get the index number of the point in the gzip index where
    the uncompressed offset is present 
 */
-int pt_index_from_ucmp_offset(struct gzip_index* index, offset_t off);
+int pt_index_from_ucmp_offset(struct gzip_zinfo* index, offset_t off);
 
-int generate_index_fp(FILE* fp, offset_t span, struct gzip_index** index);
-int generate_index(const char* filepath, offset_t span, struct gzip_index** index);
+int generate_zinfo(FILE* fp, offset_t span, struct gzip_zinfo** index);
+int generate_index(const char* filepath, offset_t span, struct gzip_zinfo** index);
 
 // TODO: Improve this
-int extract_data_from_buffer(void* d, offset_t datalen, struct gzip_index* index, offset_t offset, void* buffer, offset_t len, int first_point_index);
-int extract_data_fp(FILE *in, struct gzip_index *index, offset_t offset, void *buf, int len);
-int extract_data(const char* file, struct gzip_index* index, offset_t offset, void* buf, int len);
+int extract_data_from_buffer(void* d, offset_t datalen, struct gzip_zinfo* index, offset_t offset, void* buffer, offset_t len, int first_checkpoint);
+int extract_data_fp(FILE *in, struct gzip_zinfo *index, offset_t offset, void *buf, int len);
+int extract_data(const char* file, struct gzip_zinfo* index, offset_t offset, void* buf, int len);
 
 
-int has_bits(struct gzip_index* index, int point_index);
-offset_t get_ucomp_off(struct gzip_index* index, int point_index);
-offset_t get_comp_off(struct gzip_index* index, int point_index);
+int has_bits(struct gzip_zinfo* index, int checkpoint);
+offset_t get_ucomp_off(struct gzip_zinfo* index, int checkpoint);
+offset_t get_comp_off(struct gzip_zinfo* index, int checkpoint);
 
 /* Subroutines to convert index to/from a binary blob */
 
 /* Get size of blob given an index */
-unsigned get_blob_size(struct gzip_index* index);
+unsigned get_blob_size(struct gzip_zinfo* index);
 
-int32_t get_max_span_id(struct gzip_index* index);
+int32_t get_max_span_id(struct gzip_zinfo* index);
 
 /* Converts index to blob
    Returns the size of the buffer on success
    This function assumes that the buffer is large enough already
    to hold the entire index
 */ 
-int index_to_blob(struct gzip_index* index, void* buf);
-struct gzip_index* blob_to_index(void* buf);
+int index_to_blob(struct gzip_zinfo* index, void* buf);
+struct gzip_zinfo* blob_to_zinfo(void* buf);
 
-void free_index(struct gzip_index *index);
+void free_zinfo(struct gzip_zinfo *index);
 
 /* Convert integer types to little endian and vice versa.
    This is needed to keep index consistent across multiple architectures, ensuring that
@@ -125,4 +125,4 @@ offset_t decode_offset(offset_t source);
 int32_t encode_int32(int32_t source);
 int32_t decode_int32(int32_t source);
 
-#endif // INDEXER_H
+#endif // ZINFO_H

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -80,7 +80,7 @@ var getFileCommand = cli.Command{
 			UncompressedOffset:    fileMetadata.UncompressedOffset,
 			SpanStart:             fileMetadata.SpanStart,
 			SpanEnd:               fileMetadata.SpanEnd,
-			IndexByteData:         ztoc.CompressionInfo.IndexByteData,
+			Checkpoints:           ztoc.CompressionInfo.Checkpoints,
 			CompressedArchiveSize: ztoc.CompressedArchiveSize,
 			MaxSpanID:             ztoc.CompressionInfo.MaxSpanID,
 		}

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -17,15 +17,13 @@ The SOCI project introduces several new terms that sometimes have subtle differe
   containing the list of zTOCs in the SOCI Index as well as a reference to the image for
   which the manifest was generated.
 
-* __span__: A chunk of data that can be independently decompressed. A zTOC contains
-  periodic "snapshots" of compression state from which a process can resume
-  decompression. The chunk of data between two checkpoints is a span.
-
 * __zTOC__: A Table of Contents for compressed data. A zTOC is composed of 2 parts. 1) a
   table of contents containing file metadata and its offset in the decompressed TAR
-  archive (the "TOC"). 2) A collection of "snapshots" of the state of the compression
-  engine at various points in the layer (the "z").
+  archive (the "TOC"). 2) A collection of "checkpoints" of the state of the compression
+  engine at various points in the layer. We refer to this collection as the "zInfo".
 
+* __span__: A chunk of data that can be independently decompressed. Each checkpoint in the zInfo
+  corresponds to exactly one span in an image layer.
 
 ## Anti-terminology
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -2,17 +2,34 @@ The SOCI project introduces several new terms that sometimes have subtle differe
 
 ## Terminology 
 
-* __SOCI__: Seekable OCI (pronounced so-CHEE). SOCI combines an unmodified [OCI Image](https://github.com/opencontainers/image-spec/blob/v1.0.2/spec.md) (or Docker v2 image) with a SOCI index to enable the SOCI snapshotter to lazily pull the image at runtime.
+* __SOCI__: Seekable OCI (pronounced so-CHEE). SOCI combines an unmodified
+  [OCI Image](https://github.com/opencontainers/image-spec/blob/v1.0.2/spec.md) (or Docker v2
+  image) with a SOCI index to enable the SOCI snapshotter to lazily pull the image at runtime.
 
-* __SOCI index__: An OCI artifact consisting of a SOCI index manifest and a set of zTOCs that enable lazy loading of unmodified OCI images. "Index" refers to the whole set of objects similarly to how "image" refers to the set of image index, manifest, config, and layers.
+* __SOCI index__: An OCI artifact consisting of a SOCI index manifest and a set of zTOCs
+  that enable lazy loading of unmodified OCI images. "Index" refers to the whole set of
+  objects similarly to how "image" refers to the set of image index, manifest, config, and
+  layers.
 
-* __SOCI index manifest__: An [ORAS manifest](https://github.com/oras-project/artifacts-spec/blob/v1.0.0-rc.2/artifact-manifest.md) (soon to be an [OCI Reference Types manifest](https://github.com/opencontainers/wg-reference-types/blob/256c257cc8b725fd324722ee40ead6925b1c8ad8/docs/proposals/PROPOSAL_E.md)) containing the list of zTOCs in the SOCI Index as well as a reference to the image for which the manifest was generated. 
+* __SOCI index manifest__: An
+  [ORAS manifest](https://github.com/oras-project/artifacts-spec/blob/v1.0.0-rc.2/artifact-manifest.md)
+  (soon to be an [OCI Reference Types manifest](https://github.com/opencontainers/wg-reference-types/blob/256c257cc8b725fd324722ee40ead6925b1c8ad8/docs/proposals/PROPOSAL_E.md))
+  containing the list of zTOCs in the SOCI Index as well as a reference to the image for
+  which the manifest was generated.
 
-* __span__: A chunk of data that can be independently decompressed. A zTOC contains periodic "snapshots" of compression state from which a process can resume decompression. The chunk of data between two checkpoints is a span.
+* __span__: A chunk of data that can be independently decompressed. A zTOC contains
+  periodic "snapshots" of compression state from which a process can resume
+  decompression. The chunk of data between two checkpoints is a span.
 
-* __zTOC__: A Table of Contents for compressed data. A zTOC is composed of 2 parts. 1) a table of contents containing file metadata and its offset in the decompressed TAR archive (the "TOC"). 2) A collection of "snapshots" of the state of the compression engine at various points in the layer (the "z").
+* __zTOC__: A Table of Contents for compressed data. A zTOC is composed of 2 parts. 1) a
+  table of contents containing file metadata and its offset in the decompressed TAR
+  archive (the "TOC"). 2) A collection of "snapshots" of the state of the compression
+  engine at various points in the layer (the "z").
 
 
 ## Anti-terminology
 
-* __SOCI Image__: We generally avoid the term "SOCI Image" because there is no such thing! The image is an unmodified OCI image. Also, a single image may have many SOCI indices with different parameters such as span size, layers indexed, etc. The precise way to refer to an image that has a SOCI index is to refer to the index itself.
+* __SOCI Image__: We generally avoid the term "SOCI Image" because there is no such thing!
+  The image is an unmodified OCI image. Also, a single image may have many SOCI indices
+  with different parameters such as span size, layers indexed, etc. The precise way to
+  refer to an image that has a SOCI index is to refer to the index itself.

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -93,7 +93,7 @@ func (s *span) validateStateTransition(newState spanState) error {
 type SpanManager struct {
 	cache    cache.BlobCache
 	cacheOpt []cache.Option
-	index    *soci.GzipIndex
+	index    *soci.GzipZinfo
 	r        *io.SectionReader // reader for contents of the spans managed by SpanManager
 	spans    []*span
 	ztoc     *soci.Ztoc
@@ -113,7 +113,7 @@ type spanInfo struct {
 }
 
 func New(ztoc *soci.Ztoc, r *io.SectionReader, cache cache.BlobCache, cacheOpt ...cache.Option) *SpanManager {
-	index, err := soci.NewGzipIndex(ztoc.CompressionInfo.IndexByteData)
+	index, err := soci.NewGzipZinfo(ztoc.CompressionInfo.Checkpoints)
 	if err != nil {
 		return nil
 	}

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -70,9 +70,9 @@ func TestSociCreateSparseIndex(t *testing.T) {
 			rebootContainerd(t, sh, "", "")
 			imgInfo := dockerhub(containerImage)
 			indexDigest := buildSparseIndex(sh, imgInfo, tt.minLayerSize)
-			indexByteData := fetchContentFromPath(sh, blobStorePath+"/"+trimSha256Prefix(indexDigest))
+			checkpoints := fetchContentFromPath(sh, blobStorePath+"/"+trimSha256Prefix(indexDigest))
 
-			index, err := soci.NewIndexFromReader(bytes.NewReader(indexByteData))
+			index, err := soci.NewIndexFromReader(bytes.NewReader(checkpoints))
 			if err != nil {
 				t.Fatalf("cannot get index data: %v", err)
 			}
@@ -171,8 +171,8 @@ func TestSociCreate(t *testing.T) {
 			rebootContainerd(t, sh, "", "")
 			imgInfo := dockerhub(tt.containerImage)
 			indexDigest := optimizeImage(sh, imgInfo)
-			indexByteData := fetchContentFromPath(sh, blobStorePath+"/"+trimSha256Prefix(indexDigest))
-			sociIndex, err := soci.NewIndexFromReader(bytes.NewReader(indexByteData))
+			checkpoints := fetchContentFromPath(sh, blobStorePath+"/"+trimSha256Prefix(indexDigest))
+			sociIndex, err := soci.NewIndexFromReader(bytes.NewReader(checkpoints))
 			if err != nil {
 				t.Fatalf("cannot get soci index: %v", err)
 			}

--- a/soci/fbs/ztoc.fbs
+++ b/soci/fbs/ztoc.fbs
@@ -33,7 +33,7 @@ table CompressionInfo {
 	compression_algorithm : CompressionAlgorithm = Gzip;
 	max_span_id : int;			// The total number of spans in Ztoc - 1
 	span_digests : [string];
-	index_byte_data : [ubyte];	// the binary data used to decompress the span
+	checkpoints : [ubyte];	// the binary data used to decompress the span
 }
 
 table TOC {

--- a/soci/fbs/ztoc/CompressionInfo.go
+++ b/soci/fbs/ztoc/CompressionInfo.go
@@ -74,7 +74,7 @@ func (rcv *CompressionInfo) SpanDigestsLength() int {
 	return 0
 }
 
-func (rcv *CompressionInfo) IndexByteData(j int) byte {
+func (rcv *CompressionInfo) Checkpoints(j int) byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -83,7 +83,7 @@ func (rcv *CompressionInfo) IndexByteData(j int) byte {
 	return 0
 }
 
-func (rcv *CompressionInfo) IndexByteDataLength() int {
+func (rcv *CompressionInfo) CheckpointsLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -91,7 +91,7 @@ func (rcv *CompressionInfo) IndexByteDataLength() int {
 	return 0
 }
 
-func (rcv *CompressionInfo) IndexByteDataBytes() []byte {
+func (rcv *CompressionInfo) CheckpointsBytes() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -99,7 +99,7 @@ func (rcv *CompressionInfo) IndexByteDataBytes() []byte {
 	return nil
 }
 
-func (rcv *CompressionInfo) MutateIndexByteData(j int, n byte) bool {
+func (rcv *CompressionInfo) MutateCheckpoints(j int, n byte) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -123,10 +123,10 @@ func CompressionInfoAddSpanDigests(builder *flatbuffers.Builder, spanDigests fla
 func CompressionInfoStartSpanDigestsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func CompressionInfoAddIndexByteData(builder *flatbuffers.Builder, indexByteData flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(indexByteData), 0)
+func CompressionInfoAddCheckpoints(builder *flatbuffers.Builder, checkpoints flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(checkpoints), 0)
 }
-func CompressionInfoStartIndexByteDataVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func CompressionInfoStartCheckpointsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(1, numElems, 1)
 }
 func CompressionInfoEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {

--- a/soci/gzip_zinfo.go
+++ b/soci/gzip_zinfo.go
@@ -17,8 +17,8 @@
 package soci
 
 // #cgo CFLAGS: -I${SRCDIR}/../c/
-// #cgo LDFLAGS: -L${SRCDIR}/../out -lindexer -lz
-// #include "indexer.h"
+// #cgo LDFLAGS: -L${SRCDIR}/../out -lzinfo -lz
+// #include "zinfo.h"
 // #include <stdlib.h>
 // #include <stdint.h>
 import "C"
@@ -28,92 +28,92 @@ import (
 	"unsafe"
 )
 
-type GzipIndex struct {
-	index *C.struct_gzip_index
+type GzipZinfo struct {
+	cZinfo *C.struct_gzip_zinfo
 }
 
-// NewGzipIndex creates a new instance of `GzipIndex` from index byte blob on zTOC.
-func NewGzipIndex(indexData []byte) (*GzipIndex, error) {
-	index := C.blob_to_index(unsafe.Pointer(&indexData[0]))
-	if index == nil {
-		return nil, fmt.Errorf("cannot convert blob to gzip_index")
+// NewGzipZinfo creates a new instance of `GzipZinfo` from cZinfo byte blob on zTOC.
+func NewGzipZinfo(checkpoints []byte) (*GzipZinfo, error) {
+	cZinfo := C.blob_to_zinfo(unsafe.Pointer(&checkpoints[0]))
+	if cZinfo == nil {
+		return nil, fmt.Errorf("cannot convert blob to gzip_zinfo")
 	}
-	return &GzipIndex{
-		index: index,
+	return &GzipZinfo{
+		cZinfo: cZinfo,
 	}, nil
 }
 
-// NewGzipIndexFromFile creates a new instance of `GzipIndex` given gzip file name and span size.
-func NewGzipIndexFromFile(gzipFile string, spanSize int64) (*GzipIndex, error) {
+// NewGzipZinfoFromFile creates a new instance of `GzipZinfo` given gzip file name and span size.
+func NewGzipZinfoFromFile(gzipFile string, spanSize int64) (*GzipZinfo, error) {
 	cstr := C.CString(gzipFile)
 	defer C.free(unsafe.Pointer(cstr))
 
-	var index *C.struct_gzip_index
-	ret := C.generate_index(cstr, C.off_t(spanSize), &index)
+	var cZinfo *C.struct_gzip_zinfo
+	ret := C.generate_index(cstr, C.off_t(spanSize), &cZinfo)
 	if int(ret) < 0 {
-		return nil, fmt.Errorf("could not generate gzip index. gzip error: %v", ret)
+		return nil, fmt.Errorf("could not generate gzip zinfo. gzip error: %v", ret)
 	}
 
-	return &GzipIndex{
-		index: index,
+	return &GzipZinfo{
+		cZinfo: cZinfo,
 	}, nil
 }
 
-// Close calls `C.free` on the pointer to `C.struct_gzip_index`.
-func (i *GzipIndex) Close() {
-	if i.index != nil {
-		C.free(unsafe.Pointer(i.index))
+// Close calls `C.free` on the pointer to `C.struct_gzip_zinfo`.
+func (i *GzipZinfo) Close() {
+	if i.cZinfo != nil {
+		C.free(unsafe.Pointer(i.cZinfo))
 	}
 }
 
-// Bytes returns the byte slice containing the index.
-func (i *GzipIndex) Bytes() ([]byte, error) {
-	blobSize := C.get_blob_size(i.index)
+// Bytes returns the byte slice containing the zinfo.
+func (i *GzipZinfo) Bytes() ([]byte, error) {
+	blobSize := C.get_blob_size(i.cZinfo)
 	bytes := make([]byte, uint64(blobSize))
 	if bytes == nil {
 		return nil, fmt.Errorf("could not allocate byte array of size %d", blobSize)
 	}
 
-	ret := C.index_to_blob(i.index, unsafe.Pointer(&bytes[0]))
+	ret := C.index_to_blob(i.cZinfo, unsafe.Pointer(&bytes[0]))
 	if int(ret) <= 0 {
-		return nil, fmt.Errorf("could not serialize gzip index to byte array; gzip error: %v", ret)
+		return nil, fmt.Errorf("could not serialize gzip zinfo to byte array; gzip error: %v", ret)
 	}
 	return bytes, nil
 }
 
 // MaxSpanID returns the max span ID.
-func (i *GzipIndex) MaxSpanID() SpanID {
-	return SpanID(C.get_max_span_id(i.index))
+func (i *GzipZinfo) MaxSpanID() SpanID {
+	return SpanID(C.get_max_span_id(i.cZinfo))
 }
 
 // UncompressedOffsetToSpanID returns the ID of the span containing the data pointed by uncompressed offset.
-func (i *GzipIndex) UncompressedOffsetToSpanID(offset FileSize) SpanID {
-	return SpanID(C.pt_index_from_ucmp_offset(i.index, C.long(offset)))
+func (i *GzipZinfo) UncompressedOffsetToSpanID(offset FileSize) SpanID {
+	return SpanID(C.pt_index_from_ucmp_offset(i.cZinfo, C.long(offset)))
 }
 
 // HasBits wraps `C.has_bits` and returns true if any data is contained in the previous span.
-func (i *GzipIndex) HasBits(spanID SpanID) bool {
-	return C.has_bits(i.index, C.int(spanID)) != 0
+func (i *GzipZinfo) HasBits(spanID SpanID) bool {
+	return C.has_bits(i.cZinfo, C.int(spanID)) != 0
 }
 
 // SpanIDToCompressedOffset wraps `C.get_comp_off` and returns the offset for the span in the compressed stream.
-func (i *GzipIndex) SpanIDToCompressedOffset(spanID SpanID) FileSize {
-	return FileSize(C.get_comp_off(i.index, C.int(spanID)))
+func (i *GzipZinfo) SpanIDToCompressedOffset(spanID SpanID) FileSize {
+	return FileSize(C.get_comp_off(i.cZinfo, C.int(spanID)))
 }
 
 // SpanIDToUncompressedOffset wraps `C.get_uncomp_off` and returns the offset for the span in the uncompressed stream.
-func (i *GzipIndex) SpanIDToUncompressedOffset(spanID SpanID) FileSize {
-	return FileSize(C.get_ucomp_off(i.index, C.int(spanID)))
+func (i *GzipZinfo) SpanIDToUncompressedOffset(spanID SpanID) FileSize {
+	return FileSize(C.get_ucomp_off(i.cZinfo, C.int(spanID)))
 }
 
 // ExtractDataFromBuffer wraps the call to `C.extract_data_from_buffer`, which takes in the compressed bytes
 // and returns the decompressed bytes.
-func (i *GzipIndex) ExtractDataFromBuffer(compressedBuf []byte, uncompressedSize, uncompressedOffset FileSize, spanID SpanID) ([]byte, error) {
+func (i *GzipZinfo) ExtractDataFromBuffer(compressedBuf []byte, uncompressedSize, uncompressedOffset FileSize, spanID SpanID) ([]byte, error) {
 	bytes := make([]byte, uncompressedSize)
 	ret := C.extract_data_from_buffer(
 		unsafe.Pointer(&compressedBuf[0]),
 		C.off_t(len(compressedBuf)),
-		i.index,
+		i.cZinfo,
 		C.off_t(uncompressedOffset),
 		unsafe.Pointer(&bytes[0]),
 		C.off_t(uncompressedSize),
@@ -128,11 +128,11 @@ func (i *GzipIndex) ExtractDataFromBuffer(compressedBuf []byte, uncompressedSize
 
 // ExtractData wraps `C.extract_data` and returns the decompressed bytes given the name of the .tar.gz file,
 // offset and the size in uncompressed stream.
-func (i *GzipIndex) ExtractData(fileName string, uncompressedSize, uncompressedOffset FileSize) ([]byte, error) {
+func (i *GzipZinfo) ExtractData(fileName string, uncompressedSize, uncompressedOffset FileSize) ([]byte, error) {
 	cstr := C.CString(fileName)
 	defer C.free(unsafe.Pointer(cstr))
 	bytes := make([]byte, uncompressedSize)
-	ret := C.extract_data(cstr, i.index, C.off_t(uncompressedOffset), unsafe.Pointer(&bytes[0]), C.int(uncompressedSize))
+	ret := C.extract_data(cstr, i.cZinfo, C.off_t(uncompressedOffset), unsafe.Pointer(&bytes[0]), C.int(uncompressedSize))
 	if ret <= 0 {
 		return nil, fmt.Errorf("unable to extract data; return code = %v", ret)
 	}

--- a/soci/ztoc_getter.go
+++ b/soci/ztoc_getter.go
@@ -103,7 +103,7 @@ func flatbufToZtoc(flatbuffer []byte) *Ztoc {
 		dgst, _ := digest.Parse(string(compressionInfo.SpanDigests(i)))
 		ztoc.CompressionInfo.SpanDigests[i] = dgst
 	}
-	ztoc.CompressionInfo.IndexByteData = compressionInfo.IndexByteDataBytes()
+	ztoc.CompressionInfo.Checkpoints = compressionInfo.CheckpointsBytes()
 	return ztoc
 }
 

--- a/soci/ztoc_test.go
+++ b/soci/ztoc_test.go
@@ -109,7 +109,7 @@ func TestDecompress(t *testing.T) {
 					UncompressedOffset:    m.UncompressedOffset,
 					SpanStart:             m.SpanStart,
 					SpanEnd:               m.SpanEnd,
-					IndexByteData:         ztoc.CompressionInfo.IndexByteData,
+					Checkpoints:           ztoc.CompressionInfo.Checkpoints,
 					CompressedArchiveSize: ztoc.CompressedArchiveSize,
 					MaxSpanID:             ztoc.CompressionInfo.MaxSpanID,
 				}
@@ -224,7 +224,7 @@ func TestZtocGenerationConsistency(t *testing.T) {
 				t.Fatalf("ztoc1.MaxSpanID should be equal to ztoc2.MaxSpanID")
 			}
 			if ztoc1.Version != ztoc2.Version {
-				t.Fatalf("ztoc1.IndexByteData should be equal to ztoc2.IndexByteData")
+				t.Fatalf("ztoc1.Checkpoints should be equal to ztoc2.Checkpoints")
 			}
 			for i := 0; i < len(ztoc1.TOC.Metadata); i++ {
 				metadata1 := ztoc1.TOC.Metadata[i]
@@ -234,15 +234,15 @@ func TestZtocGenerationConsistency(t *testing.T) {
 				}
 			}
 
-			// Compare raw IndexByteData
-			if !bytes.Equal(ztoc1.CompressionInfo.IndexByteData, ztoc2.CompressionInfo.IndexByteData) {
+			// Compare raw Checkpoints
+			if !bytes.Equal(ztoc1.CompressionInfo.Checkpoints, ztoc2.CompressionInfo.Checkpoints) {
 
-				// compare IndexByteData within Go
-				index1, err := unmarshalGzipIndex(ztoc1.CompressionInfo.IndexByteData[0])
+				// compare Checkpoints within Go
+				index1, err := unmarshalGzipZinfo(ztoc1.CompressionInfo.Checkpoints[0])
 				if err != nil {
 					t.Fatalf("index from ztoc1 should contain data")
 				}
-				index2, err := unmarshalGzipIndex(ztoc2.CompressionInfo.IndexByteData[0])
+				index2, err := unmarshalGzipZinfo(ztoc2.CompressionInfo.Checkpoints[0])
 				if err != nil {
 					t.Fatalf("index from ztoc2 should contain data")
 				}
@@ -594,9 +594,9 @@ func TestZtocSerialization(t *testing.T) {
 				}
 			}
 
-			// Compare raw IndexByteData
-			if !bytes.Equal(createdZtoc.CompressionInfo.IndexByteData, readZtoc.CompressionInfo.IndexByteData) {
-				t.Fatalf("createdZtoc.IndexByteData must be identical to readZtoc.IndexByteData")
+			// Compare raw Checkpoints
+			if !bytes.Equal(createdZtoc.CompressionInfo.Checkpoints, readZtoc.CompressionInfo.Checkpoints) {
+				t.Fatalf("createdZtoc.Checkpoints must be identical to readZtoc.Checkpoints")
 			}
 		})
 	}
@@ -607,7 +607,7 @@ func TestWriteZtoc(t *testing.T) {
 	testCases := []struct {
 		name                    string
 		version                 string
-		indexByteData           []byte
+		checkpoints             []byte
 		metadata                []FileMetadata
 		compressedArchiveSize   FileSize
 		uncompressedArchiveSize FileSize
@@ -619,7 +619,7 @@ func TestWriteZtoc(t *testing.T) {
 		{
 			name:                    "success write succeeds - same digest and size",
 			version:                 "0.1",
-			indexByteData:           make([]byte, 1<<16),
+			checkpoints:             make([]byte, 1<<16),
 			metadata:                make([]FileMetadata, 2),
 			compressedArchiveSize:   2000000,
 			uncompressedArchiveSize: 2500000,
@@ -636,8 +636,8 @@ func TestWriteZtoc(t *testing.T) {
 				Metadata: tc.metadata,
 			}
 			compressionInfo := CompressionInfo{
-				IndexByteData: tc.indexByteData,
-				MaxSpanID:     tc.maxSpanID,
+				Checkpoints: tc.checkpoints,
+				MaxSpanID:   tc.maxSpanID,
 			}
 			ztoc := &Ztoc{
 				Version:                 tc.version,


### PR DESCRIPTION
*Description of changes:*

We’ve struggled to use consistent naming for the second half of the zTOC file, and for the captured state of the compression engine. This commit attempts to remedy that by using “Gzip compression info” and “Checkpoint”, respectively.


*Notes*:
* This change was generated by a script (attached below).
* If someone prefers different terminology, let's discuss. "Compression info" is a bit of a mouthful. But that's what the Flatbuffer schema used, and I can't think of anything better.
* If you see additional things that should be renamed, let me know and I will add them to the list and rerun the script.
* In some cases, the “gzip” is redundant (because the code in question is obviously gzip-specific), or incorrect (because the code in question has no business knowing about the implementation details of the compression algorithm). I left that as is for now, because that would require a judgement call, and I wanted to keep this commit entirely scripted. 

*Testing performed:*
```
go clean -testcache && make clean && make && make test 
make check
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
