### PR TITLE
Add Stargz for Benchmarking Boilerplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,3 +135,7 @@ benchmarks:
 benchmarks-comp:
 	@echo "$@"
 	@cd benchmark/comparisonTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/CompTests . && sudo ../bin/CompTests $(COMMIT) ../singleImage.csv 10
+
+benchmarks-stargz:
+	@echo "$@"
+	@cd benchmark/stargzTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/StargzTests . && sudo ../bin/StargzTests $(COMMIT) ../singleImage.csv 10

--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -153,6 +153,25 @@ func OverlayFSFullRun(
 	b.StopTimer()
 }
 
+func StargzFullRun(
+	b *testing.B,
+	imageRef string,
+	readyLine string) {
+	ctx, cancelCtx := framework.GetTestContext()
+	containerdProcess, err := getContainerdProcess(ctx)
+	if err != nil {
+		b.Fatalf("Failed to create containerd proc: %v\n", err)
+	}
+	defer containerdProcess.StopProcess(cancelCtx)
+	stargzProcess, err := getStargzProcess()
+	if err != nil {
+		b.Fatalf("Failed to create stargz proc: %v\n", err)
+	}
+	defer stargzProcess.StopProcess()
+	b.ResetTimer()
+	b.StopTimer()
+}
+
 func getContainerdProcess(ctx context.Context) (*framework.ContainerdProcess, error) {
 	return framework.StartContainerd(
 		containerdAddress,
@@ -170,4 +189,9 @@ func getSociProcess() (*SociProcess, error) {
 		containerdAddress,
 		sociConfig,
 		outputDir)
+}
+
+func getStargzProcess() (*StargzProcess, error) {
+	//TODO
+	return nil, nil
 }

--- a/benchmark/stargzTest/main.go
+++ b/benchmark/stargzTest/main.go
@@ -1,0 +1,92 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/benchmark"
+	"github.com/awslabs/soci-snapshotter/benchmark/framework"
+)
+
+var (
+	outputDir = "./output"
+)
+
+type ImageDescriptor struct {
+	shortName string
+	imageRef  string
+	readyLine string
+}
+
+func main() {
+	commit := os.Args[1]
+	configCsv := os.Args[2]
+	numberOfTests, err := strconv.Atoi(os.Args[3])
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to parse number of test %s with error:%v\n", os.Args[3], err)
+		panic(errMsg)
+	}
+	imageList, err := getImageListFromCsv(configCsv)
+	if err != nil {
+		errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
+		panic(errMsg)
+	}
+	var drivers []framework.BenchmarkTestDriver
+	for _, image := range imageList {
+		shortName := image.shortName
+		imageRef := image.imageRef
+		readyLine := image.readyLine
+		drivers = append(drivers, framework.BenchmarkTestDriver{
+			TestName:      "StargzFullRun" + shortName,
+			NumberOfTests: numberOfTests,
+			TestFunction: func(b *testing.B) {
+				benchmark.StargzFullRun(b, imageRef, readyLine)
+			},
+		})
+	}
+
+	benchmarks := framework.BenchmarkFramework{
+		OutputDir: outputDir,
+		CommitID:  commit,
+		Drivers:   drivers,
+	}
+	benchmarks.Run()
+}
+
+func getImageListFromCsv(csvLoc string) ([]ImageDescriptor, error) {
+	csvFile, err := os.Open(csvLoc)
+	if err != nil {
+		return nil, err
+	}
+	csv, err := csv.NewReader(csvFile).ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	var images []ImageDescriptor
+	for _, image := range csv {
+		images = append(images, ImageDescriptor{
+			shortName: image[0],
+			imageRef:  image[1],
+			readyLine: image[2]})
+	}
+	return images, nil
+}

--- a/benchmark/stargz_utils.go
+++ b/benchmark/stargz_utils.go
@@ -1,0 +1,28 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package benchmark
+
+type StargzProcess struct {
+}
+
+func StartStargz() (*StargzProcess, error) {
+	return nil, nil
+}
+
+func (proc *StargzProcess) StopProcess() {
+	//TODO
+}


### PR DESCRIPTION
Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

This add all of the boilerplate for stargz, but none of the logic.  It does add a Makefile target `make benchmarks-stargz` that will run and return very quickly - as it does not do anything.  These empty shells can be filled in similar to how soci was implemented.

One important thing to note is that we will need to build new images for stargz and have a file that references them.
