### PR TITLE
Reduce permissions to docker-compose.yml

### DIFF
--- a/util/dockershell/compose/compose.go
+++ b/util/dockershell/compose/compose.go
@@ -102,7 +102,7 @@ func New(dockerComposeYaml string, opts ...Option) (*Compose, error) {
 		return nil, err
 	}
 	confFile := filepath.Join(tmpContext, "docker-compose.yml")
-	if err := os.WriteFile(confFile, []byte(dockerComposeYaml), 0666); err != nil {
+	if err := os.WriteFile(confFile, []byte(dockerComposeYaml), 0600); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
`docker-compose.yml` used to have permission set `0666`, which is too broad. Setting it to `0600`.

*Testing performed:*
- `make test && make check && make integration pass`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
