### PR TITLE
Dedupe integ test mirror/dockerhub functions

### DIFF
--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -36,10 +36,6 @@ func TestSociCreateSparseIndex(t *testing.T) {
 	defer done()
 
 	rebootContainerd(t, sh, "", "")
-
-	dockerhub := func(name string) imageInfo {
-		return imageInfo{dockerLibrary + name, "", false}
-	}
 	tests := []struct {
 		name         string
 		minLayerSize int64
@@ -139,10 +135,6 @@ func TestSociCreate(t *testing.T) {
 	defer done()
 
 	rebootContainerd(t, sh, "", "")
-
-	dockerhub := func(name string) imageInfo {
-		return imageInfo{dockerLibrary + name, "", false}
-	}
 
 	tests := []struct {
 		name           string


### PR DESCRIPTION

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*

*Description of changes:*
Before this change, many tests defined the same set of helper functions. This change extracts those into reusable objects.


*Testing performed:*
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
