### PR TITLE
Remove ORAS from the snapshotter

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -31,9 +31,8 @@ import (
 const (
 	buildToolIdentifier = "AWS SOCI CLI v0.1"
 
-	spanSizeFlag           = "span-size"
-	minLayerSizeFlag       = "min-layer-size"
-	createORASManifestFlag = "oras"
+	spanSizeFlag     = "span-size"
+	minLayerSizeFlag = "min-layer-size"
 )
 
 // CreateCommand creates SOCI index for an image
@@ -55,10 +54,6 @@ var CreateCommand = cli.Command{
 			Name:  minLayerSizeFlag,
 			Usage: "The minimum layer size in bytes to build zTOC for. Default is 0.",
 			Value: 0,
-		},
-		cli.BoolFlag{
-			Name:  createORASManifestFlag,
-			Usage: "If set, will create an ORAS manifest instead of an OCI Artifact manifest. Default is false.",
 		},
 	),
 	Action: func(cliContext *cli.Context) error {
@@ -101,16 +96,10 @@ var CreateCommand = cli.Command{
 			return err
 		}
 
-		manifestType := soci.ManifestOCIArtifact
-		if cliContext.Bool(createORASManifestFlag) {
-			manifestType = soci.ManifestORAS
-		}
-
 		for _, plat := range ps {
 			sociIndexWithMetadata, err := soci.BuildSociIndex(ctx, cs, srcImg, spanSize, blobStore,
 				soci.WithMinLayerSize(minLayerSize),
 				soci.WithBuildToolIdentifier(buildToolIdentifier),
-				soci.WithManifestType(manifestType),
 				soci.WithPlatform(plat))
 
 			if err != nil {

--- a/cmd/soci/commands/index/list.go
+++ b/cmd/soci/commands/index/list.go
@@ -149,7 +149,7 @@ var listCommand = cli.Command{
 		}
 
 		writer := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
-		writer.Write([]byte("DIGEST\tSIZE\tIMAGE REF\tPLATFORM\tORAS ARTIFACT\n"))
+		writer.Write([]byte("DIGEST\tSIZE\tIMAGE REF\tPLATFORM\n"))
 
 		for _, ae := range artifacts {
 			imgs, _ := is.List(ctx, fmt.Sprintf("target.digest==%s", ae.ImageDigest))
@@ -168,11 +168,10 @@ var listCommand = cli.Command{
 
 func writeArtifactEntry(w io.Writer, ae *soci.ArtifactEntry, imageRef string) {
 	w.Write([]byte(fmt.Sprintf(
-		"%s\t%d\t%s\t%s\t%v\t\n",
+		"%s\t%d\t%s\t%s\t\n",
 		ae.Digest,
 		ae.Size,
 		imageRef,
 		ae.Platform,
-		ae.MediaType == soci.ORASManifestMediaType,
 	)))
 }

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -104,9 +104,7 @@ if they are available in the snapshotter's local content store.
 			}
 
 			indexDesc := indexDescriptors[len(indexDescriptors)-1]
-			if indexDesc.MediaType == soci.ORASManifestMediaType {
-				return fmt.Errorf("cannot push index %v to remote since it is an ORAS manifest", indexDesc.Digest.String()[7:15])
-			}
+
 			refspec, err := reference.Parse(ref)
 			if err != nil {
 				return err

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -45,7 +45,7 @@ project.  We will run it on port 5000 as an HTTP (**NOT** HTTPS) server without
 certificates.  To do this we will use Docker:
 
 ```
-docker run -d -p 5000:5000 --restart=always --name registry ghcr.io/oras-project/registry:v1.0.0-rc
+docker run -d -p 5000:5000 --restart=always --name registry ghcr.io/oci-playground/registry:v3.0.0-alpha.1
 ```
 
 Since this is just a locally run HTTP server we can interact with
@@ -134,13 +134,8 @@ does not have access to.
 
 To create the index, which can be pushed to ORAS-compatible registry, run:
 ```
-sudo ./soci create --oras localhost:5000/rabbitmq:latest
+sudo ./soci create localhost:5000/rabbitmq:latest
 ```
-The `--oras` flag instructs the CLI to build an ORAS-compatible manifest, 
-as opposed to an OCI Artifact Manifest. By default, the CLI will build the latter.
-Since the community is in the process of migrating from ORAS to OCI Artifact Manifest, 
-there's no available registry supporting latter. We suggest using ORAS registry along
-with `--oras` flag to be able to push SOCI index to the registry.
 Behind the scenes SOCI is interacting with containerd. So the tag `localhost:5000/rabbitmq` 
 has to exist in containerd. This created two kinds of objects.  
 The first is a series of ztocs (one per layer).  A ztoc is a table of contents for compressed data 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -12,8 +12,7 @@ The SOCI project introduces several new terms that sometimes have subtle differe
   layers.
 
 * __SOCI index manifest__: An
-  [ORAS manifest](https://github.com/oras-project/artifacts-spec/blob/v1.0.0-rc.2/artifact-manifest.md)
-  (soon to be an [OCI Reference Types manifest](https://github.com/opencontainers/wg-reference-types/blob/256c257cc8b725fd324722ee40ead6925b1c8ad8/docs/proposals/PROPOSAL_E.md))
+  [OCI Artifact manifest](https://github.com/opencontainers/image-spec/blob/main/artifact.md)
   containing the list of zTOCs in the SOCI Index as well as a reference to the image for
   which the manifest was generated.
 

--- a/fs/client.go
+++ b/fs/client.go
@@ -54,17 +54,17 @@ type Inner interface {
 	ReferrersCaller
 }
 
-type OrasClient struct {
+type OCIArtifactClient struct {
 	Inner
 }
 
-func NewORASClient(inner Inner) *OrasClient {
-	return &OrasClient{
+func NewOCIArtifactClient(inner Inner) *OCIArtifactClient {
+	return &OCIArtifactClient{
 		Inner: inner,
 	}
 }
 
-func (c *OrasClient) SelectReferrer(ctx context.Context, desc ocispec.Descriptor, fn IndexSelectionPolicy) (ocispec.Descriptor, error) {
+func (c *OCIArtifactClient) SelectReferrer(ctx context.Context, desc ocispec.Descriptor, fn IndexSelectionPolicy) (ocispec.Descriptor, error) {
 	descs, err := c.allReferrers(ctx, desc)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("unable to fetch referrers: %w", err)
@@ -75,7 +75,7 @@ func (c *OrasClient) SelectReferrer(ctx context.Context, desc ocispec.Descriptor
 	return fn(descs)
 }
 
-func (c *OrasClient) allReferrers(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+func (c *OCIArtifactClient) allReferrers(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 	descs := []ocispec.Descriptor{}
 	err := c.Referrers(ctx, desc, soci.SociIndexArtifactType, func(referrers []ocispec.Descriptor) error {
 		descs = append(descs, referrers...)

--- a/fs/client_test.go
+++ b/fs/client_test.go
@@ -55,7 +55,7 @@ func (f *fakeInner) Referrers(ctx context.Context, desc ocispec.Descriptor, arti
 	return fn(f.descs)
 }
 
-func TestORASClientGet(t *testing.T) {
+func TestOCIArtifactClientSelectReferrer(t *testing.T) {
 	testCases := []struct {
 		name            string
 		descs           []ocispec.Descriptor
@@ -91,7 +91,7 @@ func TestORASClientGet(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			inner := newFakeInner(tc.descs)
-			client := NewORASClient(inner)
+			client := NewOCIArtifactClient(inner)
 
 			desc, err := client.SelectReferrer(context.Background(), ocispec.Descriptor{}, tc.selectionPolicy)
 			if err != nil && !errors.Is(err, tc.expectedErr) {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -213,7 +213,7 @@ func (c *sociContext) Init(ctx context.Context, imageRef, indexDigest, imageMani
 			return
 		}
 
-		client := NewORASClient(remoteStore)
+		client := NewOCIArtifactClient(remoteStore)
 		indexDesc := ocispec.Descriptor{
 			Digest: digest.Digest(indexDigest),
 		}

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -241,7 +241,7 @@ func (db *ArtifactsDb) RemoveArtifactEntryByImageDigest(digest string) error {
 // Determines whether a bucket represents an index, as opposed to a zTOC
 func indexBucket(b *bolt.Bucket) bool {
 	mt := string(b.Get(bucketKeyMediaType))
-	return mt == OCIArtifactManifestMediaType || mt == ORASManifestMediaType
+	return mt == OCIArtifactManifestMediaType
 }
 
 // Determines whether a bucket's image digest is the same as digest

--- a/soci/index_builder.go
+++ b/soci/index_builder.go
@@ -134,7 +134,7 @@ func (b *IndexBuilder) BuildIndex(ctx context.Context, desc ocispec.Descriptor) 
 		Size:        imgManifestDesc.Size,
 		Annotations: imgManifestDesc.Annotations,
 	}
-	return newOCIArtifactManifest(ztocsDesc, refers, annotations), ztocReaders, nil
+	return NewIndex(ztocsDesc, refers, annotations), ztocReaders, nil
 }
 
 // buildSociLayer builds the ztoc for an image layer and returns a Descriptor for the new ztoc.

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -50,15 +50,6 @@ const (
 	IndexAnnotationBuildToolIdentifier = "com.amazon.soci.build-tool-identifier"
 	// media type for OCI Artifact manifest
 	OCIArtifactManifestMediaType = "application/vnd.oci.artifact.manifest.v1+json"
-	// media type for ORAS manifest
-	ORASManifestMediaType = "application/vnd.cncf.oras.artifact.manifest.v1+json"
-)
-
-type ManifestType int
-
-const (
-	ManifestOCIArtifact ManifestType = iota
-	ManifestORAS
 )
 
 var (
@@ -129,7 +120,6 @@ func GetIndexDescriptorCollection(ctx context.Context, cs content.Store, img ima
 type buildConfig struct {
 	minLayerSize        int64
 	buildToolIdentifier string
-	manifestType        ManifestType
 	platform            ocispec.Platform
 }
 
@@ -145,13 +135,6 @@ func WithMinLayerSize(minLayerSize int64) BuildOption {
 func WithBuildToolIdentifier(tool string) BuildOption {
 	return func(c *buildConfig) error {
 		c.buildToolIdentifier = tool
-		return nil
-	}
-}
-
-func WithManifestType(val ManifestType) BuildOption {
-	return func(c *buildConfig) error {
-		c.manifestType = val
 		return nil
 	}
 }
@@ -217,7 +200,7 @@ func BuildSociIndex(ctx context.Context, cs content.Store, img images.Image, spa
 		Annotations: imgManifestDesc.Annotations,
 		Platform:    &config.platform,
 	}
-	index := NewIndex(ztocsDesc, refers, annotations, config.manifestType)
+	index := NewIndex(ztocsDesc, refers, annotations)
 	return &IndexWithMetadata{
 		Index:       index,
 		ImageDigest: img.Target.Digest,
@@ -225,30 +208,13 @@ func BuildSociIndex(ctx context.Context, cs content.Store, img images.Image, spa
 }
 
 // Returns a new index.
-func NewIndex(blobs []ocispec.Descriptor, subject *ocispec.Descriptor, annotations map[string]string, manifestType ManifestType) *Index {
-	if manifestType == ManifestOCIArtifact {
-		return newOCIArtifactManifest(blobs, subject, annotations)
-	}
-	return newORASManifest(blobs, subject, annotations)
-}
-
-func newOCIArtifactManifest(blobs []ocispec.Descriptor, subject *ocispec.Descriptor, annotations map[string]string) *Index {
+func NewIndex(blobs []ocispec.Descriptor, subject *ocispec.Descriptor, annotations map[string]string) *Index {
 	return &Index{
 		Blobs:        blobs,
 		ArtifactType: SociIndexArtifactType,
 		Annotations:  annotations,
 		Subject:      subject,
 		MediaType:    OCIArtifactManifestMediaType,
-	}
-}
-
-func newORASManifest(blobs []ocispec.Descriptor, subject *ocispec.Descriptor, annotations map[string]string) *Index {
-	return &Index{
-		Blobs:        blobs,
-		ArtifactType: SociIndexArtifactType,
-		Annotations:  annotations,
-		Subject:      subject,
-		MediaType:    ORASManifestMediaType,
 	}
 }
 

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -97,7 +97,7 @@ func TestBuildSociIndexNotLayer(t *testing.T) {
 		},
 		{
 			name:      "soci index manifest",
-			mediaType: ORASManifestMediaType,
+			mediaType: OCIArtifactManifestMediaType,
 			err:       errNotLayerType,
 		},
 		{
@@ -222,29 +222,11 @@ func TestBuildSociIndexWithLimits(t *testing.T) {
 
 func TestNewIndex(t *testing.T) {
 	testcases := []struct {
-		name         string
-		blobs        []ocispec.Descriptor
-		subject      ocispec.Descriptor
-		annotations  map[string]string
-		manifestType ManifestType
+		name        string
+		blobs       []ocispec.Descriptor
+		subject     ocispec.Descriptor
+		annotations map[string]string
 	}{
-		{
-			name: "successfully build oras manifest",
-			blobs: []ocispec.Descriptor{
-				{
-					Size:   4,
-					Digest: digest.FromBytes([]byte("test")),
-				},
-			},
-			subject: ocispec.Descriptor{
-				Size:   4,
-				Digest: digest.FromBytes([]byte("test")),
-			},
-			annotations: map[string]string{
-				"foo": "bar",
-			},
-			manifestType: ManifestORAS,
-		},
 		{
 			name: "successfully build OCI ref type manifest",
 			blobs: []ocispec.Descriptor{
@@ -260,13 +242,12 @@ func TestNewIndex(t *testing.T) {
 			annotations: map[string]string{
 				"foo": "bar",
 			},
-			manifestType: ManifestOCIArtifact,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			index := NewIndex(tc.blobs, &tc.subject, tc.annotations, tc.manifestType)
+			index := NewIndex(tc.blobs, &tc.subject, tc.annotations)
 
 			if diff := cmp.Diff(index.Blobs, tc.blobs); diff != "" {
 				t.Fatalf("unexpected blobs; diff = %v", diff)
@@ -276,13 +257,8 @@ func TestNewIndex(t *testing.T) {
 				t.Fatalf("unexpected artifact type; expected = %s, got = %s", SociIndexArtifactType, index.ArtifactType)
 			}
 
-			mt := index.MediaType
-			if tc.manifestType == ManifestORAS {
-				if mt != ORASManifestMediaType {
-					t.Fatalf("unexpected media type; expected = %v, got = %v", ORASManifestMediaType, mt)
-				}
-			} else if mt != OCIArtifactManifestMediaType {
-				t.Fatalf("unexpected media type; expected = %v, got = %v", OCIArtifactManifestMediaType, mt)
+			if index.MediaType != OCIArtifactManifestMediaType {
+				t.Fatalf("unexpected media type; expected = %v, got = %v", OCIArtifactManifestMediaType, index.MediaType)
 			}
 
 			if diff := cmp.Diff(index.Subject, &tc.subject); diff != "" {
@@ -294,29 +270,11 @@ func TestNewIndex(t *testing.T) {
 
 func TestNewIndexFromReader(t *testing.T) {
 	testcases := []struct {
-		name         string
-		blobs        []ocispec.Descriptor
-		subject      ocispec.Descriptor
-		annotations  map[string]string
-		manifestType ManifestType
+		name        string
+		blobs       []ocispec.Descriptor
+		subject     ocispec.Descriptor
+		annotations map[string]string
 	}{
-		{
-			name: "successfully build oras manifest",
-			blobs: []ocispec.Descriptor{
-				{
-					Size:   4,
-					Digest: digest.FromBytes([]byte("test")),
-				},
-			},
-			subject: ocispec.Descriptor{
-				Size:   4,
-				Digest: digest.FromBytes([]byte("test")),
-			},
-			annotations: map[string]string{
-				"foo": "bar",
-			},
-			manifestType: ManifestORAS,
-		},
 		{
 			name: "successfully build OCI ref type manifest",
 			blobs: []ocispec.Descriptor{
@@ -332,13 +290,12 @@ func TestNewIndexFromReader(t *testing.T) {
 			annotations: map[string]string{
 				"foo": "bar",
 			},
-			manifestType: ManifestOCIArtifact,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			index := NewIndex(tc.blobs, &tc.subject, tc.annotations, tc.manifestType)
+			index := NewIndex(tc.blobs, &tc.subject, tc.annotations)
 			jsonBytes, err := json.Marshal(index)
 			if err != nil {
 				t.Fatalf("cannot convert index to json byte data: %v", err)


### PR DESCRIPTION
A previous commit migrated the snapshotter from ORAS to OCI Artifact, but still kept ORAS around. This commit removes ORAS completely from SOCI.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*
Resolves https://github.com/awslabs/soci-snapshotter/issues/149

*Description of changes:*

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
