### PR TITLE
Set `backgroundFetchSilencePeriod` to 0

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -53,15 +53,16 @@ const (
 )
 
 type Config struct {
-	HTTPCacheType       string `toml:"http_cache_type"`
-	FSCacheType         string `toml:"filesystem_cache_type"`
-	ResolveResultEntry  int    `toml:"resolve_result_entry"`
-	NoBackgroundFetch   bool   `toml:"no_background_fetch"`
-	Debug               bool   `toml:"debug"`
-	AllowNoVerification bool   `toml:"allow_no_verification"`
-	DisableVerification bool   `toml:"disable_verification"`
-	MaxConcurrency      int64  `toml:"max_concurrency"`
-	NoPrometheus        bool   `toml:"no_prometheus"`
+	HTTPCacheType                    string `toml:"http_cache_type"`
+	FSCacheType                      string `toml:"filesystem_cache_type"`
+	ResolveResultEntry               int    `toml:"resolve_result_entry"`
+	NoBackgroundFetch                bool   `toml:"no_background_fetch"`
+	Debug                            bool   `toml:"debug"`
+	AllowNoVerification              bool   `toml:"allow_no_verification"`
+	DisableVerification              bool   `toml:"disable_verification"`
+	MaxConcurrency                   int64  `toml:"max_concurrency"`
+	NoPrometheus                     bool   `toml:"no_prometheus"`
+	PrioritizedTaskSilencePeriodMSec int    `toml:"prioritized_task_silence_period_msec"`
 
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob"`

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -155,7 +155,7 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snapshot.F
 		return nil, fmt.Errorf("cannot create local store: %w", err)
 	}
 
-	tm := task.NewBackgroundTaskManager(maxConcurrency, 5*time.Second)
+	tm := task.NewBackgroundTaskManager(maxConcurrency, time.Duration(cfg.PrioritizedTaskSilencePeriodMSec)*time.Millisecond)
 	r, err := layer.NewResolver(root, tm, cfg, fsOpts.resolveHandlers, metadataStore, store, fsOpts.overlayOpaqueType)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to setup resolver")


### PR DESCRIPTION
This commit sets the backgroundFetchSilencePeriod for the backgroundTaskManager to 0. Additionally, add a new field to the config to make it configurable.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*

*Description of changes:*
Once the container is started, the prefetcher fetches spans in the background. It acquires the span's lock (in the span manager) and releases it once done. If an on-demand fetch comes in, the bg tasks are cancelled and restarted, but only after a 'silence period' of 5s. But the prefetcher is still holding onto the lock, which means on-demands fetches for those particular spans will have to wait 5+ seconds until the prefetcher releases the lock. 

A short-term solution is to the `silence period` to 0s, which is what this PR is doing. 

Longer term solution is to rewrite the prefetcher, so that it yields the lock when cancelled.

*Testing performed:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
