### PR TITLE
Temporarily turn off the background fetch until it gets re-worked

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -175,6 +175,11 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snapshot.F
 	if ns != nil {
 		metrics.Register(ns) // Register layer metrics.
 	}
+
+	// We are turning off the background fetch until it gets re-worked.
+	// See https://github.com/awslabs/soci-snapshotter/issues/106 for more details.
+	cfg.NoBackgroundFetch = true
+
 	return &filesystem{
 		resolver:              r,
 		getSources:            getSources,


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
Temporarily turning off the background fetch until it gets re-worked. For more details see the issue https://github.com/awslabs/soci-snapshotter/issues/106

*Testing performed:*
- `make test && make check && make integration` pass
- Deployed `soci-snapshotter-grpc` and `soci` to an EC2 instance, created an index for rethinkdb and ran the container workload in lazy loading mode. Observed no log record referring to background fetcher.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
