### PR TITLE
Fixed image descriptor returned from csv. 

### DIFF
--- a/benchmark/utils.go
+++ b/benchmark/utils.go
@@ -40,18 +40,15 @@ func GetImageListFromCsv(csvLoc string) ([]ImageDescriptor, error) {
 	}
 	var images []ImageDescriptor
 	for _, image := range csv {
-		if len(image) < 3 {
+		if len(image) < 4 {
 			return nil, errors.New("image input is not sufficient")
-		}
-		var sociIndexManifestRef string
-		if len(image) == 4 {
-			sociIndexManifestRef = image[3]
 		}
 		images = append(images, ImageDescriptor{
 			ShortName:            image[0],
 			ImageRef:             image[1],
-			ReadyLine:            image[2],
-			SociIndexManifestRef: sociIndexManifestRef})
+			SociIndexManifestRef: image[2],
+			ReadyLine:            image[3],
+		})
 	}
 	return images, nil
 }


### PR DESCRIPTION
Soci benchmarks on ecr pull were failing since the image descriptors returned after reading the test csv mismatched the ReadyLine and SociIndexManifest properties.

Signed-off-by: Yasin Turan <turyasin@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
