### PR TITLE
Move state to tmpfs in integration tests

### DIFF
--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -551,10 +551,10 @@ services:
     - NO_PROXY=127.0.0.1,localhost,{{.RegistryHost}}:443
     tmpfs:
     - /tmp:exec,mode=777
+    - /var/lib/containerd
+    - /var/lib/soci-snapshotter-grpc
     volumes:
     - /dev/fuse:/dev/fuse
-    - "lazy-containerd-data:/var/lib/containerd"
-    - "lazy-soci-snapshotter-grpc-data:/var/lib/soci-snapshotter-grpc"
   registry:
     image: ghcr.io/oras-project/registry:v1.0.0-rc
     container_name: {{.RegistryHost}}
@@ -570,9 +570,6 @@ services:
   registry-alt:
     image: registry:2
     container_name: {{.RegistryAltHost}}
-volumes:
-  lazy-containerd-data:
-  lazy-soci-snapshotter-grpc-data:
 `, struct {
 		TargetStage     string
 		ServiceName     string

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -246,10 +246,10 @@ services:
     - NO_PROXY=127.0.0.1,localhost,{{.RegistryHost}}:443
     tmpfs:
     - /tmp:exec,mode=777
+    - /var/lib/containerd
+    - /var/lib/soci-snapshotter-grpc
     volumes:
     - /dev/fuse:/dev/fuse
-    - "lazy-containerd-data:/var/lib/containerd"
-    - "lazy-soci-snapshotter-grpc-data:/var/lib/soci-snapshotter-grpc"
   registry:
     image: ghcr.io/oras-project/registry:v1.0.0-rc
     container_name: {{.RegistryHost}}
@@ -262,9 +262,6 @@ services:
     - REGISTRY_HTTP_ADDR={{.RegistryHost}}:443
     volumes:
     - {{.AuthDir}}:/auth:ro
-volumes:
-  lazy-containerd-data:
-  lazy-soci-snapshotter-grpc-data:
 {{.NetworkConfig}}
 `, struct {
 		ServiceName     string
@@ -332,13 +329,10 @@ services:
     - NO_PROXY=127.0.0.1,localhost
     tmpfs:
     - /tmp:exec,mode=777
+    - /var/lib/containerd
+    - /var/lib/soci-snapshotter-grpc
     volumes:
     - /dev/fuse:/dev/fuse
-    - "containerd-data:/var/lib/containerd"
-    - "soci-snapshotter-grpc-data:/var/lib/soci-snapshotter-grpc"
-volumes:
-  containerd-data:
-  soci-snapshotter-grpc-data:
 `, struct {
 		ServiceName     string
 		ImageContextDir string


### PR DESCRIPTION

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*

*Description of changes:*
Each integration test run in a separate docker container, however the contaienrd and soci-snapshotter state directories are shared across all the tests because they are mounted as volumes.

This change mounts them as tmpfs instead. We still need some sort of mount because otherwise the state folders will fall under the root overlayfs mount and the snapshotter will fail because it cannot create overlayfs mounts on top of overlayfs.


*Testing performed:*
`make check && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
