### PR TITLE
Remove SpanStart and SpanEnd from ztoc.FileMetadata

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -52,8 +52,8 @@ var CreateCommand = cli.Command{
 		},
 		cli.Int64Flag{
 			Name:  minLayerSizeFlag,
-			Usage: "The minimum layer size in bytes to build zTOC for. Default is 0.",
-			Value: 0,
+			Usage: "The minimum layer size in bytes to build zTOC for. Default is 10 MiB.",
+			Value: 10 << 20,
 		},
 		cli.BoolFlag{
 			Name:  createORASManifestFlag,

--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -52,8 +52,8 @@ var CreateCommand = cli.Command{
 		},
 		cli.Int64Flag{
 			Name:  minLayerSizeFlag,
-			Usage: "The minimum layer size in bytes to build zTOC for. Default is 10 MiB.",
-			Value: 10 << 20,
+			Usage: "The minimum layer size in bytes to build zTOC for. Default is 0.",
+			Value: 0,
 		},
 		cli.BoolFlag{
 			Name:  createORASManifestFlag,

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -78,8 +78,6 @@ var getFileCommand = cli.Command{
 		extractConfig := soci.FileExtractConfig{
 			UncompressedSize:      fileMetadata.UncompressedSize,
 			UncompressedOffset:    fileMetadata.UncompressedOffset,
-			SpanStart:             fileMetadata.SpanStart,
-			SpanEnd:               fileMetadata.SpanEnd,
 			Checkpoints:           ztoc.CompressionInfo.Checkpoints,
 			CompressedArchiveSize: ztoc.CompressedArchiveSize,
 			MaxSpanID:             ztoc.CompressionInfo.MaxSpanID,

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -56,7 +56,7 @@ var infoCommand = cli.Command{
 		fmt.Printf("build tool: %s\n\n\n", ztoc.BuildToolIdentifier)
 
 		for _, v := range ztoc.TOC.Metadata {
-			fmt.Printf("filename: %s, offset: %d, size: %d, span_start: %d, span_end: %d\n", v.Name, v.UncompressedOffset, v.UncompressedSize, v.SpanStart, v.SpanEnd)
+			fmt.Printf("filename: %s, offset: %d, size: %d\n", v.Name, v.UncompressedOffset, v.UncompressedSize)
 		}
 		return nil
 	},

--- a/metadata/db/db.go
+++ b/metadata/db/db.go
@@ -70,8 +70,6 @@ import (
 //         - childrenExtra                  : 2nd and following child nodes of directory.
 //           - *basename* : <node id>       : map of basename string to the child node id
 //         - uncompressedOffset : <varint>  : the offset in the uncompressed data, where the node is stored.
-//         - spanStart : <varint>           : the first span for the data.
-//         - spanEnd : <varint>             : the last span for the data.
 
 var (
 	bucketKeyFilesystems = []byte("filesystems")
@@ -96,8 +94,6 @@ var (
 	bucketKeyChildrenExtra = []byte("childrenExtra")
 
 	bucketKeyUncompressedOffset = []byte("uncompressedOffset")
-	bucketKeySpanStart          = []byte("spanStart")
-	bucketKeySpanEnd            = []byte("spanEnd")
 )
 
 type childEntry struct {
@@ -108,8 +104,7 @@ type childEntry struct {
 type metadataEntry struct {
 	children           map[string]childEntry
 	UncompressedOffset soci.FileSize
-	SpanStart          soci.SpanID
-	SpanEnd            soci.SpanID
+	UncompressedSize   soci.FileSize
 }
 
 func getNodes(tx *bolt.Tx, fsID string) (*bolt.Bucket, error) {
@@ -357,20 +352,11 @@ func writeMetadataEntry(md *bolt.Bucket, m *metadataEntry) error {
 	if err := putFileSize(md, bucketKeyUncompressedOffset, m.UncompressedOffset); err != nil {
 		return errors.Wrapf(err, "failed to set UncompressedOffset value %d", m.UncompressedOffset)
 	}
-	if err := putSpanID(md, bucketKeySpanStart, m.SpanStart); err != nil {
-		return errors.Wrapf(err, "failed to set SpanStart value %d", m.SpanStart)
-	}
-	if err := putSpanID(md, bucketKeySpanEnd, m.SpanEnd); err != nil {
-		return errors.Wrapf(err, "failed to set SpanEnd value %d", m.SpanEnd)
-	}
+
 	return nil
 }
 
 func putFileSize(b *bolt.Bucket, k []byte, v soci.FileSize) error {
-	return putInt(b, k, int64(v))
-}
-
-func putSpanID(b *bolt.Bucket, k []byte, v soci.SpanID) error {
 	return putInt(b, k, int64(v))
 }
 

--- a/metadata/db/reader.go
+++ b/metadata/db/reader.go
@@ -255,8 +255,6 @@ func (r *reader) initNodes(ztoc *soci.Ztoc) error {
 					md[id] = &metadataEntry{}
 				}
 				md[id].UncompressedOffset = ent.UncompressedOffset
-				md[id].SpanStart = ent.SpanStart
-				md[id].SpanEnd = ent.SpanEnd
 			}
 		}
 		return nil

--- a/soci/fbs/ztoc.fbs
+++ b/soci/fbs/ztoc.fbs
@@ -10,8 +10,6 @@ table FileMetadata {
 	type : string;
 	uncompressed_offset : long;
 	uncompressed_size : long;
-	span_start : int;
-	span_end : int;
 	linkname : string;		// Target name of link (valid for TypeLink or TypeSymlink)
 	mode : long;			// Permission and mode bits
 	uid : uint32;			// User ID of owner

--- a/soci/fbs/ztoc/FileMetadata.go
+++ b/soci/fbs/ztoc/FileMetadata.go
@@ -73,32 +73,8 @@ func (rcv *FileMetadata) MutateUncompressedSize(n int64) bool {
 	return rcv._tab.MutateInt64Slot(10, n)
 }
 
-func (rcv *FileMetadata) SpanStart() int32 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
-	if o != 0 {
-		return rcv._tab.GetInt32(o + rcv._tab.Pos)
-	}
-	return 0
-}
-
-func (rcv *FileMetadata) MutateSpanStart(n int32) bool {
-	return rcv._tab.MutateInt32Slot(12, n)
-}
-
-func (rcv *FileMetadata) SpanEnd() int32 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
-	if o != 0 {
-		return rcv._tab.GetInt32(o + rcv._tab.Pos)
-	}
-	return 0
-}
-
-func (rcv *FileMetadata) MutateSpanEnd(n int32) bool {
-	return rcv._tab.MutateInt32Slot(14, n)
-}
-
 func (rcv *FileMetadata) Linkname() []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
 	}
@@ -106,7 +82,7 @@ func (rcv *FileMetadata) Linkname() []byte {
 }
 
 func (rcv *FileMetadata) Mode() int64 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
 	if o != 0 {
 		return rcv._tab.GetInt64(o + rcv._tab.Pos)
 	}
@@ -114,11 +90,11 @@ func (rcv *FileMetadata) Mode() int64 {
 }
 
 func (rcv *FileMetadata) MutateMode(n int64) bool {
-	return rcv._tab.MutateInt64Slot(18, n)
+	return rcv._tab.MutateInt64Slot(14, n)
 }
 
 func (rcv *FileMetadata) Uid() uint32 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(16))
 	if o != 0 {
 		return rcv._tab.GetUint32(o + rcv._tab.Pos)
 	}
@@ -126,11 +102,11 @@ func (rcv *FileMetadata) Uid() uint32 {
 }
 
 func (rcv *FileMetadata) MutateUid(n uint32) bool {
-	return rcv._tab.MutateUint32Slot(20, n)
+	return rcv._tab.MutateUint32Slot(16, n)
 }
 
 func (rcv *FileMetadata) Gid() uint32 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(18))
 	if o != 0 {
 		return rcv._tab.GetUint32(o + rcv._tab.Pos)
 	}
@@ -138,11 +114,11 @@ func (rcv *FileMetadata) Gid() uint32 {
 }
 
 func (rcv *FileMetadata) MutateGid(n uint32) bool {
-	return rcv._tab.MutateUint32Slot(22, n)
+	return rcv._tab.MutateUint32Slot(18, n)
 }
 
 func (rcv *FileMetadata) Uname() []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(20))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
 	}
@@ -150,7 +126,7 @@ func (rcv *FileMetadata) Uname() []byte {
 }
 
 func (rcv *FileMetadata) Gname() []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(26))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
 	}
