### PR TITLE
Add logging to bencharmking tests

### DIFF
--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/awslabs/soci-snapshotter/benchmark/framework"
+	"github.com/containerd/containerd/log"
 )
 
 var (
@@ -37,13 +38,12 @@ var (
 	awsSecretFile     = "../aws_secret"
 )
 
-func PullImageFromECR(b *testing.B, imageRef string) {
-	ctx, cancelCtx := framework.GetTestContext()
+func PullImageFromECR(ctx context.Context, b *testing.B, imageRef string) {
 	containerdProcess, err := getContainerdProcess(ctx)
 	if err != nil {
 		b.Fatalf("Error Starting Containerd: %v\n", err)
 	}
-	defer containerdProcess.StopProcess(cancelCtx)
+	defer containerdProcess.StopProcess()
 	b.ResetTimer()
 	_, err = containerdProcess.PullImageFromECR(ctx, imageRef, platform, awsSecretFile)
 	if err != nil {
@@ -57,15 +57,15 @@ func PullImageFromECR(b *testing.B, imageRef string) {
 }
 
 func SociRPullPullImage(
+	ctx context.Context,
 	b *testing.B,
 	imageRef string,
 	indexDigest string) {
-	ctx, cancelCtx := framework.GetTestContext()
 	containerdProcess, err := getContainerdProcess(ctx)
 	if err != nil {
 		b.Fatalf("Failed to create containerd proc: %v\n", err)
 	}
-	defer containerdProcess.StopProcess(cancelCtx)
+	defer containerdProcess.StopProcess()
 	sociProcess, err := getSociProcess()
 	if err != nil {
 		b.Fatalf("Failed to create soci proc: %v\n", err)
@@ -81,16 +81,18 @@ func SociRPullPullImage(
 }
 
 func SociFullRun(
+	ctx context.Context,
 	b *testing.B,
 	imageRef string,
 	indexDigest string,
-	readyLine string) {
-	ctx, cancelCtx := framework.GetTestContext()
+	readyLine string,
+	testName string) {
+	log.G(ctx).WithField("test_name", testName).WithField("benchmark", "Test").WithField("event", "Start").Infof("Start Test")
 	containerdProcess, err := getContainerdProcess(ctx)
 	if err != nil {
 		b.Fatalf("Failed to create containerd proc: %v\n", err)
 	}
-	defer containerdProcess.StopProcess(cancelCtx)
+	defer containerdProcess.StopProcess()
 	sociProcess, err := getSociProcess()
 	if err != nil {
 		b.Fatalf("Failed to create soci proc: %v\n", err)
@@ -121,15 +123,17 @@ func SociFullRun(
 }
 
 func OverlayFSFullRun(
+	ctx context.Context,
 	b *testing.B,
 	imageRef string,
-	readyLine string) {
-	ctx, cancelCtx := framework.GetTestContext()
+	readyLine string,
+	testName string) {
+	log.G(ctx).WithField("test_name", testName).WithField("benchmark", "Test").WithField("event", "Start").Infof("Start Test")
 	containerdProcess, err := getContainerdProcess(ctx)
 	if err != nil {
 		b.Fatalf("Failed to create containerd proc: %v\n", err)
 	}
-	defer containerdProcess.StopProcess(cancelCtx)
+	defer containerdProcess.StopProcess()
 	b.ResetTimer()
 	image, err := containerdProcess.PullImageFromECR(ctx, imageRef, platform, awsSecretFile)
 	if err != nil {

--- a/benchmark/framework/framework.go
+++ b/benchmark/framework/framework.go
@@ -17,13 +17,16 @@
 package framework
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io/fs"
 	"os"
+	"strconv"
 	"testing"
 
+	"github.com/containerd/containerd/log"
 	"github.com/montanaflynn/stats"
 )
 
@@ -56,7 +59,7 @@ type BenchmarkTestDriver struct {
 	Max            float64          `json:"max"`
 }
 
-func (frame *BenchmarkFramework) Run() {
+func (frame *BenchmarkFramework) Run(ctx context.Context) {
 	testing.Init()
 	flag.Set("test.benchtime", "1x")
 	flag.Parse()
@@ -67,6 +70,7 @@ func (frame *BenchmarkFramework) Run() {
 			testDriver.BeforeFunction()
 		}
 		for j := 0; j < testDriver.NumberOfTests; j++ {
+			log.G(ctx).WithField("test_name", testDriver.TestName).Infof("TestStart for " + testDriver.TestName + "_" + strconv.Itoa(j+1))
 			fmt.Printf("Running test %d of %d\n", j+1, testDriver.NumberOfTests)
 			res := testing.Benchmark(testDriver.TestFunction)
 			testDriver.TestTimes = append(testDriver.TestTimes, res.T.Seconds())


### PR DESCRIPTION
Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

Adds logging that writes out to the output directory.  This provides us the path forward to having multiple timers within a benchmark run.

This implementation requires the context to be created at the whole run level, where previously we were creating a new context for each test.

Example Log from `benchmark/comparisonTest/output/benchmark_log` :
```
{"level":"info","msg":"TestStart for OverlayFSFullbusybox_1","test_name":"OverlayFSFullbusybox","time":"2022-11-21T18:39:43.647980774Z"}
{"benchmark":"Test","event":"Start","level":"info","msg":"Start Test","test_name":"OverlayFSFullbusybox","time":"2022-11-21T18:39:43.649012321Z"}
{"level":"info","msg":"TestStart for OverlayFSFullbusybox_2","test_name":"OverlayFSFullbusybox","time":"2022-11-21T18:39:46.347959736Z"}
{"benchmark":"Test","event":"Start","level":"info","msg":"Start Test","test_name":"OverlayFSFullbusybox","time":"2022-11-21T18:39:46.348964137Z"}
{"level":"info","msg":"TestStart for SociFullbusybox_1","test_name":"SociFullbusybox","time":"2022-11-21T18:39:48.760611866Z"}
{"benchmark":"Test","event":"Start","level":"info","msg":"Start Test","test_name":"SociFullbusybox","time":"2022-11-21T18:39:48.761509165Z"}
{"level":"info","msg":"TestStart for SociFullbusybox_2","test_name":"SociFullbusybox","time":"2022-11-21T18:39:53.509261625Z"}
```