### PR TITLE
Remove unnecessary buffer in fs.reader

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -75,9 +75,8 @@ import (
 )
 
 const (
-	defaultFuseTimeout    = time.Second
-	defaultMaxConcurrency = 2
-	fusermountBin         = "fusermount"
+	defaultFuseTimeout = time.Second
+	fusermountBin      = "fusermount"
 )
 
 var (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove unnecessary temporary buffer ``content`` in fs.reader when reading file contents.

*Testing performed:*
``make check`` && ``make test`` && ``make integration``

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