@@ -158,7 +134,7 @@ func (rcv *FileMetadata) Gname() []byte {
 }
 
 func (rcv *FileMetadata) ModTime() []byte {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
 	}
@@ -166,7 +142,7 @@ func (rcv *FileMetadata) ModTime() []byte {
 }
 
 func (rcv *FileMetadata) Devmajor() int64 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(30))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(26))
 	if o != 0 {
 		return rcv._tab.GetInt64(o + rcv._tab.Pos)
 	}
@@ -174,11 +150,11 @@ func (rcv *FileMetadata) Devmajor() int64 {
 }
 
 func (rcv *FileMetadata) MutateDevmajor(n int64) bool {
-	return rcv._tab.MutateInt64Slot(30, n)
+	return rcv._tab.MutateInt64Slot(26, n)
 }
 
 func (rcv *FileMetadata) Devminor() int64 {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(32))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(28))
 	if o != 0 {
 		return rcv._tab.GetInt64(o + rcv._tab.Pos)
 	}
@@ -186,11 +162,11 @@ func (rcv *FileMetadata) Devminor() int64 {
 }
 
 func (rcv *FileMetadata) MutateDevminor(n int64) bool {
-	return rcv._tab.MutateInt64Slot(32, n)
+	return rcv._tab.MutateInt64Slot(28, n)
 }
 
 func (rcv *FileMetadata) Xattrs(obj *Xattr, j int) bool {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(34))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(30))
 	if o != 0 {
 		x := rcv._tab.Vector(o)
 		x += flatbuffers.UOffsetT(j) * 4
@@ -202,7 +178,7 @@ func (rcv *FileMetadata) Xattrs(obj *Xattr, j int) bool {
 }
 
 func (rcv *FileMetadata) XattrsLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(34))
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(30))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
 	}
