### PR TITLE
Deduplicate buffer creation during decompression

### DIFF
--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -383,11 +383,10 @@ func (m *SpanManager) fetchSpan(buf []byte, spanID soci.SpanID, r *io.SectionRea
 
 func (m *SpanManager) uncompressSpan(s *span, compressedBuf []byte) ([]byte, error) {
 	uncompSize := s.endUncompOffset - s.startUncompOffset
-	bytes := make([]byte, uncompSize)
 
 	// Theoretically, a span can be empty. If that happens, just return an empty buffer.
 	if uncompSize == 0 {
-		return bytes, nil
+		return []byte{}, nil
 	}
 
 	bytes, err := m.index.ExtractDataFromBuffer(compressedBuf, uncompSize, s.startUncompOffset, s.id)

--- a/soci/ztoc.go
+++ b/soci/ztoc.go
@@ -90,16 +90,15 @@ type MetadataEntry struct {
 }
 
 func ExtractFile(r *io.SectionReader, config *FileExtractConfig) ([]byte, error) {
-	bytes := make([]byte, config.UncompressedSize)
 	if config.UncompressedSize == 0 {
-		return bytes, nil
+		return []byte{}, nil
 	}
 
 	numSpans := config.SpanEnd - config.SpanStart + 1
 
 	gzipZinfo, err := NewGzipZinfo(config.Checkpoints)
 	if err != nil {
-		return bytes, nil
+		return nil, nil
 	}
 	defer gzipZinfo.Close()
 
@@ -153,10 +152,10 @@ func ExtractFile(r *io.SectionReader, config *FileExtractConfig) ([]byte, error)
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		return bytes, err
+		return nil, err
 	}
 
-	bytes, err = gzipZinfo.ExtractDataFromBuffer(buf, config.UncompressedSize, config.UncompressedOffset, config.SpanStart)
+	bytes, err := gzipZinfo.ExtractDataFromBuffer(buf, config.UncompressedSize, config.UncompressedOffset, config.SpanStart)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The byte buffer for holding uncompressed data was being allocated twice, once during SpanManager.uncompressSpan
https://github.com/awslabs/soci-snapshotter/blob/973e073ee50f5499cf9498316c77b3f9223f417c/fs/span-manager/span_manager.go#L386
 and then immediately in soci.ExtractDataFromBuffer
https://github.com/awslabs/soci-snapshotter/blob/973e073ee50f5499cf9498316c77b3f9223f417c/soci/gzip_zinfo.go#L112
therefore doubling the number of allocations and memory required.

This commit removes the buffer allocation in SpanManager.uncompressSpan.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Testing performed:*

`make`, `make check`, `make test`, `make integration` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
