### PR TITLE
Set default value for min-layer-size to 10MiB

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -53,8 +53,8 @@ var CreateCommand = cli.Command{
 		},
 		cli.Int64Flag{
 			Name:  minLayerSizeFlag,
-			Usage: "The minimum layer size in bytes to build zTOC for. Default is 0.",
-			Value: 0,
+			Usage: "The minimum layer size in bytes to build zTOC for. Default is 10 MiB.",
+			Value: 10 << 20,
 		},
 		cli.BoolFlag{
 			Name:  createORASManifestFlag,


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*

*Description of changes:*
Looks like the commit https://github.com/awslabs/soci-snapshotter/pull/165/commits/31531b30a0236ac9e071da0bf3c8c5fd432b7ef7 got overridden by https://github.com/awslabs/soci-snapshotter/pull/165/commits/e3c1471ea940924dba2fb108dd9fa643f3df6186, so the value for `min-layer-size` was still 0. Fixing that in this PR by setting the default value for `min-layer-size` to 10MiB.
10MiB appears to be a sweet spot to get the most out of soci-snapshotter for most of the container workloads.
After we conclude on the performance optimizations, we will need to revisit this (https://github.com/awslabs/soci-snapshotter/issues/174).

*Testing performed:*
- `make test && make check && make integration` pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