@@ -210,7 +186,7 @@ func (rcv *FileMetadata) XattrsLength() int {
 }
 
 func FileMetadataStart(builder *flatbuffers.Builder) {
-	builder.StartObject(16)
+	builder.StartObject(14)
 }
 func FileMetadataAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(name), 0)
@@ -224,41 +200,35 @@ func FileMetadataAddUncompressedOffset(builder *flatbuffers.Builder, uncompresse
 func FileMetadataAddUncompressedSize(builder *flatbuffers.Builder, uncompressedSize int64) {
 	builder.PrependInt64Slot(3, uncompressedSize, 0)
 }
-func FileMetadataAddSpanStart(builder *flatbuffers.Builder, spanStart int32) {
-	builder.PrependInt32Slot(4, spanStart, 0)
-}
-func FileMetadataAddSpanEnd(builder *flatbuffers.Builder, spanEnd int32) {
-	builder.PrependInt32Slot(5, spanEnd, 0)
-}
 func FileMetadataAddLinkname(builder *flatbuffers.Builder, linkname flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(6, flatbuffers.UOffsetT(linkname), 0)
+	builder.PrependUOffsetTSlot(4, flatbuffers.UOffsetT(linkname), 0)
 }
 func FileMetadataAddMode(builder *flatbuffers.Builder, mode int64) {
-	builder.PrependInt64Slot(7, mode, 0)
+	builder.PrependInt64Slot(5, mode, 0)
 }
 func FileMetadataAddUid(builder *flatbuffers.Builder, uid uint32) {
-	builder.PrependUint32Slot(8, uid, 0)
+	builder.PrependUint32Slot(6, uid, 0)
 }
 func FileMetadataAddGid(builder *flatbuffers.Builder, gid uint32) {
-	builder.PrependUint32Slot(9, gid, 0)
+	builder.PrependUint32Slot(7, gid, 0)
 }
 func FileMetadataAddUname(builder *flatbuffers.Builder, uname flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(10, flatbuffers.UOffsetT(uname), 0)
+	builder.PrependUOffsetTSlot(8, flatbuffers.UOffsetT(uname), 0)
 }
 func FileMetadataAddGname(builder *flatbuffers.Builder, gname flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(11, flatbuffers.UOffsetT(gname), 0)
+	builder.PrependUOffsetTSlot(9, flatbuffers.UOffsetT(gname), 0)
 }
 func FileMetadataAddModTime(builder *flatbuffers.Builder, modTime flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(12, flatbuffers.UOffsetT(modTime), 0)
+	builder.PrependUOffsetTSlot(10, flatbuffers.UOffsetT(modTime), 0)
 }
 func FileMetadataAddDevmajor(builder *flatbuffers.Builder, devmajor int64) {
-	builder.PrependInt64Slot(13, devmajor, 0)
+	builder.PrependInt64Slot(11, devmajor, 0)
 }
 func FileMetadataAddDevminor(builder *flatbuffers.Builder, devminor int64) {
-	builder.PrependInt64Slot(14, devminor, 0)
+	builder.PrependInt64Slot(12, devminor, 0)
 }
 func FileMetadataAddXattrs(builder *flatbuffers.Builder, xattrs flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(15, flatbuffers.UOffsetT(xattrs), 0)
+	builder.PrependUOffsetTSlot(13, flatbuffers.UOffsetT(xattrs), 0)
 }
 func FileMetadataStartXattrsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)

