### PR TITLE
[Benchmarker] Add parser for benchmark logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,3 +136,7 @@ benchmarks-comp:
 benchmarks-stargz:
 	@echo "$@"
 	@cd benchmark/stargzTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/StargzTests . && sudo ../bin/StargzTests $(COMMIT) ../singleImage.csv 10 $(STARGZ_BINARY)
+
+benchmarks-parser:
+	@echo "$@"
+	@cd benchmark/parser ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/Parser .

--- a/benchmark/parser/main.go
+++ b/benchmark/parser/main.go
@@ -1,0 +1,112 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+type BenchmarkEvent struct {
+	Benchmark string `json:"benchmark"`
+	Event     string `json:"event"`
+	TestName  string `json:"test_name"`
+	UUID      string `json:"uuid"`
+	Timestamp string `json:"time"`
+}
+
+type ProfileEvent struct {
+	EventName string
+	StartTime time.Time
+	StopTime  time.Time
+}
+
+type BenchmarkProfile struct {
+	UUID     string
+	TestName string
+	Events   map[string]ProfileEvent
+}
+
+func main() {
+	logMap := make(map[string]BenchmarkProfile)
+	logFileName := os.Args[1]
+	logFile, err := os.Open(logFileName)
+	if err != nil {
+		panic("Cannot open " + logFileName)
+	}
+	defer logFile.Close()
+	fileScanner := bufio.NewScanner(logFile)
+
+	fileScanner.Split(bufio.ScanLines)
+
+	for fileScanner.Scan() {
+		line := fileScanner.Text()
+		if strings.Contains(line, "benchmark") {
+			parseLogLineToMap(fileScanner.Text(), logMap)
+		}
+	}
+	if err := fileScanner.Err(); err != nil {
+		panic("scan error: " + err.Error())
+	}
+
+	printLogMap(logMap)
+}
+
+func parseLogLineToMap(logline string, logmap map[string]BenchmarkProfile) {
+	var event BenchmarkEvent
+	json.Unmarshal([]byte(logline), &event)
+
+	testData, ok := logmap[event.UUID]
+	if !ok {
+		testData = BenchmarkProfile{
+			UUID:     event.UUID,
+			TestName: event.TestName,
+			Events:   make(map[string]ProfileEvent),
+		}
+		logmap[event.UUID] = testData
+	}
+	profileEvent, ok := testData.Events[event.Benchmark]
+	if !ok {
+		profileEvent = ProfileEvent{
+			EventName: event.Benchmark,
+		}
+		testData.Events[event.Benchmark] = profileEvent
+	}
+	if event.Event == "Start" {
+		startTime, _ := time.Parse(time.RFC3339, event.Timestamp)
+		profileEvent.StartTime = startTime
+	}
+	if event.Event == "Stop" {
+		stopTime, _ := time.Parse(time.RFC3339, event.Timestamp)
+		profileEvent.StopTime = stopTime
+	}
+	testData.Events[event.Benchmark] = profileEvent
+	fmt.Printf("profile Event: %v\n", profileEvent)
+}
+
+func printLogMap(logMap map[string]BenchmarkProfile) {
+	for uuid, profile := range logMap {
+		fmt.Printf("Test: %s ID: %s Key: %s\n", profile.TestName, profile.UUID, uuid)
+		for benchmarkName, benchmark := range profile.Events {
+			fmt.Printf("    Event: %v Key: %s\n", benchmark, benchmarkName)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Scott Buckfelder <buckscot@amazon.com>

*Issue #, if available:*

*Description of changes:*
This adds a new binary that parses benchmark logs.  This first PR consumes a logfile and parses it.   A future PR will perform statistics and output csv files.

The input benchmarks logs are in the json format at the line level,
e.g.
```
{"benchmark":"CreateContainer","event":"Stop","level":"info","msg":"Stop Create Container","test_name":"OverlayFSFulldrupal","time":"2022-11-29T14:14:31.593866765Z","uuid":"a515ccfc-fe1d-4dca-8488-afd141a8fd66"}
```
This is represented (and decoded into) the `BenchmarkEvent` struct.

What this does is builds a map keyed by the uuid (each uuid represents a run).  The entry in the map is a `BenchmarkProfile` struct, which is really just a container of events.  Each event has a start and stop time which is what we are going to use for timing in the statistics.

Right now there is a debug helper function `printLogMap` which shows us the contents, this will be removed in a future PR.  The example output looks like:
```
Test: OverlayFSFulldrupal ID: f5422f9b-a219-4a26-90b7-114e78b20285 Key: f5422f9b-a219-4a26-90b7-114e78b20285
    Event: {RunTaskTwice 2022-11-29 14:15:34.981682546 +0000 UTC 2022-11-29 14:15:35.045593364 +0000 UTC} Key: RunTaskTwice
    Event: {Test 2022-11-29 14:15:27.017584809 +0000 UTC 2022-11-29 14:15:35.045635312 +0000 UTC} Key: Test
    Event: {Pull 2022-11-29 14:15:27.017620993 +0000 UTC 2022-11-29 14:15:28.343088158 +0000 UTC} Key: Pull
    Event: {Unpack 2022-11-29 14:15:28.343140005 +0000 UTC 2022-11-29 14:15:34.743789776 +0000 UTC} Key: Unpack
    Event: {CreateContainer 2022-11-29 14:15:34.743828828 +0000 UTC 2022-11-29 14:15:34.75831766 +0000 UTC} Key: CreateContainer
    Event: {CreateTask 2022-11-29 14:15:34.758377697 +0000 UTC 2022-11-29 14:15:34.837654116 +0000 UTC} Key: CreateTask
    Event: {RunTask 2022-11-29 14:15:34.837715302 +0000 UTC 2022-11-29 14:15:34.902399283 +0000 UTC} Key: RunTask
Test: SociFulldrupal ID: 96355a30-a079-4445-a24b-1be36a27487f Key: 96355a30-a079-4445-a24b-1be36a27487f
    Event: {CreateTask 2022-11-29 14:16:29.207613372 +0000 UTC 2022-11-29 14:16:29.295869504 +0000 UTC} Key: CreateTask
    Event: {RunTask 2022-11-29 14:16:29.295906725 +0000 UTC 2022-11-29 14:16:32.275384934 +0000 UTC} Key: RunTask
    Event: {RunTaskTwice 2022-11-29 14:16:32.373066189 +0000 UTC 2022-11-29 14:16:32.491703415 +0000 UTC} Key: RunTaskTwice
    Event: {Test 2022-11-29 14:16:27.742905917 +0000 UTC 2022-11-29 14:16:32.491770466 +0000 UTC} Key: Test
    Event: {Pull 2022-11-29 14:16:27.742960554 +0000 UTC 2022-11-29 14:16:29.063761204 +0000 UTC} Key: Pull
    Event: {CreateContainer 2022-11-29 14:16:29.063807779 +0000 UTC 2022-11-29 14:16:29.207566275 +0000 UTC} Key: CreateContainer
```


*Testing performed:*
- make check
- make benchmarks
- make 
- make benchmarks-parser

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
