### PR TITLE
Remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@
 
 linters:
   enable:
-    - structcheck
-    - varcheck
     - staticcheck
     - unconvert
     - gofmt


### PR DESCRIPTION
'varcheck' and 'structcheck' are  deprecated and replaced by 'unused'. This commit removes the use of these linters.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
