### PR TITLE
Add file access logging

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -99,4 +99,8 @@ type FuseConfig struct {
 
 	// NegativeTimeout defines the overall entry timeout for failed lookups.
 	NegativeTimeout int64 `toml:"negative_timeout"`
+
+	// LogFuseOperations enables logging of operations on FUSE FS. This is to be used
+	// for debugging purposes only.
+	LogFuseOperations bool `toml:"log_fuse_operations"`
 }

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -524,7 +524,7 @@ func (l *layer) RootNode(baseInode uint32) (fusefs.InodeEmbedder, error) {
 	if l.r == nil {
 		return nil, fmt.Errorf("layer hasn't been verified yet")
 	}
-	return newNode(l.desc.Digest, l.r, l.blob, baseInode, l.resolver.overlayOpaqueType)
+	return newNode(l.desc.Digest, l.r, l.blob, baseInode, l.resolver.overlayOpaqueType, l.resolver.config.LogFuseOperations)
 }
 
 func (l *layer) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, error) {

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -371,7 +371,7 @@ func hasSize(name string, size int) check {
 }
 
 func getRootNode(t *testing.T, r reader.Reader, opaque OverlayOpaqueType) *node {
-	rootNode, err := newNode(testStateLayerDigest, &testReader{r}, &testBlobState{10, 5}, 100, opaque)
+	rootNode, err := newNode(testStateLayerDigest, &testReader{r}, &testBlobState{10, 5}, 100, opaque, false)
 	if err != nil {
 		t.Fatalf("failed to get root node: %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*
#184 

*Description of changes:*
To be able to collect file access patterns via fuse, this change adds the debug logging in node.go for FUSE operations as well as config option to enable that logging. This capability should never be used in production. It is turned off by default.

*Testing performed:*
- `make test && make check && make integration` pass
- Deployed snapshotter to ec2 instance, updated `/etc/soci-snapshotter-grpc/config.toml` to set `log_fuse_operations` to true. Ran rethinkdb workload in soci mode and observed the following lines in the log (the workload without setting `log_fuse_operations` to true does not produce the log lines with fuse operations information): 

```
...
{"level":"debug","msg":"[FUSE] operation=Getxattr on path=etc/resolv.conf","time":"2022-11-21T22:17:49.035050285Z"}
{"level":"debug","msg":"[FUSE] operation=Getxattr on path=data","time":"2022-11-21T22:17:49.036099425Z"}
{"level":"debug","msg":"[FUSE] operation=Getxattr on path=data","time":"2022-11-21T22:17:49.036198736Z"}
{"level":"debug","msg":"[FUSE] operation=Getattr on path=data","time":"2022-11-21T22:17:49.037002695Z"}
{"level":"debug","msg":"[FUSE] operation=Getxattr on path=etc/passwd","time":"2022-11-21T22:17:49.037338965Z"}
{"level":"debug","msg":"[FUSE] operation=Open on path=etc/passwd","time":"2022-11-21T22:17:49.037430002Z"}
{"level":"debug","msg":"[FUSE] operation=Getxattr on path=etc/group","time":"2022-11-21T22:17:49.037588983Z"}
{"level":"debug","msg":"[FUSE] operation=Open on path=etc/group","time":"2022-11-21T22:17:49.037667408Z"}
{"level":"debug","msg":"[FUSE] operation=Read on path=etc/passwd","time":"2022-11-21T22:17:49.037766639Z"}
{"level":"debug","msg":"[FUSE] operation=Getxattr on path=usr","time":"2022-11-21T22:17:49.038198795Z"}
...
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
