### PR TITLE
Implement background fetcher

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -83,7 +83,7 @@ require (
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.4.0 // indirect
-	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	golang.org/x/time v0.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -1224,8 +1224,9 @@ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.2.0 h1:52I/1L54xyEQAYdtcSuxtiT84KGYTBGXwayxmIpNJhE=
+golang.org/x/time v0.2.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/fs/backgroundfetcher/background_fetcher.go
+++ b/fs/backgroundfetcher/background_fetcher.go
@@ -1,0 +1,170 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package backgroundfetcher
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/containerd/containerd/log"
+	"golang.org/x/time/rate"
+)
+
+type Option func(*BackgroundFetcher) error
+
+func WithSilencePeriod(period time.Duration) Option {
+	return func(bf *BackgroundFetcher) error {
+		bf.silencePeriod = period
+		return nil
+	}
+}
+
+func WithFetchPeriod(period time.Duration) Option {
+	return func(bf *BackgroundFetcher) error {
+		bf.fetchPeriod = period
+		return nil
+	}
+}
+
+func WithMaxQueueSize(size int) Option {
+	return func(bf *BackgroundFetcher) error {
+		bf.maxQueueSize = size
+		return nil
+	}
+}
+
+// An interface for a type to "pause" the background fetcher.
+// Useful for mocking in unit tests.
+type pauser interface {
+	pause(time.Duration)
+}
+
+type defaultPauser struct{}
+
+func (p defaultPauser) pause(d time.Duration) {
+	time.Sleep(d)
+}
+
+// A backgroundFetcher is responsible for fetching spans from layers
+// in the background.
+type BackgroundFetcher struct {
+	silencePeriod time.Duration
+	fetchPeriod   time.Duration
+	maxQueueSize  int
+
+	rateLimiter *rate.Limiter
+
+	bfPauser pauser
+
+	// All span managers are added to the channel and picked up in Run().
+	// If a span manager is still able to fetch, it is reinserted into the chanel.
+	workQueue chan Resolver
+	closeChan chan struct{}
+	pauseChan chan struct{}
+}
+
+func NewBackgroundFetcher(opts ...Option) (*BackgroundFetcher, error) {
+	bf := new(BackgroundFetcher)
+	for _, o := range opts {
+		if err := o(bf); err != nil {
+			return nil, err
+		}
+	}
+	// Create a rate-limiter that will fetch every bf.fetchPeriod
+	// with a burst capacity of 1 (i.e., it will never invoke more than 1 bg-fetch
+	// within bf.fetchPeriod)
+	bf.rateLimiter = rate.NewLimiter(rate.Every(bf.fetchPeriod), 1)
+	bf.workQueue = make(chan Resolver, bf.maxQueueSize)
+	bf.closeChan = make(chan struct{})
+	bf.pauseChan = make(chan struct{})
+
+	if bf.bfPauser == nil {
+		bf.bfPauser = defaultPauser{}
+	}
+
+	return bf, nil
+}
+
+// Add a new Resolver to be background fetched from.
+// Sends the resolver through the channel, which will be received in the Run() method.
+func (bf *BackgroundFetcher) Add(resolver Resolver) {
+	bf.workQueue <- resolver
+}
+
+func (bf *BackgroundFetcher) Close() error {
+	bf.closeChan <- struct{}{}
+	return nil
+}
+
+// Sends a signal to pause the background fetcher for silencePeriod on the next iteration.
+func (bf *BackgroundFetcher) Pause() {
+	bf.pauseChan <- struct{}{}
+}
+
+func (bf *BackgroundFetcher) pause(ctx context.Context) {
+	needPause := false
+loop:
+	for {
+		select {
+		// A new image has been mounted. Need to pause the background fetcher
+		case <-bf.pauseChan:
+			needPause = true
+		default:
+			break loop
+		}
+	}
+	if needPause {
+		log.G(ctx).WithField("silencePeriod", bf.silencePeriod).Debug("new image mounted, pausing the background fetcher for silence period")
+		bf.bfPauser.pause(bf.silencePeriod)
+	}
+}
+
+func (bf *BackgroundFetcher) Run(ctx context.Context) error {
+	for {
+		// Pause the background fetcher if necessary.
+		bf.pause(ctx)
+
+		select {
+		case <-bf.closeChan:
+			return nil
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		select {
+		case lr := <-bf.workQueue:
+			if lr.Closed() {
+				continue
+			}
+			go func() {
+				more, err := lr.Resolve(ctx)
+				if more {
+					bf.workQueue <- lr
+				} else if err != nil {
+					log.G(ctx).WithError(err).Warn("error trying to resolve layer, removing it from the queue")
+				}
+			}()
+		default:
+		}
+
+		if err := bf.rateLimiter.Wait(ctx); err != nil {
+			return fmt.Errorf("background fetch: error while waiting for rate limiter: %w", err)
+		}
+	}
+}

--- a/fs/backgroundfetcher/background_fetcher_test.go
+++ b/fs/backgroundfetcher/background_fetcher_test.go
@@ -1,0 +1,194 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package backgroundfetcher
+
+import (
+	"compress/gzip"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/awslabs/soci-snapshotter/cache"
+	spanmanager "github.com/awslabs/soci-snapshotter/fs/span-manager"
+	"github.com/awslabs/soci-snapshotter/util/testutil"
+	"github.com/awslabs/soci-snapshotter/ztoc"
+	"github.com/opencontainers/go-digest"
+)
+
+func withPauser(p pauser) Option {
+	return func(bf *BackgroundFetcher) error {
+		bf.bfPauser = p
+		return nil
+	}
+}
+
+type countingPauser struct {
+	mu    sync.Mutex
+	count int
+}
+
+func (c *countingPauser) pause(time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.count++
+}
+
+func TestBackgroundFetcherPause(t *testing.T) {
+	p := &countingPauser{}
+	bf, err := NewBackgroundFetcher(WithSilencePeriod(0), withPauser(p))
+	if err != nil {
+		t.Fatal(err)
+	}
+	go bf.Run(context.Background())
+	defer bf.Close()
+	bf.Pause()
+
+	time.Sleep(10 * time.Millisecond)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.count != 1 {
+		t.Fatalf("unexpected pause count; expected 1, got %v", p.count)
+	}
+}
+
+func TestBackgroundFetcherRun(t *testing.T) {
+	testCases := []struct {
+		name     string
+		waitTime time.Duration
+		entries  [][]testutil.TarEntry
+	}{
+		{
+			name:     "background fetcher fetches all data for single span manager",
+			waitTime: 1 * time.Second,
+			entries: [][]testutil.TarEntry{
+				{
+					testutil.File("test", string(genRandomByteData(10000000))),
+				},
+			},
+		},
+		{
+			name:     "background fetcher fetches all data for multiple span managers",
+			waitTime: 1 * time.Second,
+			entries: [][]testutil.TarEntry{
+				{
+					testutil.File("test1", string(genRandomByteData(10000000))),
+				},
+				{
+					testutil.File("test2", string(genRandomByteData(20000000))),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			type testInfo struct {
+				sm    *spanmanager.SpanManager
+				cache *countingCache
+				ztoc  *ztoc.Ztoc
+			}
+
+			var infos []testInfo
+			for _, entries := range tc.entries {
+				ztoc, sr, err := ztoc.BuildZtocReader(entries, gzip.DefaultCompression, 1000000)
+				if err != nil {
+					t.Fatalf("error building span manager and section reader: %v", err)
+				}
+				cache := &countingCache{}
+				sm := spanmanager.New(ztoc, sr, cache)
+				infos = append(infos, testInfo{sm, cache, ztoc})
+			}
+
+			bf, err := NewBackgroundFetcher(WithFetchPeriod(0))
+			if err != nil {
+				t.Fatalf("unable to construct background fetcher: %v", err)
+			}
+
+			go bf.Run(context.Background())
+			defer bf.Close()
+
+			for _, info := range infos {
+				bf.Add(NewSequentialResolver(digest.FromString("test"), info.sm))
+			}
+
+			time.Sleep(tc.waitTime)
+
+			for _, info := range infos {
+				if info.cache.addCount != int(info.ztoc.CompressionInfo.MaxSpanID)+1 {
+					t.Fatalf("unexpected number of adds to cache; expected %d, got %d", info.ztoc.CompressionInfo.MaxSpanID+1, info.cache.addCount)
+				}
+
+				// The first 10 bytes of a compressed gzip archive is the gzip header.
+				// We don't fetch it when lazy-loading; therefore, subtracting 10 from the total compressed archive size.
+				compressedSize := info.ztoc.CompressedArchiveSize - 10
+				if info.cache.addBytes != int64(compressedSize) {
+					t.Fatalf("unexpected number of bytes added to cache; expected %d, got %d", compressedSize, info.cache.addBytes)
+				}
+			}
+		})
+	}
+}
+
+// countingCache is an implementation of cache.BlobCache
+// which counts the number of times `cache.Add` was invoked
+// and the number of bytes added to the cache.
+// All writes to the cache succeed.
+type countingCache struct {
+	addCount int
+	addBytes int64
+}
+
+var _ cache.BlobCache = &countingCache{}
+
+func (c *countingCache) Add(key string, opts ...cache.Option) (cache.Writer, error) {
+	return &countingWriter{c}, nil
+}
+
+func (c *countingCache) Get(key string, opts ...cache.Option) (cache.Reader, error) {
+	return nil, nil
+}
+
+func (c *countingCache) Close() error {
+	return nil
+}
+
+type countingWriter struct {
+	cache *countingCache
+}
+
+var _ cache.Writer = &countingWriter{}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.cache.addBytes += int64(len(p))
+	c.cache.addCount++
+	return len(p), nil
+}
+
+func (c *countingWriter) Close() error {
+	return nil
+}
+
+func (c *countingWriter) Commit() error {
+	return nil
+}
+
+func (c *countingWriter) Abort() error {
+	return nil
+}

--- a/fs/backgroundfetcher/resolver.go
+++ b/fs/backgroundfetcher/resolver.go
@@ -1,0 +1,96 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package backgroundfetcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/awslabs/soci-snapshotter/compression"
+	sm "github.com/awslabs/soci-snapshotter/fs/span-manager"
+	"github.com/containerd/containerd/log"
+	"github.com/opencontainers/go-digest"
+	"github.com/sirupsen/logrus"
+)
+
+type Resolver interface {
+	// Resolve fetches and caches the next span. Returns true if there is still more data to be fetched.
+	// Returns false otherwise.
+	Resolve(context.Context) (bool, error)
+
+	// Closes the resolver.
+	Close() error
+
+	// Checks whether the resolver is closed or not.
+	Closed() bool
+}
+
+type base struct {
+	*sm.SpanManager
+	layerDigest digest.Digest
+	closed      bool
+	closedMu    sync.Mutex
+}
+
+func (b *base) Close() error {
+	b.closedMu.Lock()
+	defer b.closedMu.Unlock()
+	b.closed = true
+	return nil
+}
+
+func (b *base) Closed() bool {
+	b.closedMu.Lock()
+	defer b.closedMu.Unlock()
+	return b.closed
+}
+
+// A sequentialLayerResolver background fetches spans sequentially, starting from span 0.
+type sequentialLayerResolver struct {
+	*base
+	nextSpanFetchID compression.SpanID
+}
+
+func NewSequentialResolver(layerDigest digest.Digest, spanManager *sm.SpanManager) Resolver {
+	return &sequentialLayerResolver{
+		base: &base{
+			SpanManager: spanManager,
+			layerDigest: layerDigest,
+		},
+	}
+}
+
+func (lr *sequentialLayerResolver) Resolve(ctx context.Context) (bool, error) {
+	log.G(ctx).WithFields(logrus.Fields{
+		"layer":  lr.layerDigest,
+		"spanId": lr.nextSpanFetchID,
+	}).Debug("fetching span")
+
+	err := lr.FetchSingleSpan(lr.nextSpanFetchID)
+	if err == nil {
+		lr.nextSpanFetchID++
+		return true, nil
+	}
+	if errors.Is(err, sm.ErrExceedMaxSpan) {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("error trying to fetch span with spanId = %d from layerDigest = %s: %w",
+		lr.nextSpanFetchID, lr.layerDigest.String(), err)
+}

--- a/fs/backgroundfetcher/resolver_test.go
+++ b/fs/backgroundfetcher/resolver_test.go
@@ -1,0 +1,86 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package backgroundfetcher
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/rand"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/cache"
+	spanmanager "github.com/awslabs/soci-snapshotter/fs/span-manager"
+	"github.com/awslabs/soci-snapshotter/util/testutil"
+	"github.com/awslabs/soci-snapshotter/ztoc"
+	"github.com/opencontainers/go-digest"
+)
+
+func TestSequentialResolver(t *testing.T) {
+	testCases := []struct {
+		name    string
+		entries []testutil.TarEntry
+	}{
+		{
+			name: "resolver fetches spans sequentially",
+			entries: []testutil.TarEntry{
+				testutil.File("test", string(genRandomByteData(10000000))),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ztoc, sr, err := ztoc.BuildZtocReader(tc.entries, gzip.DefaultCompression, 1000000)
+			if err != nil {
+				t.Fatalf("error build ztoc and section reader: %v", err)
+			}
+			sm := spanmanager.New(ztoc, sr, cache.NewMemoryCache())
+			sequentialResolver := NewSequentialResolver(digest.FromString("test"), sm)
+
+			var resolvedSpans []int
+			for {
+				resolvedSpans = append(resolvedSpans, int(sequentialResolver.(*sequentialLayerResolver).nextSpanFetchID))
+				more, err := sequentialResolver.Resolve(context.Background())
+				if !more {
+					break
+				}
+				if err != nil {
+					t.Fatalf("error while resolving span: %v", err)
+				}
+			}
+
+			lastSpanID := sequentialResolver.(*sequentialLayerResolver).nextSpanFetchID
+			// assert that we've resolved all spans
+			if lastSpanID != ztoc.CompressionInfo.MaxSpanID+1 {
+				t.Fatalf("unexpected number of spans resolved; expected %d, got %d", ztoc.CompressionInfo.MaxSpanID+1, lastSpanID)
+			}
+
+			// assert that all spans are resolved sequentially
+			for i := 0; i < len(resolvedSpans); i++ {
+				if i != resolvedSpans[i] {
+					t.Fatalf("unexpected span id; expected %d, got %d", i, resolvedSpans[i])
+				}
+			}
+		})
+	}
+}
+
+func genRandomByteData(size int64) []byte {
+	data := make([]byte, size)
+	rand.Read(data)
+	return data
+}

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -71,6 +71,8 @@ type Config struct {
 	DirectoryCacheConfig `toml:"directory_cache"`
 
 	FuseConfig `toml:"fuse"`
+
+	BackgroundFetchConfig `toml:"background_fetch"`
 }
 
 type BlobConfig struct {
@@ -103,4 +105,21 @@ type FuseConfig struct {
 	// LogFuseOperations enables logging of operations on FUSE FS. This is to be used
 	// for debugging purposes only.
 	LogFuseOperations bool `toml:"log_fuse_operations"`
+}
+
+type BackgroundFetchConfig struct {
+	Disable bool `toml:"disable"`
+
+	// SilencePeriodMSec defines the time (in ms) the background fetcher
+	// will be paused for when a new image is mounted.
+	SilencePeriodMSec int64 `toml:"silence_period_msec"`
+
+	// FetchPeriodMSec specifies how often a background fetch will occur.
+	// The background fetcher will fetch one span every FetchPeriodMSec.
+	FetchPeriodMSec int64 `toml:"fetch_period_msec"`
+
+	// MaxQueueSize specifies the maximum size of the work queue
+	// i.e., the maximum number of span managers that can be queued
+	// in the background fetcher.
+	MaxQueueSize int `toml:"max_queue_size"`
 }

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
 	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
+	golang.org/x/time v0.2.0
 	google.golang.org/grpc v1.43.0
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
@@ -78,7 +79,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	google.golang.org/protobuf v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1191,8 +1191,9 @@ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.2.0 h1:52I/1L54xyEQAYdtcSuxtiT84KGYTBGXwayxmIpNJhE=
+golang.org/x/time v0.2.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION

This PR implements a global, rate-limited background fetcher. 

Features:

- `backgroundFetcher.silencePeriod`: Whenever a new layer comes in, all background fetches are suspended for `silencePeriod` (configurable)

- `backgroundFetcher.fetchPeriod`: At most 1 background fetch will be initiated every `fetchPeriod` (configurable)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
