### PR TITLE
Add benchmarking framework and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /out
 *.db
 .vscode/
+/benchmark/*/output/
+/benchmark/bin/

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ GO_LD_FLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/versi
 SOCI_SNAPSHOTTER_PROJECT_ROOT ?= $(shell pwd)
 LTAG_TEMPLATE_FLAG=-t ./.headers
 FBS_FILE_PATH=$(CURDIR)/soci/fbs/ztoc.fbs
+COMMIT=$(shell git rev-parse HEAD)
 
 CMD=soci-snapshotter-grpc soci
 
@@ -126,3 +127,11 @@ integration: pre-build
 	@echo "$@"
 	@echo "SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT)"
 	@GO111MODULE=$(GO111MODULE_VALUE) SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT) ENABLE_INTEGRATION_TEST=true go test $(GO_TEST_FLAGS) -v -timeout=0 ./integration
+
+benchmarks:
+	@echo "$@"
+	@cd benchmark/performanceTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/PerfTests . && sudo ../bin/PerfTests $(COMMIT) ../singleImage.csv 10
+
+benchmarks-comp:
+	@echo "$@"
+	@cd benchmark/comparisonTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/CompTests . && sudo ../bin/CompTests $(COMMIT) ../singleImage.csv 10

--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -1,0 +1,173 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package benchmark
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/benchmark/framework"
+)
+
+var (
+	outputDir         = "./output"
+	containerdAddress = "/tmp/containerd-grpc/containerd.sock"
+	containerdRoot    = "/tmp/lib/containerd"
+	containerdState   = "/tmp/containerd"
+	containerdConfig  = "../containerd-config.toml"
+	platform          = "linux/amd64"
+	sociBinary        = "../../out/soci-snapshotter-grpc"
+	sociAddress       = "/tmp/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"
+	sociRoot          = "/tmp/lib/soci-snapshotter-grpc"
+	sociConfig        = "../soci_config.toml"
+	awsSecretFile     = "../aws_secret"
+)
+
+func PullImageFromECR(b *testing.B, imageRef string) {
+	ctx, cancelCtx := framework.GetTestContext()
+	containerdProcess, err := getContainerdProcess(ctx)
+	if err != nil {
+		b.Fatalf("Error Starting Containerd: %v\n", err)
+	}
+	defer containerdProcess.StopProcess(cancelCtx)
+	b.ResetTimer()
+	_, err = containerdProcess.PullImageFromECR(ctx, imageRef, platform, awsSecretFile)
+	if err != nil {
+		b.Fatalf("Error Pulling Image: %v\n", err)
+	}
+	b.StopTimer()
+	err = containerdProcess.DeleteImage(ctx, imageRef)
+	if err != nil {
+		b.Fatalf("Error Deleting Image: %v\n", err)
+	}
+}
+
+func SociRPullPullImage(
+	b *testing.B,
+	imageRef string,
+	indexDigest string) {
+	ctx, cancelCtx := framework.GetTestContext()
+	containerdProcess, err := getContainerdProcess(ctx)
+	if err != nil {
+		b.Fatalf("Failed to create containerd proc: %v\n", err)
+	}
+	defer containerdProcess.StopProcess(cancelCtx)
+	sociProcess, err := getSociProcess()
+	if err != nil {
+		b.Fatalf("Failed to create soci proc: %v\n", err)
+	}
+	defer sociProcess.StopProcess()
+	sociContainerdProc := SociContainerdProcess{containerdProcess}
+	b.ResetTimer()
+	_, err = sociContainerdProc.SociRPullImageFromECR(ctx, imageRef, indexDigest, awsSecretFile)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	b.StopTimer()
+}
+
+func SociFullRun(
+	b *testing.B,
+	imageRef string,
+	indexDigest string,
+	readyLine string) {
+	ctx, cancelCtx := framework.GetTestContext()
+	containerdProcess, err := getContainerdProcess(ctx)
+	if err != nil {
+		b.Fatalf("Failed to create containerd proc: %v\n", err)
+	}
+	defer containerdProcess.StopProcess(cancelCtx)
+	sociProcess, err := getSociProcess()
+	if err != nil {
+		b.Fatalf("Failed to create soci proc: %v\n", err)
+	}
+	defer sociProcess.StopProcess()
+	sociContainerdProc := SociContainerdProcess{containerdProcess}
+	b.ResetTimer()
+	image, err := sociContainerdProc.SociRPullImageFromECR(ctx, imageRef, indexDigest, awsSecretFile)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	container, cleanupContainer, err := sociContainerdProc.CreateSociContainer(ctx, image)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	defer cleanupContainer()
+	taskDetails, cleanupTask, err := sociContainerdProc.CreateTask(ctx, container)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	defer cleanupTask()
+	cleanupRun, err := sociContainerdProc.RunContainerTaskForReadyLine(ctx, taskDetails, readyLine)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	defer cleanupRun()
+	b.StopTimer()
+}
+
+func OverlayFSFullRun(
+	b *testing.B,
+	imageRef string,
+	readyLine string) {
+	ctx, cancelCtx := framework.GetTestContext()
+	containerdProcess, err := getContainerdProcess(ctx)
+	if err != nil {
+		b.Fatalf("Failed to create containerd proc: %v\n", err)
+	}
+	defer containerdProcess.StopProcess(cancelCtx)
+	b.ResetTimer()
+	image, err := containerdProcess.PullImageFromECR(ctx, imageRef, platform, awsSecretFile)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	container, cleanupContainer, err := containerdProcess.CreateContainer(ctx, image)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	defer cleanupContainer()
+	taskDetails, cleanupTask, err := containerdProcess.CreateTask(ctx, container)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	defer cleanupTask()
+	cleanupRun, err := containerdProcess.RunContainerTaskForReadyLine(ctx, taskDetails, readyLine)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	defer cleanupRun()
+	b.StopTimer()
+}
+
+func getContainerdProcess(ctx context.Context) (*framework.ContainerdProcess, error) {
+	return framework.StartContainerd(
+		containerdAddress,
+		containerdRoot,
+		containerdState,
+		containerdConfig,
+		outputDir)
+}
+
+func getSociProcess() (*SociProcess, error) {
+	return StartSoci(
+		sociBinary,
+		sociAddress,
+		sociRoot,
+		containerdAddress,
+		sociConfig,
+		outputDir)
+}

--- a/benchmark/comparisonTest/main.go
+++ b/benchmark/comparisonTest/main.go
@@ -1,0 +1,102 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/benchmark"
+	"github.com/awslabs/soci-snapshotter/benchmark/framework"
+)
+
+var (
+	outputDir = "./output"
+)
+
+type ImageDescriptor struct {
+	shortName            string
+	imageRef             string
+	sociIndexManifestRef string
+	readyLine            string
+}
+
+func main() {
+	commit := os.Args[1]
+	configCsv := os.Args[2]
+	numberOfTests, err := strconv.Atoi(os.Args[3])
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to parse number of test %s with error:%v\n", os.Args[3], err)
+		panic(errMsg)
+	}
+	imageList, err := getImageListFromCsv(configCsv)
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
+		panic(errMsg)
+	}
+	var drivers []framework.BenchmarkTestDriver
+	for _, image := range imageList {
+		shortName := image.shortName
+		imageRef := image.imageRef
+		sociIndexManifestRef := image.sociIndexManifestRef
+		readyLine := image.readyLine
+		drivers = append(drivers, framework.BenchmarkTestDriver{
+			TestName:      "OverlayFSFull" + shortName,
+			NumberOfTests: numberOfTests,
+			TestFunction: func(b *testing.B) {
+				benchmark.OverlayFSFullRun(b, imageRef, readyLine)
+			},
+		})
+		drivers = append(drivers, framework.BenchmarkTestDriver{
+			TestName:      "SociFull" + shortName,
+			NumberOfTests: numberOfTests,
+			TestFunction: func(b *testing.B) {
+				benchmark.SociFullRun(b, imageRef, sociIndexManifestRef, readyLine)
+			},
+		})
+	}
+
+	benchmarks := framework.BenchmarkFramework{
+		OutputDir: outputDir,
+		CommitID:  commit,
+		Drivers:   drivers,
+	}
+	benchmarks.Run()
+}
+
+func getImageListFromCsv(csvLoc string) ([]ImageDescriptor, error) {
+	csvFile, err := os.Open(csvLoc)
+	if err != nil {
+		return nil, err
+	}
+	csv, err := csv.NewReader(csvFile).ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	var images []ImageDescriptor
+	for _, image := range csv {
+		images = append(images, ImageDescriptor{
+			shortName:            image[0],
+			imageRef:             image[1],
+			sociIndexManifestRef: image[2],
+			readyLine:            image[3]})
+	}
+	return images, nil
+}

--- a/benchmark/containerd-config.toml
+++ b/benchmark/containerd-config.toml
@@ -1,0 +1,7 @@
+version = 2
+[debug]
+  level = "DEBUG"
+[proxy_plugins]
+  [proxy_plugins.soci]
+    type = "snapshot"
+    address = "/tmp/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"

--- a/benchmark/framework/aws_utils.go
+++ b/benchmark/framework/aws_utils.go
@@ -1,0 +1,61 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"os"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/remotes/docker/config"
+)
+
+func (proc *ContainerdProcess) PullImageFromECR(
+	ctx context.Context,
+	imageRef string,
+	platform string,
+	awsSecretFile string) (containerd.Image, error) {
+	opts := GetRemoteOpts(ctx, platform)
+	opts = append(opts, containerd.WithResolver(GetECRResolver(ctx, awsSecretFile)))
+	image, pullErr := proc.Client.Pull(ctx, imageRef, opts...)
+	if pullErr != nil {
+		return nil, pullErr
+	}
+	return image, nil
+}
+
+func GetECRResolver(ctx context.Context, awsSecretFile string) remotes.Resolver {
+	username := "AWS"
+	secretByteArray, err := os.ReadFile(awsSecretFile)
+	secret := string(secretByteArray)
+	if err != nil {
+		panic("Cannot read aws ecr login password")
+	}
+	hostOptions := config.HostOptions{}
+	hostOptions.Credentials = func(host string) (string, string, error) {
+		return username, secret, nil
+	}
+	var PushTracker = docker.NewInMemoryTracker()
+	options := docker.ResolverOptions{
+		Tracker: PushTracker,
+	}
+	options.Hosts = config.ConfigureHosts(ctx, hostOptions)
+
+	return docker.NewResolver(options)
+}

--- a/benchmark/framework/containerd_utils.go
+++ b/benchmark/framework/containerd_utils.go
@@ -1,0 +1,305 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package framework
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+)
+
+var (
+	testNamespace               = "BENCHMARK_TESTING"
+	testContainerID             = "TEST_RUN_CONTAINER"
+	testEnvironment             = "TEST_RUNTIME"
+	outputFilePerm  fs.FileMode = 0777
+)
+
+type ContainerdProcess struct {
+	command *exec.Cmd
+	address string
+	root    string
+	state   string
+	stdout  *os.File
+	stderr  *os.File
+	Client  *containerd.Client
+}
+
+func StartContainerd(
+	containerdAddress string,
+	containerdRoot string,
+	containerdState string,
+	containerdConfig string,
+	containerdOutput string) (*ContainerdProcess, error) {
+	containerdCmd := exec.Command("containerd",
+		"-a", containerdAddress,
+		"--root", containerdRoot,
+		"--state", containerdState,
+		"-c", containerdConfig)
+	err := os.MkdirAll(containerdOutput, outputFilePerm)
+	if err != nil {
+		return nil, err
+	}
+	stdoutFile, err := os.Create(containerdOutput + "/containerd-stdout")
+	if err != nil {
+		return nil, err
+	}
+	containerdCmd.Stdout = stdoutFile
+	stderrFile, err := os.Create(containerdOutput + "/containerd-stderr")
+	if err != nil {
+		return nil, err
+	}
+	containerdCmd.Stderr = stderrFile
+	err = containerdCmd.Start()
+	if err != nil {
+		return nil, err
+	}
+	client, err := newClient(containerdAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ContainerdProcess{
+		command: containerdCmd,
+		address: containerdAddress,
+		root:    containerdRoot,
+		stdout:  stdoutFile,
+		stderr:  stderrFile,
+		state:   containerdState,
+		Client:  client}, nil
+}
+
+func (proc *ContainerdProcess) StopProcess(cancelContext context.CancelFunc) {
+	if proc.Client != nil {
+		proc.Client.Close()
+	}
+	if proc.stdout != nil {
+		proc.stdout.Close()
+	}
+	if proc.stderr != nil {
+		proc.stderr.Close()
+	}
+	if cancelContext != nil {
+		cancelContext()
+	}
+	if proc.command != nil {
+		proc.command.Process.Kill()
+	}
+	os.RemoveAll(proc.root)
+	os.RemoveAll(proc.state)
+	os.RemoveAll(proc.address)
+}
+
+func (proc *ContainerdProcess) PullImage(
+	ctx context.Context,
+	imageRef string,
+	platform string) (containerd.Image, error) {
+	image, pullErr := proc.Client.Pull(ctx, imageRef, GetRemoteOpts(ctx, platform)...)
+	if pullErr != nil {
+		return nil, pullErr
+	}
+	return image, nil
+}
+
+func (proc *ContainerdProcess) DeleteImage(ctx context.Context, imageRef string) error {
+	imageService := proc.Client.ImageService()
+	err := imageService.Delete(ctx, imageRef, images.SynchronousDelete())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (proc *ContainerdProcess) CreateContainer(
+	ctx context.Context,
+	image containerd.Image,
+	opts ...containerd.NewContainerOpts) (containerd.Container, func(), error) {
+	id := fmt.Sprintf("%s-%d", testContainerID, time.Now().UnixNano())
+	opts = append(opts, containerd.WithNewSnapshot(id, image))
+	opts = append(opts, containerd.WithNewSpec(oci.WithImageConfig(image)))
+	container, err := proc.Client.NewContainer(
+		ctx,
+		id,
+		opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanupFunc := func() {
+		err = container.Delete(ctx, containerd.WithSnapshotCleanup)
+		if err != nil {
+			fmt.Printf("Error deleting container: %v\n", err)
+		}
+	}
+	return container, cleanupFunc, nil
+}
+
+type TaskDetails struct {
+	task         containerd.Task
+	stdoutReader io.Reader
+	stderrReader io.Reader
+}
+
+func (proc *ContainerdProcess) CreateTask(
+	ctx context.Context,
+	container containerd.Container) (*TaskDetails, func(), error) {
+	stdoutPipeReader, stdoutPipeWriter := io.Pipe()
+	stderrPipeReader, stderrPipeWriter := io.Pipe()
+	cioCreator := cio.NewCreator(cio.WithStreams(os.Stdin, stdoutPipeWriter, stderrPipeWriter))
+	task, err := container.NewTask(ctx, cioCreator)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanupFunc := func() {
+		stdoutPipeReader.Close()
+		stdoutPipeWriter.Close()
+		stderrPipeReader.Close()
+		stderrPipeWriter.Close()
+		processStatus, _ := task.Status(ctx)
+		if processStatus.Status != "stopped" {
+			fmt.Printf("Tried to kill task")
+			err = task.Kill(ctx, syscall.SIGKILL)
+			if err != nil {
+				fmt.Printf("Error killing task: %v\n", err)
+			}
+		}
+		_, err = task.Delete(ctx)
+		if err != nil {
+			fmt.Printf("Error deleting task: %v\n", err)
+		}
+	}
+
+	return &TaskDetails{
+			task,
+			stdoutPipeReader,
+			stderrPipeReader},
+		cleanupFunc,
+		err
+}
+
+func (proc *ContainerdProcess) RunContainerTaskForReadyLine(
+	ctx context.Context,
+	taskDetails *TaskDetails,
+	readyLine string) (func(), error) {
+	stdoutScanner := bufio.NewScanner(taskDetails.stdoutReader)
+	stderrScanner := bufio.NewScanner(taskDetails.stderrReader)
+
+	exitStatusC, err := taskDetails.task.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resultChannel := make(chan string, 1)
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	go func() {
+		select {
+		case <-exitStatusC:
+			resultChannel <- "PROC_EXIT"
+		case <-timeoutCtx.Done():
+			return
+		}
+	}()
+
+	go func() {
+		for stderrScanner.Scan() {
+			nextLine := stderrScanner.Text()
+			if strings.Contains(nextLine, readyLine) {
+				resultChannel <- "READYLINE_STDERR"
+				return
+			}
+			select {
+			case <-timeoutCtx.Done():
+				return
+			default:
+			}
+		}
+	}()
+
+	go func() {
+		for stdoutScanner.Scan() {
+			nextLine := stdoutScanner.Text()
+			if strings.Contains(nextLine, readyLine) {
+				resultChannel <- "READYLINE_STDOUT"
+				return
+			}
+			select {
+			case <-timeoutCtx.Done():
+				return
+			default:
+			}
+		}
+	}()
+
+	if err := taskDetails.task.Start(ctx); err != nil {
+		return nil, err
+	}
+
+	select {
+	case <-resultChannel:
+		break
+	case <-timeoutCtx.Done():
+		break
+	}
+
+	cleanupFunc := func() {
+		processStatus, _ := taskDetails.task.Status(ctx)
+		if processStatus.Status == "running" {
+			err = taskDetails.task.Kill(ctx, syscall.SIGKILL)
+			if err != nil {
+				fmt.Printf("Error killing task: %v\n", err)
+			}
+			exitChannel, _ := taskDetails.task.Wait(ctx)
+			<-exitChannel
+		}
+	}
+	return cleanupFunc, nil
+}
+
+func GetRemoteOpts(ctx context.Context, platform string) []containerd.RemoteOpt {
+	var opts []containerd.RemoteOpt
+	opts = append(opts, containerd.WithPlatform(platform))
+	opts = append(opts, containerd.WithPullUnpack)
+
+	return opts
+}
+
+func GetTestContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = namespaces.WithNamespace(ctx, testNamespace)
+	return ctx, cancel
+}
+
+func newClient(address string) (*containerd.Client, error) {
+	opts := []containerd.ClientOpt{}
+	if rt := os.Getenv(testEnvironment); rt != "" {
+		opts = append(opts, containerd.WithDefaultRuntime(rt))
+	}
+
+	return containerd.New(address, opts...)
+}

--- a/benchmark/framework/framework.go
+++ b/benchmark/framework/framework.go
@@ -1,0 +1,137 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package framework
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/montanaflynn/stats"
+)
+
+var (
+	resultFilename             = "results.json"
+	resultFilePerm fs.FileMode = 0644
+)
+
+type BenchmarkFramework struct {
+	OutputDir string                `json:"-"`
+	CommitID  string                `json:"commit"`
+	Drivers   []BenchmarkTestDriver `json:"benchmarkTests"`
+}
+
+type BenchmarkTestDriver struct {
+	TestName       string           `json:"testName"`
+	NumberOfTests  int              `json:"numberOfTests"`
+	BeforeFunction func()           `json:"-"`
+	TestFunction   func(*testing.B) `json:"-"`
+	AfterFunction  func()           `json:"-"`
+	TestsRun       int              `json:"-"`
+	TestTimes      []float64        `json:"testTimes"`
+	StdDev         float64          `json:"stdDev"`
+	Mean           float64          `json:"mean"`
+	Min            float64          `json:"min"`
+	Pct25          float64          `json:"pct25"`
+	Pct50          float64          `json:"pct50"`
+	Pct75          float64          `json:"pct75"`
+	Pct90          float64          `json:"pct90"`
+	Max            float64          `json:"max"`
+}
+
+func (frame *BenchmarkFramework) Run() {
+	testing.Init()
+	flag.Set("test.benchtime", "1x")
+	flag.Parse()
+	for i := 0; i < len(frame.Drivers); i++ {
+		testDriver := &frame.Drivers[i]
+		fmt.Printf("Running tests for %s\n", testDriver.TestName)
+		if testDriver.BeforeFunction != nil {
+			testDriver.BeforeFunction()
+		}
+		for j := 0; j < testDriver.NumberOfTests; j++ {
+			fmt.Printf("Running test %d of %d\n", j+1, testDriver.NumberOfTests)
+			res := testing.Benchmark(testDriver.TestFunction)
+			testDriver.TestTimes = append(testDriver.TestTimes, res.T.Seconds())
+		}
+		testDriver.calculateStats()
+		if testDriver.AfterFunction != nil {
+			testDriver.AfterFunction()
+		}
+	}
+
+	json, err := json.MarshalIndent(frame, "", " ")
+	if err != nil {
+		fmt.Printf("JSON Marshalling Error: %v\n", err)
+	}
+	err = os.MkdirAll(frame.OutputDir, resultFilePerm)
+	if err != nil {
+		fmt.Printf("Failed to Create Output Dir: %v\n", err)
+	}
+	resultFileLoc := frame.OutputDir + "/" + resultFilename
+	err = os.WriteFile(resultFileLoc, json, resultFilePerm)
+	if err != nil {
+		fmt.Printf("WriteFile Error: %v\n", err)
+	}
+}
+
+func (driver *BenchmarkTestDriver) calculateStats() {
+	var err error
+	driver.StdDev, err = stats.StandardDeviation(driver.TestTimes)
+	if err != nil {
+		fmt.Printf("Error Calculating Std Dev: %v\n", err)
+		driver.StdDev = -1
+	}
+	driver.Mean, err = stats.Mean(driver.TestTimes)
+	if err != nil {
+		fmt.Printf("Error Calculating Mean: %v\n", err)
+		driver.Mean = -1
+	}
+	driver.Min, err = stats.Min(driver.TestTimes)
+	if err != nil {
+		fmt.Printf("Error Calculating Min: %v\n", err)
+		driver.Min = -1
+	}
+	driver.Pct25, err = stats.Percentile(driver.TestTimes, 25)
+	if err != nil {
+		fmt.Printf("Error Calculating 25th Pct: %v\n", err)
+		driver.Pct25 = -1
+	}
+	driver.Pct50, err = stats.Percentile(driver.TestTimes, 50)
+	if err != nil {
+		fmt.Printf("Error Calculating 50th Pct: %v\n", err)
+		driver.Pct50 = -1
+	}
+	driver.Pct75, err = stats.Percentile(driver.TestTimes, 75)
+	if err != nil {
+		fmt.Printf("Error Calculating 75th Pct: %v\n", err)
+		driver.Pct75 = -1
+	}
+	driver.Pct90, err = stats.Percentile(driver.TestTimes, 90)
+	if err != nil {
+		fmt.Printf("Error Calculating 90th Pct: %v\n", err)
+		driver.Pct90 = -1
+	}
+	driver.Max, err = stats.Max(driver.TestTimes)
+	if err != nil {
+		fmt.Printf("Error Calculating Max: %v\n", err)
+		driver.Max = -1
+	}
+}

--- a/benchmark/performanceTest/main.go
+++ b/benchmark/performanceTest/main.go
@@ -1,0 +1,95 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/benchmark"
+	"github.com/awslabs/soci-snapshotter/benchmark/framework"
+)
+
+var (
+	outputDir = "./output"
+)
+
+type ImageDescriptor struct {
+	shortName            string
+	imageRef             string
+	sociIndexManifestRef string
+	readyLine            string
+}
+
+func main() {
+	commit := os.Args[1]
+	configCsv := os.Args[2]
+	numberOfTests, err := strconv.Atoi(os.Args[3])
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to parse number of test %s with error:%v\n", os.Args[3], err)
+		panic(errMsg)
+	}
+	imageList, err := getImageListFromCsv(configCsv)
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
+		panic(errMsg)
+	}
+	var drivers []framework.BenchmarkTestDriver
+	for _, image := range imageList {
+		shortName := image.shortName
+		imageRef := image.imageRef
+		sociIndexManifestRef := image.sociIndexManifestRef
+		readyLine := image.readyLine
+		drivers = append(drivers, framework.BenchmarkTestDriver{
+			TestName:      "SociFull" + shortName,
+			NumberOfTests: numberOfTests,
+			TestFunction: func(b *testing.B) {
+				benchmark.SociFullRun(b, imageRef, sociIndexManifestRef, readyLine)
+			},
+		})
+	}
+
+	benchmarks := framework.BenchmarkFramework{
+		OutputDir: outputDir,
+		CommitID:  commit,
+		Drivers:   drivers,
+	}
+	benchmarks.Run()
+}
+
+func getImageListFromCsv(csvLoc string) ([]ImageDescriptor, error) {
+	csvFile, err := os.Open(csvLoc)
+	if err != nil {
+		return nil, err
+	}
+	csv, err := csv.NewReader(csvFile).ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	var images []ImageDescriptor
+	for _, image := range csv {
+		images = append(images, ImageDescriptor{
+			shortName:            image[0],
+			imageRef:             image[1],
+			sociIndexManifestRef: image[2],
+			readyLine:            image[3]})
+	}
+	return images, nil
+}

--- a/benchmark/soci_config.toml
+++ b/benchmark/soci_config.toml
@@ -1,0 +1,3 @@
+[cri_keychain]
+  enable_keychain = true 
+  image_service_path = "/tmp/containerd-grpc/containerd.sock"

--- a/benchmark/soci_utils.go
+++ b/benchmark/soci_utils.go
@@ -1,0 +1,161 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package benchmark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/awslabs/soci-snapshotter/benchmark/framework"
+	"github.com/awslabs/soci-snapshotter/fs/source"
+	"github.com/containerd/containerd"
+)
+
+var (
+	outputFilePerm fs.FileMode = 0777
+)
+
+type SociContainerdProcess struct {
+	*framework.ContainerdProcess
+}
+
+type SociProcess struct {
+	command *exec.Cmd
+	address string
+	root    string
+	stdout  *os.File
+	stderr  *os.File
+}
+
+func StartSoci(
+	sociBinary string,
+	sociAddress string,
+	sociRoot string,
+	containerdAddress string,
+	configFile string,
+	outputDir string) (*SociProcess, error) {
+	sociCmd := exec.Command(sociBinary,
+		"-address", sociAddress,
+		"-config", configFile,
+		"-log-level", "debug",
+		"-root", sociRoot)
+	err := os.MkdirAll(outputDir, outputFilePerm)
+	if err != nil {
+		return nil, err
+	}
+	stdoutFile, err := os.Create(outputDir + "/soci-snapshotter-stdout")
+	if err != nil {
+		return nil, err
+	}
+	sociCmd.Stdout = stdoutFile
+	stderrFile, err := os.Create(outputDir + "/soci-snapshotter-stderr")
+	if err != nil {
+		return nil, err
+	}
+	sociCmd.Stderr = stderrFile
+	err = sociCmd.Start()
+	if err != nil {
+		fmt.Printf("Soci Failed to Start %v\n", err)
+		return nil, err
+	}
+
+	// The soci-snapshotter-grpc is not ready to be used until the
+	// unix socket file is created
+	sleepCount := 0
+	loopExit := false
+	for !loopExit {
+		time.Sleep(1 * time.Second)
+		sleepCount++
+		if _, err := os.Stat(sociAddress); err == nil {
+			loopExit = true
+		}
+		if sleepCount > 15 {
+			return nil, errors.New("Could not create .sock in time")
+		}
+	}
+
+	return &SociProcess{
+		command: sociCmd,
+		address: sociAddress,
+		root:    sociRoot,
+		stdout:  stdoutFile,
+		stderr:  stderrFile}, nil
+}
+
+func (proc *SociProcess) StopProcess() {
+	if proc.stdout != nil {
+		proc.stdout.Close()
+	}
+	if proc.stderr != nil {
+		proc.stderr.Close()
+	}
+	if proc.command != nil {
+		proc.command.Process.Kill()
+	}
+	err := os.RemoveAll(proc.address)
+	if err != nil {
+		fmt.Printf("Error removing Address: %v\n", err)
+	}
+
+	snapshotDir := proc.root + "/snapshotter/snapshots/"
+	snapshots, err := os.ReadDir(snapshotDir)
+	if err != nil {
+		fmt.Printf("Could not read dir: %s\n", snapshotDir)
+	}
+
+	for _, s := range snapshots {
+		mountpoint := snapshotDir + s.Name() + "/fs"
+		_ = syscall.Unmount(mountpoint, syscall.MNT_FORCE)
+	}
+	err = os.RemoveAll(proc.root)
+	if err != nil {
+		fmt.Printf("Error removing root: %v\n", err)
+	}
+}
+
+func (proc *SociContainerdProcess) SociRPullImageFromECR(
+	ctx context.Context,
+	imageRef string,
+	sociIndexDigest string,
+	awsSecretFile string) (containerd.Image, error) {
+	image, err := proc.Client.Pull(ctx, imageRef, []containerd.RemoteOpt{
+		containerd.WithResolver(framework.GetECRResolver(ctx, awsSecretFile)),
+		containerd.WithSchema1Conversion,
+		containerd.WithPullUnpack,
+		containerd.WithPullSnapshotter("soci"),
+		containerd.WithImageHandlerWrapper(source.AppendDefaultLabelsHandlerWrapper(
+			imageRef,
+			sociIndexDigest)),
+	}...)
+	if err != nil {
+		fmt.Printf("Soci Pull Failed %v\n", err)
+		return nil, err
+	}
+	return image, nil
+}
+
+func (proc *SociContainerdProcess) CreateSociContainer(
+	ctx context.Context,
+	image containerd.Image) (containerd.Container, func(), error) {
+	return proc.CreateContainer(ctx, image, containerd.WithSnapshotter("soci"))
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/moby/sys/mountinfo v0.5.0
+	github.com/montanaflynn/stats v0.6.6
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2
@@ -39,16 +40,21 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect
+	github.com/containerd/console v1.0.3 // indirect
+	github.com/containerd/fifo v1.0.0 // indirect
 	github.com/containerd/ttrpc v1.1.0 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/go-logr/logr v1.2.2 // indirect
+	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
@@ -57,15 +63,23 @@ require (
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/sys/signal v0.6.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/onsi/ginkgo v1.16.4 // indirect
 	github.com/onsi/gomega v1.17.0 // indirect
+	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 // indirect
+	github.com/opencontainers/runc v1.1.2 // indirect
+	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
+	github.com/opencontainers/selinux v1.10.1 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.30.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/urfave/cli v1.22.2 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,7 @@ github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50/go.mod h1:Tj/on
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
+github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/containerd/containerd v1.2.10/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -215,6 +216,7 @@ github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv
 github.com/containerd/fifo v0.0.0-20200410184934-f15a3290365b/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=
 github.com/containerd/fifo v0.0.0-20201026212402-0724c46b320c/go.mod h1:jPQ2IAeZRCYxpS/Cm1495vGFww6ecHmMk1YJH2Q5ln0=
 github.com/containerd/fifo v0.0.0-20210316144830-115abcc95a1d/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
+github.com/containerd/fifo v1.0.0 h1:6PirWBr9/L7GDamKr+XM0IeUFXu5mf3M/BPpH9gaLBU=
 github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
 github.com/containerd/go-cni v1.0.1/go.mod h1:+vUpYxKvAF72G9i1WoDOiPGRtQpqsNW/ZHtSlv++smU=
 github.com/containerd/go-cni v1.0.2/go.mod h1:nrNABBHzu0ZwCug9Ije8hL2xBCYh/pjfMb1aZGrrohk=
@@ -285,6 +287,7 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -400,6 +403,7 @@ github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
+github.com/gogo/googleapis v1.4.0 h1:zgVt4UpGxcqVOw97aRGxT4svlcmdK35fynLNctY32zI=
 github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -635,6 +639,7 @@ github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2J
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.5.0 h1:2Ks8/r6lopsxWi9m58nlwjaeSzUX9iiL1vj5qB/9ObI=
 github.com/moby/sys/mountinfo v0.5.0/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
+github.com/moby/sys/signal v0.6.0 h1:aDpY94H8VlhTGa9sNYUFCFsMZIUh5wm0B6XkIoJj/iY=
 github.com/moby/sys/signal v0.6.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/moby/sys/symlink v0.2.0/go.mod h1:7uZVF2dqJjG/NsClqul95CqKOBRQyYSNnJ6BMgR/gFs=
@@ -647,6 +652,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
+github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -707,18 +714,21 @@ github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rm
 github.com/opencontainers/runc v1.0.0-rc93/go.mod h1:3NOsor4w32B2tC0Zbl8Knk4Wg84SM2ImC1fxBuqJ/H0=
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runc v1.1.0/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
+github.com/opencontainers/runc v1.1.2 h1:2VSZwLx5k/BfsBxMMipG/LYUnmqOD/BPkIVgQUcTlLw=
 github.com/opencontainers/runc v1.1.2/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2-0.20190207185410-29686dbc5559/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
+github.com/opencontainers/selinux v1.10.1 h1:09LIPVRP3uuZGQvgR+SgMSNBd1Eb3vlRbGqQpoHsF8w=
 github.com/opencontainers/selinux v1.10.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/oras-project/artifacts-spec v1.0.0-rc.2 h1:9SMCNSxkJEHqWGDiMCuy6TXHgvjgwXGdXZZGXLKQvVE=
@@ -782,7 +792,9 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.3.0 h1:6NjYksEUlhurdVehpc7S7dk6DAmcKv8V9gG0FsVN2U4=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
@@ -793,6 +805,7 @@ github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
@@ -852,6 +865,7 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=


### PR DESCRIPTION
This adds a benchmark framework and tests for the soci snapshotter and overlayfs.

### High Level Description of the Benchmarking Framework
Each unit of work that we are benchmarking is a `BenchmarkTestDriver`.  These are then collected in a `BenchmarkFramework`object, that then runs each test driver and writes out statistics.  The benchmark framework relies on the go testing library.  So each `BenchmarkTestDriver` has a struct field `TestFunction  func(*testing.B)` that contains the actual test. 

The `BenchmarkTestDriver`'s are defined in `benchmark/main.go` and are built up of from the different lifecycle actions defined in containerd.  All of these lifecycle actions are accessible via helper functions in `benchmark/soci_utils.go`, `benchmark/framework/containerd_utils.go`, and `benchmark/framework/aws_utils.go`.

### Details of Changes
The benchmarker adds a new binary build which runs benchmarking tests.  This is called via the make target _benchmarks_ (e.g. run `make benchmarks`).  It takes in a .csv file as its input.  Each line of the csv file is a different workload that every test is run against. 

**benchmark/main.go** - this lists the tests that are being run, sets the 'global variables', and takes care of the csv parsing.  Also the main func for the binary.
**benchmark/benchmarkTests.go** - this defines all of the individual tests. 
**benchmark/framework/framework.go** - this contains benchmarking framework ideas such as TestDrivers, etc..  It also the main loop that runs the collection of tests.
**benchmark/soci_utils.go** - adds soci specific lifecycle actions and objects
**benchmark/framework/aws_utils.go** - adds aws specific lifecycle actions and objects, important for ECR
**benchmark/framework/containerd_utils.go** - adds containerd specific lifecycle actions and objects
**benchmark/soci_config.toml** - soci config file
**benchmark/containerd-config.toml** - containerd config file
**.gitignore** - ignores the artifcats created in benchmarking
**Makefile** - adds the make benchmarks target
**go.mod** - updated due to adding a stats library
**go.sum** - updated due to adding a stats library

Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
