### PR TITLE
Reduce permissions for the root directory

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -593,7 +593,7 @@ func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 		return "", errors.Wrap(err, "failed to create temp dir")
 	}
 
-	if err := os.Mkdir(filepath.Join(td, "fs"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(td, "fs"), 0711); err != nil {
 		return td, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
Setting the limited permission set for snapshotter's root folder (`/var/lib/soci-snapshotter`).

*Testing performed:*
- `make test && make check && make integration` pass
- deployed on EC2 instance, created an index and verified that the permission set applies:
```
$ sudo ls -l /var/lib
total 0
...
drwx--x--x 10 root    root    307 Oct 25 20:30 containerd
drwx--x--x  3 root    root     41 Oct 25 20:30 soci-snapshotter-grpc
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
