### PR TITLE
Remove platform from subject descriptor

### DIFF
--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -85,6 +85,7 @@ type Index struct {
 
 type IndexWithMetadata struct {
 	Index       *Index
+	Platform    *ocispec.Platform
 	ImageDigest digest.Digest
 }
 
@@ -215,11 +216,11 @@ func BuildSociIndex(ctx context.Context, cs content.Store, img images.Image, spa
 		Digest:      imgManifestDesc.Digest,
 		Size:        imgManifestDesc.Size,
 		Annotations: imgManifestDesc.Annotations,
-		Platform:    &config.platform,
 	}
 	index := NewIndex(ztocsDesc, refers, annotations, config.manifestType)
 	return &IndexWithMetadata{
 		Index:       index,
+		Platform:    &config.platform,
 		ImageDigest: img.Target.Digest,
 	}, nil
 }
@@ -406,7 +407,7 @@ func WriteSociIndex(ctx context.Context, indexWithMetadata *IndexWithMetadata, s
 		Digest:         dgst.String(),
 		OriginalDigest: refers.Digest.String(),
 		ImageDigest:    indexWithMetadata.ImageDigest.String(),
-		Platform:       platforms.Format(*refers.Platform),
+		Platform:       platforms.Format(*indexWithMetadata.Platform),
 		Type:           ArtifactEntryTypeIndex,
 		Location:       refers.Digest.String(),
 		Size:           size,


### PR DESCRIPTION


Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*
The OCI image spec states:
> Descriptors pointing to application/vnd.oci.image.manifest.v1+json SHOULD include the extended field platform

However, it doesn't state anything else. For docker v2 images, the platform is field is thus undefined for the descriptor and should not be included in the SOCI Index manifest.

*Description of changes:*

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
