### PR TITLE
Start and stop stargz process for benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SOCI_SNAPSHOTTER_PROJECT_ROOT ?= $(shell pwd)
 LTAG_TEMPLATE_FLAG=-t ./.headers
 FBS_FILE_PATH=$(CURDIR)/soci/fbs/ztoc.fbs
 COMMIT=$(shell git rev-parse HEAD)
+STARGZ_BINARY?=/usr/local/bin/containerd-stargz-grpc
 
 CMD=soci-snapshotter-grpc soci
 
@@ -138,4 +139,4 @@ benchmarks-comp:
 
 benchmarks-stargz:
 	@echo "$@"
-	@cd benchmark/stargzTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/StargzTests . && sudo ../bin/StargzTests $(COMMIT) ../singleImage.csv 10
+	@cd benchmark/stargzTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/StargzTests . && sudo ../bin/StargzTests $(COMMIT) ../singleImage.csv 10 $(STARGZ_BINARY)

--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -36,6 +36,9 @@ var (
 	sociRoot          = "/tmp/lib/soci-snapshotter-grpc"
 	sociConfig        = "../soci_config.toml"
 	awsSecretFile     = "../aws_secret"
+	stargzAddress     = "/tmp/containerd-stargz-grpc/containerd-stargz-grpc.sock"
+	stargzConfig      = "../stargz_config.toml"
+	stargzRoot        = "/tmp/lib/containerd-stargz-grpc"
 )
 
 func PullImageFromECR(ctx context.Context, b *testing.B, imageRef string) {
@@ -161,13 +164,14 @@ func StargzFullRun(
 	ctx context.Context,
 	b *testing.B,
 	imageRef string,
-	readyLine string) {
+	readyLine string,
+	stargzBinary string) {
 	containerdProcess, err := getContainerdProcess(ctx)
 	if err != nil {
 		b.Fatalf("Failed to create containerd proc: %v\n", err)
 	}
 	defer containerdProcess.StopProcess()
-	stargzProcess, err := getStargzProcess()
+	stargzProcess, err := getStargzProcess(stargzBinary)
 	if err != nil {
 		b.Fatalf("Failed to create stargz proc: %v\n", err)
 	}
@@ -195,7 +199,11 @@ func getSociProcess() (*SociProcess, error) {
 		outputDir)
 }
 
-func getStargzProcess() (*StargzProcess, error) {
-	//TODO
-	return nil, nil
+func getStargzProcess(stargzBinary string) (*StargzProcess, error) {
+	return StartStargz(
+		stargzBinary,
+		stargzAddress,
+		stargzRoot,
+		stargzConfig,
+		outputDir)
 }

--- a/benchmark/comparisonTest/main.go
+++ b/benchmark/comparisonTest/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"encoding/csv"
 	"fmt"
 	"os"
 	"strconv"
@@ -31,13 +30,6 @@ var (
 	outputDir = "./output"
 )
 
-type ImageDescriptor struct {
-	shortName            string
-	imageRef             string
-	sociIndexManifestRef string
-	readyLine            string
-}
-
 func main() {
 	commit := os.Args[1]
 	configCsv := os.Args[2]
@@ -46,7 +38,7 @@ func main() {
 		errMsg := fmt.Sprintf("Failed to parse number of test %s with error:%v\n", os.Args[3], err)
 		panic(errMsg)
 	}
-	imageList, err := getImageListFromCsv(configCsv)
+	imageList, err := benchmark.GetImageListFromCsv(configCsv)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
 		panic(errMsg)
@@ -67,10 +59,10 @@ func main() {
 
 	var drivers []framework.BenchmarkTestDriver
 	for _, image := range imageList {
-		shortName := image.shortName
-		imageRef := image.imageRef
-		sociIndexManifestRef := image.sociIndexManifestRef
-		readyLine := image.readyLine
+		shortName := image.ShortName
+		imageRef := image.ImageRef
+		sociIndexManifestRef := image.SociIndexManifestRef
+		readyLine := image.ReadyLine
 		drivers = append(drivers, framework.BenchmarkTestDriver{
 			TestName:      "OverlayFSFull" + shortName,
 			NumberOfTests: numberOfTests,
@@ -93,24 +85,4 @@ func main() {
 		Drivers:   drivers,
 	}
 	benchmarks.Run(ctx)
-}
-
-func getImageListFromCsv(csvLoc string) ([]ImageDescriptor, error) {
-	csvFile, err := os.Open(csvLoc)
-	if err != nil {
-		return nil, err
-	}
-	csv, err := csv.NewReader(csvFile).ReadAll()
-	if err != nil {
-		return nil, err
-	}
-	var images []ImageDescriptor
-	for _, image := range csv {
-		images = append(images, ImageDescriptor{
-			shortName:            image[0],
-			imageRef:             image[1],
-			sociIndexManifestRef: image[2],
-			readyLine:            image[3]})
-	}
-	return images, nil
 }

--- a/benchmark/performanceTest/main.go
+++ b/benchmark/performanceTest/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"encoding/csv"
 	"fmt"
 	"os"
 	"strconv"
@@ -31,13 +30,6 @@ var (
 	outputDir = "./output"
 )
 
-type ImageDescriptor struct {
-	shortName            string
-	imageRef             string
-	sociIndexManifestRef string
-	readyLine            string
-}
-
 func main() {
 	commit := os.Args[1]
 	configCsv := os.Args[2]
@@ -46,7 +38,7 @@ func main() {
 		errMsg := fmt.Sprintf("Failed to parse number of test %s with error:%v\n", os.Args[3], err)
 		panic(errMsg)
 	}
-	imageList, err := getImageListFromCsv(configCsv)
+	imageList, err := benchmark.GetImageListFromCsv(configCsv)
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
 		panic(errMsg)
@@ -67,10 +59,10 @@ func main() {
 
 	var drivers []framework.BenchmarkTestDriver
 	for _, image := range imageList {
-		shortName := image.shortName
-		imageRef := image.imageRef
-		sociIndexManifestRef := image.sociIndexManifestRef
-		readyLine := image.readyLine
+		shortName := image.ShortName
+		imageRef := image.ImageRef
+		sociIndexManifestRef := image.SociIndexManifestRef
+		readyLine := image.ReadyLine
 		testName := "SociFull" + shortName
 		drivers = append(drivers, framework.BenchmarkTestDriver{
 			TestName:      testName,
@@ -87,24 +79,4 @@ func main() {
 		Drivers:   drivers,
 	}
 	benchmarks.Run(ctx)
-}
-
-func getImageListFromCsv(csvLoc string) ([]ImageDescriptor, error) {
-	csvFile, err := os.Open(csvLoc)
-	if err != nil {
-		return nil, err
-	}
-	csv, err := csv.NewReader(csvFile).ReadAll()
-	if err != nil {
-		return nil, err
-	}
-	var images []ImageDescriptor
-	for _, image := range csv {
-		images = append(images, ImageDescriptor{
-			shortName:            image[0],
-			imageRef:             image[1],
-			sociIndexManifestRef: image[2],
-			readyLine:            image[3]})
-	}
-	return images, nil
 }

--- a/benchmark/stargz_utils.go
+++ b/benchmark/stargz_utils.go
@@ -16,13 +16,103 @@
 
 package benchmark
 
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
 type StargzProcess struct {
+	command *exec.Cmd
+	address string
+	root    string
+	stdout  *os.File
+	stderr  *os.File
 }
 
-func StartStargz() (*StargzProcess, error) {
-	return nil, nil
+func StartStargz(
+	stargzBinary string,
+	stargzAddress string,
+	stargzConfig string,
+	stargzRoot string,
+	outputDir string) (*StargzProcess, error) {
+	stargzCmd := exec.Command(stargzBinary,
+		"-address", stargzAddress,
+		"-config", stargzConfig,
+		"-log-level", "debug",
+		"-root", stargzRoot)
+	err := os.MkdirAll(outputDir, 0777)
+	if err != nil {
+		return nil, err
+	}
+	stdoutFile, err := os.Create(outputDir + "/stargz-snapshotter-stdout")
+	if err != nil {
+		return nil, err
+	}
+	stargzCmd.Stdout = stdoutFile
+	stderrFile, err := os.Create(outputDir + "/stargz-snapshotter-stderr")
+	if err != nil {
+		return nil, err
+	}
+	stargzCmd.Stderr = stderrFile
+	err = stargzCmd.Start()
+	if err != nil {
+		fmt.Printf("Stargz process failed to start %v\n", err)
+		return nil, err
+	}
+
+	// The stargz-snapshotter-grpc is not ready to be used until the
+	// unix socket file is created
+	sleepCount := 0
+	loopExit := false
+	for !loopExit {
+		time.Sleep(1 * time.Second)
+		sleepCount++
+		if _, err := os.Stat(stargzAddress); err == nil {
+			loopExit = true
+		}
+		if sleepCount > 15 {
+			return nil, errors.New("Could not create .sock in time")
+		}
+	}
+	return &StargzProcess{
+		command: stargzCmd,
+		address: stargzAddress,
+		root:    stargzRoot,
+		stdout:  stdoutFile,
+		stderr:  stderrFile}, nil
 }
 
 func (proc *StargzProcess) StopProcess() {
-	//TODO
+	if proc.stdout != nil {
+		proc.stdout.Close()
+	}
+	if proc.stderr != nil {
+		proc.stderr.Close()
+	}
+	if proc.command != nil {
+		proc.command.Process.Kill()
+	}
+	err := os.RemoveAll(proc.address)
+	if err != nil {
+		fmt.Printf("Error removing stargz process address: %v\n", err)
+	}
+
+	snapshotDir := proc.root + "/snapshotter/snapshots/"
+	snapshots, err := os.ReadDir(snapshotDir)
+	if err != nil {
+		fmt.Printf("Could not read dir: %s\n", snapshotDir)
+	}
+
+	for _, s := range snapshots {
+		mountpoint := snapshotDir + s.Name() + "/fs"
+		_ = syscall.Unmount(mountpoint, syscall.MNT_FORCE)
+	}
+	err = os.RemoveAll(proc.root)
+	if err != nil {
+		fmt.Printf("Error removing stargz process root: %v\n", err)
+	}
 }

--- a/benchmark/utils.go
+++ b/benchmark/utils.go
@@ -1,0 +1,57 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package benchmark
+
+import (
+	"encoding/csv"
+	"errors"
+	"os"
+)
+
+type ImageDescriptor struct {
+	ShortName            string
+	ImageRef             string
+	SociIndexManifestRef string
+	ReadyLine            string
+}
+
+func GetImageListFromCsv(csvLoc string) ([]ImageDescriptor, error) {
+	csvFile, err := os.Open(csvLoc)
+	if err != nil {
+		return nil, err
+	}
+	csv, err := csv.NewReader(csvFile).ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	var images []ImageDescriptor
+	for _, image := range csv {
+		if len(image) < 3 {
+			return nil, errors.New("image input is not sufficient")
+		}
+		var sociIndexManifestRef string
+		if len(image) == 4 {
+			sociIndexManifestRef = image[3]
+		}
+		images = append(images, ImageDescriptor{
+			ShortName:            image[0],
+			ImageRef:             image[1],
+			ReadyLine:            image[2],
+			SociIndexManifestRef: sociIndexManifestRef})
+	}
+	return images, nil
+}


### PR DESCRIPTION
Add the ability of starting and stopping the stargz snapshotter process in running benchmarks.

To run the stargz benchmark, run:
``make benchmarks-stargz``
It uses the default location of the stargz binary installed by the stargz snapshotter's makefile.

Or, we can optionally pass in the path to the stargz binary to the command:
``make benchmarks-stargz STARGZ_BINARY=<path-to-binary>``

Also moved ``ImageDescriptor`` and ``GetImageListFromCsv`` to a new ``utils.go`` file as they can be shared by both soci and stargz tests.

Signed-off-by: Hanyue Liang <hanliang@amazon.com>

*Issue #, if available:* [#183
](https://github.com/awslabs/soci-snapshotter/issues/183)
*Description of changes:*

*Testing performed:* 
``make benchmarks-stargz`` runs successfully.
``make benchmarks-stargz STARGZ_BINARY=<path-to-binary>`` runs successfully
``make benchmarks-comp`` pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
