### PR TITLE
[BENCHMARKS] Add lifecycle events to benchmark logs

### DIFF
--- a/benchmark/framework/containerd_utils.go
+++ b/benchmark/framework/containerd_utils.go
@@ -283,7 +283,6 @@ func (proc *ContainerdProcess) RunContainerTaskForReadyLine(
 func GetRemoteOpts(ctx context.Context, platform string) []containerd.RemoteOpt {
 	var opts []containerd.RemoteOpt
 	opts = append(opts, containerd.WithPlatform(platform))
-	opts = append(opts, containerd.WithPullUnpack)
 
 	return opts
 }

--- a/benchmark/utils.go
+++ b/benchmark/utils.go
@@ -45,12 +45,12 @@ func GetImageListFromCsv(csvLoc string) ([]ImageDescriptor, error) {
 		}
 		var sociIndexManifestRef string
 		if len(image) == 4 {
-			sociIndexManifestRef = image[3]
+			sociIndexManifestRef = image[2]
 		}
 		images = append(images, ImageDescriptor{
 			ShortName:            image[0],
 			ImageRef:             image[1],
-			ReadyLine:            image[2],
+			ReadyLine:            image[3],
 			SociIndexManifestRef: sociIndexManifestRef})
 	}
 	return images, nil

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/flatbuffers v2.0.8+incompatible
 	github.com/google/go-cmp v0.5.6
+	github.com/google/uuid v1.2.0
 	github.com/hanwen/go-fuse/v2 v2.1.1-0.20210825171523-3ab5d95a30ae
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.0
@@ -51,7 +52,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect


### PR DESCRIPTION
Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

This PR adds log statements after each event so that we can get time stamp information.

Here is an example of logs for the pull event.
```
{"benchmark":"Pull","event":"Start","level":"info","msg":"Start Pull Image","test_name":"OverlayFSFulldrupal","time":"2022-11-28T17:15:50.349475037Z","uuid":"2fa95c1d-959e-4373-a380-ff0632c55c9f"}
{"benchmark":"Pull","event":"Stop","level":"info","msg":"Stop Pull Image","test_name":"OverlayFSFulldrupal","time":"2022-11-28T17:15:53.565088295Z","uuid":"2fa95c1d-959e-4373-a380-ff0632c55c9f"}
```

These logs can the be parsed to get the time spent pulling.

One thing to note is that the 'unpack' event (uncompressing) only exists for overlayfs, when I do it for soci it appears to download everything.  