### PR TITLE
Allow multi-platform/cross-platform index build

### DIFF
--- a/cmd/soci/commands/internal/platform.go
+++ b/cmd/soci/commands/internal/platform.go
@@ -1,0 +1,70 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli"
+)
+
+const (
+	PlatformFlagKey     = "platform"
+	AllPlatformsFlagKey = "all-platforms"
+)
+
+var PlatformFlags = []cli.Flag{
+	cli.BoolFlag{
+		Name:  AllPlatformsFlagKey,
+		Usage: "",
+	},
+	cli.StringSliceFlag{
+		Name:  PlatformFlagKey + ", p",
+		Usage: "",
+	},
+}
+
+// GetPlatforms returns the set of platforms from a cli.Context
+// The order of preference is:
+// 1) all platforms supported by the image if the `all-plaforms` flag is set
+// 2) the set of platforms specified by the `platform` flag
+// 3) the default platform
+//
+// This method is not suitable for situations where the default should be all supported platforms (e.g. the `soci index list` command)
+func GetPlatforms(ctx context.Context, cliContext *cli.Context, img images.Image, cs content.Store) ([]ocispec.Platform, error) {
+	if cliContext.Bool(AllPlatformsFlagKey) {
+		return images.Platforms(ctx, cs, img.Target)
+	}
+	ps := cliContext.StringSlice(PlatformFlagKey)
+	if len(ps) == 0 {
+		return []ocispec.Platform{platforms.DefaultSpec()}, nil
+	}
+	var result []ocispec.Platform
+	for _, p := range ps {
+		platform, err := platforms.Parse(p)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse platform %s: %w", p, err)
+		}
+		result = append(result, platform)
+	}
+	return result, nil
+}

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -44,6 +44,7 @@ import (
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
 	"github.com/awslabs/soci-snapshotter/util/dockershell/compose"
 	"github.com/awslabs/soci-snapshotter/util/testutil"
+	"github.com/containerd/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/rs/xid"
 )
@@ -747,9 +748,9 @@ func encodeImageInfo(ii ...imageInfo) [][]string {
 func copyImage(sh *shell.Shell, src, dst imageInfo) {
 	opts := encodeImageInfo(src, dst)
 	sh.
-		X(append([]string{"ctr", "i", "pull", "--all-platforms"}, opts[0]...)...).
+		X(append([]string{"ctr", "i", "pull", "--platform", platforms.Format(src.platform)}, opts[0]...)...).
 		X("ctr", "i", "tag", src.ref, dst.ref).
-		X(append([]string{"ctr", "i", "push"}, opts[1]...)...)
+		X(append([]string{"ctr", "i", "push", "--platform", platforms.Format(src.platform)}, opts[1]...)...)
 }
 
 func optimizeImage(sh *shell.Shell, src imageInfo) string {
@@ -759,9 +760,9 @@ func optimizeImage(sh *shell.Shell, src imageInfo) string {
 func buildSparseIndex(sh *shell.Shell, src imageInfo, minLayerSize int64) string {
 	opts := encodeImageInfo(src)
 	indexDigest := sh.
-		X(append([]string{"ctr", "i", "pull"}, opts[0]...)...).
-		X("soci", "create", src.ref, "--min-layer-size", fmt.Sprintf("%d", minLayerSize)).
-		O("soci", "index", "list", "-q", "--ref", src.ref) // this will make SOCI artifact available locally
+		X(append([]string{"ctr", "i", "pull", "--platform", platforms.Format(src.platform)}, opts[0]...)...).
+		X("soci", "create", src.ref, "--min-layer-size", fmt.Sprintf("%d", minLayerSize), "--platform", platforms.Format(src.platform)).
+		O("soci", "index", "list", "-q", "--ref", src.ref, "--platform", platforms.Format(src.platform)) // this will make SOCI artifact available locally
 	return strings.Trim(string(indexDigest), "\n")
 }
 

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -22,6 +22,7 @@ import (
 
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
 	"github.com/awslabs/soci-snapshotter/util/testutil"
+	"github.com/containerd/containerd/platforms"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -69,23 +70,46 @@ level = "debug"
 		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
 	}
 
-	rebootContainerd(t, sh, "", "")
-
-	imageName := ubuntuImage
-	copyImage(sh, dockerhub(imageName), regConfig.mirror(imageName))
-	indexDigest := optimizeImage(sh, regConfig.mirror(imageName))
-	artifactsStoreContentDigest := getSociLocalStoreContentDigest(sh)
-	sh.X("soci", "push", "--user", regConfig.creds(), regConfig.mirror(imageName).ref)
-	sh.X("rm", "-rf", "/var/lib/soci-snapshotter-grpc/content/blobs/sha256")
-
-	sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(imageName).ref)
-	artifactsStoreContentDigestAfterRPull := getSociLocalStoreContentDigest(sh)
-
-	if artifactsStoreContentDigest != artifactsStoreContentDigestAfterRPull {
-		t.Fatalf("unexpected digests before and after rpull; before = %v, after = %v", artifactsStoreContentDigest, artifactsStoreContentDigestAfterRPull)
+	tests := []struct {
+		Name     string
+		Platform string
+	}{
+		{
+			Name:     "amd64",
+			Platform: "linux/amd64",
+		},
+		{
+			Name:     "arm64",
+			Platform: "linux/arm64",
+		},
 	}
-}
 
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			rebootContainerd(t, sh, "", "")
+
+			platform, err := platforms.Parse(tt.Platform)
+			if err != nil {
+				t.Fatalf("could not parse platform %s: %v", tt.Platform, err)
+			}
+
+			imageName := ubuntuImage
+			copyImage(sh, dockerhub(imageName, withPlatform(platform)), regConfig.mirror(imageName, withPlatform(platform)))
+			indexDigest := optimizeImage(sh, regConfig.mirror(imageName, withPlatform(platform)))
+			artifactsStoreContentDigest := getSociLocalStoreContentDigest(sh)
+			sh.X("soci", "push", "--user", regConfig.creds(), "--platform", tt.Platform, regConfig.mirror(imageName).ref)
+			sh.X("rm", "-rf", "/var/lib/soci-snapshotter-grpc/content/blobs/sha256")
+
+			sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, "--platform", tt.Platform, regConfig.mirror(imageName).ref)
+			artifactsStoreContentDigestAfterRPull := getSociLocalStoreContentDigest(sh)
+
+			if artifactsStoreContentDigest != artifactsStoreContentDigestAfterRPull {
+				t.Fatalf("unexpected digests before and after rpull; before = %v, after = %v", artifactsStoreContentDigest, artifactsStoreContentDigestAfterRPull)
+			}
+		})
+	}
+
+}
 func getSociLocalStoreContentDigest(sh *shell.Shell) digest.Digest {
 	content := sh.O("ls", "/var/lib/soci-snapshotter-grpc/content/blobs/sha256")
 	return digest.FromBytes(content)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This change allows users to interact with SOCI indices from multiple platforms or in a cross platform context (e.g. creating an index for ARM64 on an x86_64 machine).

CLI Changes:
* `soci create` can now take `--platform` or `--all-platforms`. By default, it will create an index for the default platform.
* `soci push` can now take `--platform` or `--all-platforms`. By default, it will push an index for the default platform.
* `soci index list` can now take `--platform`. By default, it will list all platforms.

the --platform flag uses strict matching. E.g. specifying linux/amd64 will not create an index for linux/386.

Signed-off-by: Kern Walster <walster@amazon.com>

*Testing performed:*
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
