### PR TITLE
Update oras-go to support OCI Artifacts

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/docker/go-metrics v0.0.1
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.0.3-0.20220913132419-decdb1500673
+	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/pelletier/go-toml v1.9.4
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
@@ -17,7 +17,7 @@ require (
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 	google.golang.org/grpc v1.47.0
 	k8s.io/cri-api v0.25.0
-	oras.land/oras-go/v2 v2.0.0-rc.3
+	oras.land/oras-go/v2 v2.0.0-rc.4
 )
 
 require (
@@ -66,7 +66,6 @@ require (
 	github.com/moby/sys/symlink v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 // indirect
 	github.com/opencontainers/runc v1.1.2 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.10.1 // indirect
@@ -82,7 +81,7 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
-	golang.org/x/sync v0.0.0-20220907140024-f12130a52804 // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -705,8 +705,6 @@ github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDs
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
-github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -718,8 +716,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/image-spec v1.0.2-0.20211117181255-693428a734f5/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.3-0.20220913132419-decdb1500673 h1:TRZoGOwfSmQPv+EJW1AxasEu5UJ2Z0TyTEnUmyi6f5Q=
-github.com/opencontainers/image-spec v1.0.3-0.20220913132419-decdb1500673/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
+github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
+github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -1094,8 +1092,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220907140024-f12130a52804 h1:0SH2R3f1b1VmIMG7BXbEZCBUu2dKmHschSmjqGUrW8A=
-golang.org/x/sync v0.0.0-20220907140024-f12130a52804/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1528,8 +1526,8 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b h1:wxEMGetGMur3J1xuGLQY7GEQYg9bZxKn3tKo5k/eYcs=
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-oras.land/oras-go/v2 v2.0.0-rc.3 h1:O4GeIwJ9Ge7rbCkqa/M7DLrL55ww+ZEc+Rhc63OYitU=
-oras.land/oras-go/v2 v2.0.0-rc.3/go.mod h1:PrY+cCglzK/DrQoJUtxbYVbL94ZHecVS3eJR01RglpE=
+oras.land/oras-go/v2 v2.0.0-rc.4 h1:hg/R2znUQ1+qd43gRmL16VeX1GIZ8hQlLalBjYhhKSk=
+oras.land/oras-go/v2 v2.0.0-rc.4/go.mod h1:YGHvWBGuqRlZgUyXUIoKsR3lcuCOb3DAtG0SEsEw1iY=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -92,8 +92,8 @@ if they are available in the snapshotter's local content store.
 		}
 
 		indexDesc := indexDescriptors[len(indexDescriptors)-1]
-		if indexDesc.MediaType == soci.OCIArtifactManifestMediaType {
-			return fmt.Errorf("cannot push index %v to remote since it is not an ORAS manifest", indexDesc.Digest.String()[7:15])
+		if indexDesc.MediaType == soci.ORASManifestMediaType {
+			return fmt.Errorf("cannot push index %v to remote since it is an ORAS manifest", indexDesc.Digest.String()[7:15])
 		}
 		refspec, err := reference.Parse(ref)
 		if err != nil {

--- a/fs/client_test.go
+++ b/fs/client_test.go
@@ -25,14 +25,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactsspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 )
 
 type fakeInner struct {
-	descs []artifactsspec.Descriptor
+	descs []ocispec.Descriptor
 }
 
-func newFakeInner(descs []artifactsspec.Descriptor) *fakeInner {
+func newFakeInner(descs []ocispec.Descriptor) *fakeInner {
 	return &fakeInner{
 		descs: descs,
 	}
@@ -52,26 +51,26 @@ func (f *fakeInner) Push(ctx context.Context, expected ocispec.Descriptor, conte
 	return nil
 }
 
-func (f *fakeInner) Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []artifactsspec.Descriptor) error) error {
+func (f *fakeInner) Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
 	return fn(f.descs)
 }
 
 func TestORASClientGet(t *testing.T) {
 	testCases := []struct {
 		name            string
-		descs           []artifactsspec.Descriptor
+		descs           []ocispec.Descriptor
 		expectedErr     error
 		expectedDesc    ocispec.Descriptor
 		selectionPolicy IndexSelectionPolicy
 	}{
 		{
 			name:        "empty referrers list returns ErrNoReferrers",
-			descs:       make([]artifactsspec.Descriptor, 0),
+			descs:       make([]ocispec.Descriptor, 0),
 			expectedErr: ErrNoReferrers,
 		},
 		{
 			name: "SelectFirstPolicy returns the first descriptor",
-			descs: []artifactsspec.Descriptor{
+			descs: []ocispec.Descriptor{
 				{
 					Digest: digest.FromBytes([]byte("foo")),
 					Size:   3,

--- a/go.mod
+++ b/go.mod
@@ -8,14 +8,14 @@ require (
 	github.com/docker/cli v20.10.11+incompatible
 	github.com/docker/go-metrics v0.0.1
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+	github.com/google/flatbuffers v2.0.8+incompatible
 	github.com/google/go-cmp v0.5.6
 	github.com/hanwen/go-fuse/v2 v2.1.1-0.20210825171523-3ab5d95a30ae
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.0
-	github.com/klauspost/compress v1.13.6
 	github.com/moby/sys/mountinfo v0.5.0
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.0.3-0.20220913132419-decdb1500673
+	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.1
@@ -23,14 +23,14 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	go.etcd.io/bbolt v1.3.6
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
-	golang.org/x/sync v0.0.0-20220907140024-f12130a52804
+	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
 	google.golang.org/grpc v1.43.0
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
 	k8s.io/client-go v0.23.0
 	k8s.io/cri-api v0.24.0-alpha.0
-	oras.land/oras-go/v2 v2.0.0-rc.3
+	oras.land/oras-go/v2 v2.0.0-rc.4
 )
 
 require (
@@ -48,20 +48,19 @@ require (
 	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/flatbuffers v2.0.8+incompatible // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/onsi/ginkgo v1.16.4 // indirect
 	github.com/onsi/gomega v1.17.0 // indirect
-	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -687,8 +687,6 @@ github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDs
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
-github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -700,8 +698,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/image-spec v1.0.2-0.20211117181255-693428a734f5/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.3-0.20220913132419-decdb1500673 h1:TRZoGOwfSmQPv+EJW1AxasEu5UJ2Z0TyTEnUmyi6f5Q=
-github.com/opencontainers/image-spec v1.0.3-0.20220913132419-decdb1500673/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
+github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
+github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -1065,8 +1063,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220907140024-f12130a52804 h1:0SH2R3f1b1VmIMG7BXbEZCBUu2dKmHschSmjqGUrW8A=
-golang.org/x/sync v0.0.0-20220907140024-f12130a52804/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1489,8 +1487,8 @@ k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b h1:wxEMGetGMur3J1xuGLQY7GEQYg9bZxKn3tKo5k/eYcs=
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-oras.land/oras-go/v2 v2.0.0-rc.3 h1:O4GeIwJ9Ge7rbCkqa/M7DLrL55ww+ZEc+Rhc63OYitU=
-oras.land/oras-go/v2 v2.0.0-rc.3/go.mod h1:PrY+cCglzK/DrQoJUtxbYVbL94ZHecVS3eJR01RglpE=
+oras.land/oras-go/v2 v2.0.0-rc.4 h1:hg/R2znUQ1+qd43gRmL16VeX1GIZ8hQlLalBjYhhKSk=
+oras.land/oras-go/v2 v2.0.0-rc.4/go.mod h1:YGHvWBGuqRlZgUyXUIoKsR3lcuCOb3DAtG0SEsEw1iY=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -73,7 +73,7 @@ func TestSociCreateSparseIndex(t *testing.T) {
 				t.Fatalf("cannot get index data: %v", err)
 			}
 
-			if index.MediaType != artifactsspec.MediaTypeArtifactManifest {
+			if index.MediaType != ocispec.MediaTypeArtifactManifest {
 				t.Fatalf("unexpected index media type; expected = %v, got = %v", artifactsspec.MediaTypeArtifactManifest, index.MediaType)
 			}
 
@@ -168,7 +168,7 @@ func TestSociCreate(t *testing.T) {
 				t.Fatalf("cannot get soci index: %v", err)
 			}
 
-			if sociIndex.MediaType != artifactsspec.MediaTypeArtifactManifest {
+			if sociIndex.MediaType != ocispec.MediaTypeArtifactManifest {
 				t.Fatalf("unexpected index media type; expected = %v, got = %v", artifactsspec.MediaTypeArtifactManifest, sociIndex.MediaType)
 			}
 

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -556,7 +556,7 @@ services:
     - "lazy-containerd-data:/var/lib/containerd"
     - "lazy-soci-snapshotter-grpc-data:/var/lib/soci-snapshotter-grpc"
   registry:
-    image: ghcr.io/oras-project/registry:v1.0.0-rc
+    image: ghcr.io/oci-playground/registry:v3.0.0-alpha.1
     container_name: {{.RegistryHost}}
     environment:
     - REGISTRY_AUTH=htpasswd
@@ -760,7 +760,7 @@ func buildSparseIndex(sh *shell.Shell, src imageInfo, minLayerSize int64) string
 	opts := encodeImageInfo(src)
 	indexDigest := sh.
 		X(append([]string{"ctr", "i", "pull"}, opts[0]...)...).
-		X("soci", "create", src.ref, "--min-layer-size", fmt.Sprintf("%d", minLayerSize), "--oras").
+		X("soci", "create", src.ref, "--min-layer-size", fmt.Sprintf("%d", minLayerSize)).
 		O("soci", "index", "list", "-q", "--ref", src.ref) // this will make SOCI artifact available locally
 	return strings.Trim(string(indexDigest), "\n")
 }

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -251,7 +251,7 @@ services:
     - "lazy-containerd-data:/var/lib/containerd"
     - "lazy-soci-snapshotter-grpc-data:/var/lib/soci-snapshotter-grpc"
   registry:
-    image: ghcr.io/oras-project/registry:v1.0.0-rc
+    image: ghcr.io/oci-playground/registry:v3.0.0-alpha.1
     container_name: {{.RegistryHost}}
     environment:
     - REGISTRY_AUTH=htpasswd

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -76,28 +76,10 @@ type Index struct {
 	// Blobs referenced by the manifest
 	Blobs []ocispec.Descriptor `json:"blobs,omitempty"`
 
-	// Optional reference to manifest to refer to
-	// ORAS and OCI Artifact have different names for the field
-	// During deserialization, the appropriate field is filled.
-
-	// For ORAS
 	Subject *ocispec.Descriptor `json:"subject,omitempty"`
-
-	// For OCI Artifact
-	Refers *ocispec.Descriptor `json:"refers,omitempty"`
 
 	// Optional annotations in the manifest
 	Annotations map[string]string `json:"annotations,omitempty"`
-}
-
-func (i *Index) refers() *ocispec.Descriptor {
-	switch i.MediaType {
-	case ORASManifestMediaType:
-		return i.Subject
-	case OCIArtifactManifestMediaType:
-		return i.Refers
-	}
-	return nil
 }
 
 type IndexWithMetadata struct {
@@ -240,7 +222,7 @@ func newOCIArtifactManifest(blobs []ocispec.Descriptor, subject *ocispec.Descrip
 		Blobs:        blobs,
 		ArtifactType: SociIndexArtifactType,
 		Annotations:  annotations,
-		Refers:       subject,
+		Subject:      subject,
 		MediaType:    OCIArtifactManifestMediaType,
 	}
 }
@@ -399,7 +381,7 @@ func WriteSociIndex(ctx context.Context, indexWithMetadata IndexWithMetadata, st
 
 	log.G(ctx).WithField("digest", dgst.String()).Debugf("soci index has been written")
 
-	refers := indexWithMetadata.Index.refers()
+	refers := indexWithMetadata.Index.Subject
 
 	if refers == nil {
 		return errors.New("cannot write soci index: the Refers field is nil")

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -279,18 +279,14 @@ func TestNewIndex(t *testing.T) {
 			mt := index.MediaType
 			if tc.manifestType == ManifestORAS {
 				if mt != ORASManifestMediaType {
-					t.Fatalf("unexpected media type; expected = %v, got = %v", ManifestORAS, mt)
+					t.Fatalf("unexpected media type; expected = %v, got = %v", ORASManifestMediaType, mt)
 				}
-				if diff := cmp.Diff(index.Subject, &tc.subject); diff != "" {
-					t.Fatalf("the subject field is not equal; diff = %v", diff)
-				}
-			} else {
-				if mt != OCIArtifactManifestMediaType {
-					t.Fatalf("unexpected media type; expected = %v, got = %v", ManifestORAS, mt)
-				}
-				if diff := cmp.Diff(index.Refers, &tc.subject); diff != "" {
-					t.Fatalf("the refers field is not equal; diff = %v", diff)
-				}
+			} else if mt != OCIArtifactManifestMediaType {
+				t.Fatalf("unexpected media type; expected = %v, got = %v", OCIArtifactManifestMediaType, mt)
+			}
+
+			if diff := cmp.Diff(index.Subject, &tc.subject); diff != "" {
+				t.Fatalf("the subject field is not equal; diff = %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This commit updates the oras-go library to v2.0.0-rc4, which deprecates ORAS in favor of OCI Artifact. With this change, it is now possible to push and pull OCI Artifact compatible manifests.

This is a breaking change! Following this change, users will not be able to push and pull ORAS manifests anymore, and all existing manifests will be rendered unusable. Building an ORAS manifest is still possible, though.

Also, the OCI Artifact spec has renamed the `Refers` field in the manifest to `Subject` (similar to ORAS). Therefore, removed the field from SOCI Index.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*
#149 

*Testing performed:*

Successfully pushed and pulled SOCI artifacts from an OCI Artifact compatible registry. Successfully ran multiple images using the SOCI snapshotter. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
