### PR TITLE
Use setup-go in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
           # in order to calculate the range. i.e. HEAD~20..HEAD includes
           # 20 commits, but including HEAD it needs 21 commits.
           fetch-depth: 21
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.18.0'
       - run: wget https://github.com/google/flatbuffers/releases/download/v22.9.29/Linux.flatc.binary.g++-10.zip
       - run: unzip Linux.flatc.binary.g++-10.zip
       - run: make install-check-tools
@@ -28,10 +31,16 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.18.0'
       - run: make
       - run: make test
   integration:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.18.0'
       - run: make integration


### PR DESCRIPTION
This commit adds a 'setup-go' step in the build workflow to set the Go version to >= 1.18. This is necessary since oras-go v2.0.0-rc4 (which migrates from ORAS to OCI Artifact) requires at least Go 1.18.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
