### PR TITLE
Refactor SOCI index builder code into a separate module.

### DIFF
--- a/cmd/soci/commands/index/list.go
+++ b/cmd/soci/commands/index/list.go
@@ -72,7 +72,7 @@ var listCommand = cli.Command{
 			}
 
 			cs := client.ContentStore()
-			desc, err := soci.GetImageManifestDescriptor(ctx, cs, img, platforms.Default())
+			desc, err := soci.GetImageManifestDescriptor(ctx, cs, img.Target, platforms.Default())
 			if err != nil {
 				return err
 			}

--- a/soci/index_builder.go
+++ b/soci/index_builder.go
@@ -1,0 +1,198 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package soci
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	DefaultSpanSize            = int64(1 << 22)
+	MinLayerSize               = 0
+	DefaultBuildToolIdentifier = "AWS SOCI CLI v0.1"
+)
+
+type IndexBuilder struct {
+	contentStore        content.Store
+	spanSize            int64
+	minLayerSize        int64
+	buildToolIdentifier string
+}
+
+type IndexBuilderOption func(*IndexBuilder) error
+
+func NewIndexBuilder(contentStore content.Store, opts ...IndexBuilderOption) (*IndexBuilder, error) {
+	b := &IndexBuilder{
+		contentStore:        contentStore,
+		spanSize:            DefaultSpanSize,
+		minLayerSize:        MinLayerSize,
+		buildToolIdentifier: DefaultBuildToolIdentifier,
+	}
+
+	for _, opt := range opts {
+		if err := opt(b); err != nil {
+			return nil, err
+		}
+	}
+
+	return b, nil
+}
+
+func WithSpanSizeOption(spanSize int64) IndexBuilderOption {
+	return func(b *IndexBuilder) error {
+		b.spanSize = spanSize
+		return nil
+	}
+}
+
+func WithMinLayerSizeOption(minLayerSize int64) IndexBuilderOption {
+	return func(b *IndexBuilder) error {
+		b.minLayerSize = minLayerSize
+		return nil
+	}
+}
+
+func WithBuildToolIdentifierOption(buildToolIdentifier string) IndexBuilderOption {
+	return func(b *IndexBuilder) error {
+		b.buildToolIdentifier = buildToolIdentifier
+		return nil
+	}
+}
+
+// BuildIndex builds SOCI index for an image
+// This returns SOCI index manifest and an array of io.Reader of zTOCs
+func (b *IndexBuilder) BuildIndex(ctx context.Context, desc ocispec.Descriptor) (*Index, []io.Reader, error) {
+	platform := platforms.Default()
+	// we get manifest descriptor before calling images.Manifest, since after calling
+	// images.Manifest, images.Children will error out when reading the manifest blob (this happens on containerd side)
+	imgManifestDesc, err := GetImageManifestDescriptor(ctx, b.contentStore, desc, platform)
+	if err != nil {
+		return nil, nil, err
+	}
+	imageManifest, err := images.Manifest(ctx, b.contentStore, desc, platform)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sociLayersDesc := make([]*ocispec.Descriptor, len(imageManifest.Layers))
+	ztocReaders := make([]io.Reader, len(imageManifest.Layers))
+	eg, ctx := errgroup.WithContext(ctx)
+	for i, l := range imageManifest.Layers {
+		i, l := i, l
+		eg.Go(func() error {
+			ztocReader, desc, err := b.buildSociLayer(ctx, l, b.spanSize)
+			if err != nil {
+				return fmt.Errorf("could not build zTOC for %s: %w", l.Digest.String(), err)
+			}
+			sociLayersDesc[i] = desc
+			ztocReaders[i] = ztocReader
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, nil, err
+	}
+
+	ztocsDesc := make([]ocispec.Descriptor, 0, len(imageManifest.Layers))
+	for _, desc := range sociLayersDesc {
+		if desc != nil {
+			ztocsDesc = append(ztocsDesc, *desc)
+		}
+	}
+
+	annotations := map[string]string{
+		IndexAnnotationBuildToolIdentifier: b.buildToolIdentifier,
+	}
+
+	refers := &ocispec.Descriptor{
+		MediaType:   imgManifestDesc.MediaType,
+		Digest:      imgManifestDesc.Digest,
+		Size:        imgManifestDesc.Size,
+		Annotations: imgManifestDesc.Annotations,
+	}
+	return newOCIArtifactManifest(ztocsDesc, refers, annotations), ztocReaders, nil
+}
+
+// buildSociLayer builds the ztoc for an image layer and returns a Descriptor for the new ztoc.
+func (b *IndexBuilder) buildSociLayer(ctx context.Context, desc ocispec.Descriptor, spanSize int64) (io.Reader, *ocispec.Descriptor, error) {
+	if !images.IsLayerType(desc.MediaType) {
+		return nil, nil, errNotLayerType
+	}
+	// check if we need to skip building the zTOC
+	if desc.Size < b.minLayerSize {
+		fmt.Printf("layer %s -> ztoc skipped\n", desc.Digest)
+		return nil, nil, nil
+	}
+	compression, err := images.DiffCompression(ctx, desc.MediaType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not determine layer compression: %w", err)
+	}
+	if compression != "gzip" {
+		return nil, nil, fmt.Errorf("layer %s (%s) must be compressed by gzip, but got %q: %w",
+			desc.Digest, desc.MediaType, compression, errUnsupportedLayerFormat)
+	}
+
+	ra, err := b.contentStore.ReaderAt(ctx, desc)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer ra.Close()
+	sr := io.NewSectionReader(ra, 0, desc.Size)
+
+	tmpFile, err := os.CreateTemp("", "tmp.*")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer os.Remove(tmpFile.Name())
+	n, err := io.Copy(tmpFile, sr)
+	if err != nil {
+		return nil, nil, err
+	}
+	if n != desc.Size {
+		return nil, nil, errors.New("the size of the temp file doesn't match that of the layer")
+	}
+
+	ztoc, err := BuildZtoc(tmpFile.Name(), spanSize, b.buildToolIdentifier)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ztocReader, ztocDesc, err := NewZtocReader(ztoc)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fmt.Printf("layer %s -> ztoc %s\n", desc.Digest, ztocDesc.Digest)
+
+	ztocDesc.MediaType = SociLayerMediaType
+	ztocDesc.Annotations = map[string]string{
+		IndexAnnotationImageLayerMediaType: ocispec.MediaTypeImageLayerGzip,
+		IndexAnnotationImageLayerDigest:    desc.Digest.String(),
+	}
+
+	return ztocReader, &ztocDesc, err
+}

--- a/soci/testutils.go
+++ b/soci/testutils.go
@@ -229,7 +229,7 @@ func BuildZtocReader(ents []testutil.TarEntry, compressionLevel int, spanSize in
 	tarData := tarBuf.Bytes()
 	sr := io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData)))
 	cfg := &buildConfig{}
