### PR TITLE
Fixes broken build

### DIFF
--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -158,15 +158,15 @@ func OverlayFSFullRun(
 }
 
 func StargzFullRun(
+	ctx context.Context,
 	b *testing.B,
 	imageRef string,
 	readyLine string) {
-	ctx, cancelCtx := framework.GetTestContext()
 	containerdProcess, err := getContainerdProcess(ctx)
 	if err != nil {
 		b.Fatalf("Failed to create containerd proc: %v\n", err)
 	}
-	defer containerdProcess.StopProcess(cancelCtx)
+	defer containerdProcess.StopProcess()
 	stargzProcess, err := getStargzProcess()
 	if err != nil {
 		b.Fatalf("Failed to create stargz proc: %v\n", err)

--- a/benchmark/comparisonTest/main.go
+++ b/benchmark/comparisonTest/main.go
@@ -52,6 +52,11 @@ func main() {
 		panic(errMsg)
 	}
 
+	err = os.Mkdir(outputDir, 0755)
+	if err != nil && !os.IsExist(err) {
+		panic(err)
+	}
+
 	logFile, err := os.OpenFile(outputDir+"/benchmark_log", os.O_RDWR|os.O_CREATE, 0664)
 	if err != nil {
 		panic(err)

--- a/benchmark/performanceTest/main.go
+++ b/benchmark/performanceTest/main.go
@@ -51,6 +51,12 @@ func main() {
 		errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
 		panic(errMsg)
 	}
+
+	err = os.Mkdir(outputDir, 0755)
+	if err != nil && !os.IsExist(err) {
+		panic(err)
+	}
+
 	logFile, err := os.OpenFile(outputDir+"/benchmark_log", os.O_RDWR|os.O_CREATE, 0664)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

*Issue #, if available:*

*Description of changes:*
This fixes the broken build.  The build was broken for two reasons: 
1) the new stargz test did not implement the new logs (thanks @kzys  for finding this) 
2) if an output dir was not present it would error out (thanks @hanyuel for finding this)

*Testing performed:*
- make
- make check
- make benchmarks
- make benchmarks-stargz

Made sure to also check if this works with or without the output dir added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
