### PR TITLE
Update Ztoc media type

### DIFF
--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -40,7 +40,7 @@ const (
 	// artifactType of index SOCI index
 	SociIndexArtifactType = "application/vnd.amazon.soci.index.v1+json"
 	// mediaType of ztoc
-	SociLayerMediaType = "application/zstd"
+	SociLayerMediaType = "application/octet-stream"
 	// index annotation for image layer media type
 	IndexAnnotationImageLayerMediaType = "com.amazon.soci.image-layer-mediaType"
 	// index annotation for image layer digest


### PR DESCRIPTION
This commit updates the Ztoc media type from 'application/zstd' to 'application/octet-stream' since we do not compress Ztocs with zstd anymore.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
