### PR TITLE
Set stderr on piped commands

### DIFF
--- a/util/dockershell/shell.go
+++ b/util/dockershell/shell.go
@@ -248,6 +248,7 @@ func (s *Shell) Pipe(out io.Writer, commands ...[]string) *Shell {
 				break
 			}
 		}
+		cmd.Stderr = s.r.Stderr()
 		err = cmd.Start()
 		if err != nil {
 			s.r.Errorf("failed to start %v: %v", cmd.Args, err)


### PR DESCRIPTION


Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*

*Description of changes:*
A previous commit refactored the dockershell piping logic but incorrectly stopped copying the command's stderr to the reporter. This restores that reporting.

*Testing performed:*
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