--- a/soci/ztoc_builder.go
+++ b/soci/ztoc_builder.go
@@ -161,8 +161,6 @@ func prepareMetadataOffset(builder *flatbuffers.Builder, me FileMetadata) flatbu
 	ztoc_flatbuffers.FileMetadataAddType(builder, t)
 	ztoc_flatbuffers.FileMetadataAddUncompressedOffset(builder, int64(me.UncompressedOffset))
 	ztoc_flatbuffers.FileMetadataAddUncompressedSize(builder, int64(me.UncompressedSize))
-	ztoc_flatbuffers.FileMetadataAddSpanStart(builder, int32(me.SpanStart))
-	ztoc_flatbuffers.FileMetadataAddSpanEnd(builder, int32(me.SpanEnd))
 	ztoc_flatbuffers.FileMetadataAddLinkname(builder, linkName)
 	ztoc_flatbuffers.FileMetadataAddMode(builder, me.Mode)
 	ztoc_flatbuffers.FileMetadataAddUid(builder, uint32(me.UID))
@@ -273,11 +271,6 @@ func getGzipFileMetadata(gzipFile string, index *GzipZinfo) ([]FileMetadata, Fil
 			}
 		}
 
-		start := pt.CurrentPos()
-		end := pt.CurrentPos() + FileSize(hdr.Size)
-		indexStart := index.UncompressedOffsetToSpanID(start)
-		indexEnd := index.UncompressedOffsetToSpanID(end)
-
 		fileType, err := getType(hdr)
 		if err != nil {
 			return nil, 0, err
@@ -288,8 +281,6 @@ func getGzipFileMetadata(gzipFile string, index *GzipZinfo) ([]FileMetadata, Fil
 			Type:               fileType,
 			UncompressedOffset: pt.CurrentPos(),
 			UncompressedSize:   FileSize(hdr.Size),
-			SpanStart:          indexStart,
-			SpanEnd:            indexEnd,
 			Linkname:           hdr.Linkname,
 			Mode:               hdr.Mode,
 			UID:                hdr.Uid,

--- a/soci/ztoc_getter.go
+++ b/soci/ztoc_getter.go
@@ -70,8 +70,6 @@ func flatbufToZtoc(flatbuffer []byte) *Ztoc {
 		me.Type = string(metadataEntry.Type())
 		me.UncompressedOffset = FileSize(metadataEntry.UncompressedOffset())
 		me.UncompressedSize = FileSize(metadataEntry.UncompressedSize())
-		me.SpanStart = SpanID(metadataEntry.SpanStart())
-		me.SpanEnd = SpanID(metadataEntry.SpanEnd())
 		me.Linkname = string(metadataEntry.Linkname())
 		me.Mode = metadataEntry.Mode()
 		me.UID = int(metadataEntry.Uid())

--- a/soci/ztoc_test.go
+++ b/soci/ztoc_test.go
@@ -107,8 +107,6 @@ func TestDecompress(t *testing.T) {
 				extractConfig := &FileExtractConfig{
 					UncompressedSize:      m.UncompressedSize,
 					UncompressedOffset:    m.UncompressedOffset,
-					SpanStart:             m.SpanStart,
-					SpanEnd:               m.SpanEnd,
 					Checkpoints:           ztoc.CompressionInfo.Checkpoints,
 					CompressedArchiveSize: ztoc.CompressedArchiveSize,
 					MaxSpanID:             ztoc.CompressionInfo.MaxSpanID,
@@ -502,12 +500,6 @@ func TestZtocSerialization(t *testing.T) {
 					if readZtocMetadata.UncompressedSize != createdZtocMetadata.UncompressedSize {
 						t.Fatalf("createdZtoc.Metadata[%d].UncompressedSize should be equal to readZtoc.Metadata[%d].UncompressedSize", i, i)
 					}
-					if readZtocMetadata.SpanStart != createdZtocMetadata.SpanStart {
-						t.Fatalf("createdZtoc.Metadata[%d].SpanStart should be equal to readZtoc.Metadata[%d].SpanStart", i, i)
-					}
-					if readZtocMetadata.SpanEnd != createdZtocMetadata.SpanEnd {
-						t.Fatalf("createdZtoc.Metadata[%d].SpanEnd should be equal to readZtoc.Metadata[%d].SpanEnd", i, i)
-					}
 					if readZtocMetadata.Linkname != createdZtocMetadata.Linkname {
 						t.Fatalf("createdZtoc.Metadata[%d].Linkname should be equal to readZtoc.Metadata[%d].Linkname", i, i)
 					}
@@ -576,8 +568,8 @@ func TestWriteZtoc(t *testing.T) {
 			uncompressedArchiveSize: 2500000,
 			maxSpanID:               3,
 			buildTool:               "AWS SOCI CLI",
-			expDigest:               "sha256:ee2fd7cf479ccbbe769fa67120a04b420133a7425ea0fa03791ed9ffe9b8340b",
-			expSize:                 65936,
+			expDigest:               "sha256:9c8effca78ecc82fad49a4d591dd81615555b05eaaae605a621c927ecf6fc1e7",
+			expSize:                 65928,
 		},
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
#148 

*Description of changes:*
`SpanStart` and `SpanEnd` are no longer part of `ztoc.FileMetadata`. `UncompressedOffset` and `UncompressedSize` are used instead. This allows to separate TOC from knowing details about compression.

*Testing performed:*
- `make check && make test && make integration` pass
- Deployed `soci` and `soci-snapshotter-grpc` to an EC2 instance and ran the container workload for rethinkdb using lazy loading and got the following output:

```
$ sudo soci-snapshotter/out/soci run --snapshotter=soci --net-host $IMAGE container-id 2>&1
1:C 07 Nov 2022 17:23:27.290 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 07 Nov 2022 17:23:27.290 # Redis version=7.0.5, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 07 Nov 2022 17:23:27.290 # Warning: no config file specified, using the default config. In order to specify a config file use redis-server /path/to/redis.conf
1:M 07 Nov 2022 17:23:27.291 # You requested maxclients of 10000 requiring at least 10032 max file descriptors.
1:M 07 Nov 2022 17:23:27.291 # Server can't set maximum open files to 10032 because of OS error: Operation not permitted.
1:M 07 Nov 2022 17:23:27.291 # Current maximum open files is 1024. maxclients has been reduced to 992 to compensate for low ulimit. If you need higher maxclients increase 'ulimit -n'.
1:M 07 Nov 2022 17:23:27.291 * monotonic clock: POSIX clock_gettime
1:M 07 Nov 2022 17:23:27.291 * Running mode=standalone, port=6379.
1:M 07 Nov 2022 17:23:27.291 # Server initialized
1:M 07 Nov 2022 17:23:27.291 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
1:M 07 Nov 2022 17:23:27.291 # WARNING Your system is configured to use the 'xen' clocksource which might lead to degraded performance. Check the result of the [slow-clocksource] system check: run 'redis-server --check-system' to check if the system's clocksource isn't degrading performance.
1:M 07 Nov 2022 17:23:27.292 * Ready to accept connections
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