-	ztoc, err := BuildZtoc(tarFile.Name(), spanSize, cfg)
+	ztoc, err := BuildZtoc(tarFile.Name(), spanSize, cfg.buildToolIdentifier)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build sample ztoc: %v", err)
 	}

--- a/soci/ztoc_builder.go
+++ b/soci/ztoc_builder.go
@@ -32,7 +32,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func BuildZtoc(gzipFile string, span int64, cfg *buildConfig) (*Ztoc, error) {
+func BuildZtoc(gzipFile string, span int64, buildToolIdentifier string) (*Ztoc, error) {
 	if gzipFile == "" {
 		return nil, fmt.Errorf("need to provide gzip file")
 	}
@@ -78,7 +78,7 @@ func BuildZtoc(gzipFile string, span int64, cfg *buildConfig) (*Ztoc, error) {
 		TOC:                     toc,
 		CompressedArchiveSize:   fs,
 		UncompressedArchiveSize: uncompressedArchiveSize,
-		BuildToolIdentifier:     cfg.buildToolIdentifier,
+		BuildToolIdentifier:     buildToolIdentifier,
 		CompressionInfo:         compressionInfo,
 	}, nil
 }

--- a/soci/ztoc_test.go
+++ b/soci/ztoc_test.go
@@ -79,7 +79,7 @@ func TestDecompress(t *testing.T) {
 	for _, tc := range tests {
 		spansize := tc.spanSize
 		cfg := &buildConfig{}
-		ztoc, err := BuildZtoc(*tarGzip, spansize, cfg)
+		ztoc, err := BuildZtoc(*tarGzip, spansize, cfg.buildToolIdentifier)
 		if err != nil {
 			t.Fatalf("%s: can't build ztoc: %v", tc.name, err)
 		}
@@ -194,7 +194,7 @@ func TestZtocGenerationConsistency(t *testing.T) {
 			defer os.Remove(*tarGzip)
 			spansize := tc.spanSize
 			cfg := &buildConfig{}
-			ztoc1, err := BuildZtoc(*tarGzip, spansize, cfg)
+			ztoc1, err := BuildZtoc(*tarGzip, spansize, cfg.buildToolIdentifier)
 			if err != nil {
 				t.Fatalf("can't build ztoc1: %v", err)
 			}
@@ -205,7 +205,7 @@ func TestZtocGenerationConsistency(t *testing.T) {
 				t.Fatalf("ztoc1 metadata file count mismatch. expected: %d, actual: %d", len(fileNames), len(ztoc1.TOC.Metadata))
 			}
 
-			ztoc2, err := BuildZtoc(*tarGzip, spansize, cfg)
+			ztoc2, err := BuildZtoc(*tarGzip, spansize, cfg.buildToolIdentifier)
 			if err != nil {
 				t.Fatalf("can't build ztoc2: %v", err)
 			}
@@ -361,7 +361,7 @@ func TestZtocGeneration(t *testing.T) {
 			cfg := &buildConfig{
 				buildToolIdentifier: tc.buildTool,
 			}
-			ztoc, err := BuildZtoc(*tarGzip, spansize, cfg)
+			ztoc, err := BuildZtoc(*tarGzip, spansize, cfg.buildToolIdentifier)
 			if err != nil {
 				t.Fatalf("can't build ztoc: error=%v", err)
 			}
@@ -449,7 +449,7 @@ func TestZtocSerialization(t *testing.T) {
 			cfg := &buildConfig{
 				buildToolIdentifier: tc.buildTool,
 			}
-			createdZtoc, err := BuildZtoc(*tarGzip, spansize, cfg)
+			createdZtoc, err := BuildZtoc(*tarGzip, spansize, cfg.buildToolIdentifier)
 			if err != nil {
 				t.Fatalf("can't build ztoc: error=%v", err)
 			}


### PR DESCRIPTION
*Issue #, if available:* #128

*Description of changes:*
Refactor SOCI index builder code into a separate module.
Motivation: to allow reusing the index builder code in other projects (issue #128).

This PR contains minimal change to existing soci_index.go. If this PR is accepted, we'll have another follow up PR that replaces existing index builder code with the newly created module.

*Testing performed:*
- running `make && make test && make check`
- writing an example code and use the module locally to build soci index for a pulled image

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
