### PR TITLE
Set more restrictive permissions for artifacts.db

### DIFF
--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -119,7 +119,7 @@ func writeArtifactEntry(entry *ArtifactEntry) error {
 func NewDB() (*ArtifactsDb, error) {
 	once.Do(func() {
 		path := path.Join(config.SociSnapshotterRootPath, artifactsDbName)
-		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 		if err != nil {
 			log.G(context.Background()).Errorf("can't create or open the file %s", path)
 			return


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
`artifacts.db` has too broad permission set (0644). Reducing to 0600.

*Testing performed:*
- `make test && make check && make integration` pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
