### PR TITLE
Use simpler piping in integration tests

### DIFF
--- a/util/dockershell/exec/cmd.go
+++ b/util/dockershell/exec/cmd.go
@@ -127,9 +127,15 @@ func (cmd *Cmd) toDocker() *exec.Cmd {
 	}
 	base := append([]string{"docker", "exec"}, append(opts, cmd.containerName)...)
 	cmd.dockerExec.Args = append(base, cmd.Args...)
-	cmd.dockerExec.Stdin = cmd.Stdin
-	cmd.dockerExec.Stdout = cmd.Stdout
-	cmd.dockerExec.Stderr = cmd.Stderr
+	if cmd.dockerExec.Stdin == nil {
+		cmd.dockerExec.Stdin = cmd.Stdin
+	}
+	if cmd.dockerExec.Stdout == nil {
+		cmd.dockerExec.Stdout = cmd.Stdout
+	}
+	if cmd.dockerExec.Stderr == nil {
+		cmd.dockerExec.Stderr = cmd.Stderr
+	}
 	return cmd.dockerExec
 }
 
@@ -155,6 +161,14 @@ func (cmd *Cmd) Run() error {
 		return err
 	}
 	return cmd.toDocker().Run()
+}
+
+func (cmd *Cmd) Start() error {
+	return cmd.toDocker().Start()
+}
+
+func (cmd *Cmd) Wait() error {
+	return cmd.toDocker().Wait()
 }
 
 // StderrPipe returns the pipe that will be connected to stderr of the executed command.


### PR DESCRIPTION

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
This change is meant to avoid an occasionally truncated pipe between processes in integration tests. The tests execute tar inside a SOCI enabled container, pipe the output to the host, and untar on the host into a temp directory to verify contents. Sometimes the untar operation gets an upexpected EOF. While the root cause of this EOF is still unkown, this change seems to fix it consistently.

Before this change, `dockershell.Shell.Pipe` allocated an `io.Pipe` to connect the stdout of one process to the stdin of another. Inside go's `exec.Cmd`, this results in creating a pair of `os.Pipe` to connect each end of `io.Pipe`'s in-memory connection to the child process. The structure for piping IO between 2 processes look like this: proc 1 std-out ===> io.copy in test proc ---> io.copy in test proc ===> proc 2 stdin where ===> is a unix pipe and ---> is an in memory pipe.

With this change, we let `exec.Cmd` create an manage pipes between the process which look like this:
proc 1 stdin ===> proc 2 stdin

We are also able to:
a) Stop manually ensuring that the pipes get close appropriately b) Stop requiring go routines since it's all IPC anyway

It's possible this is only solving the issue because the copy is faster and we are winning a race.

*Testing performed:*
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
