### PR TITLE
Introduce setting NetativeTimeout for go-fuse

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -99,4 +99,7 @@ type FuseConfig struct {
 
 	// EntryTimeout defines TTL for directory, name lookup in seconds.
 	EntryTimeout int64 `toml:"entry_timeout"`
+
+	// NegativeTimeout defines the overall entry timeout for failed lookups.
+	NegativeTimeout int64 `toml:"negative_timeout"`
 }


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*
#119 

*Description of changes:*
This change adds the ability to set `NegativeTimeout` for `go-fuse`. This is controlled by `negative_timeout` setting in `config.toml`. This change does not tune the default value for that setting. This will be done in the separate PR.

*Testing performed:*
- `make check && make test && make integration` pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
