### PR TITLE
[BENCHMARKS] Added a parser to the benchmark framework to collect fuse file access patterns

### DIFF
--- a/benchmark/framework/framework.go
+++ b/benchmark/framework/framework.go
@@ -46,7 +46,7 @@ type BenchmarkTestDriver struct {
 	NumberOfTests  int              `json:"numberOfTests"`
 	BeforeFunction func()           `json:"-"`
 	TestFunction   func(*testing.B) `json:"-"`
-	AfterFunction  func()           `json:"-"`
+	AfterFunction  func() error     `json:"-"`
 	TestsRun       int              `json:"-"`
 	TestTimes      []float64        `json:"testTimes"`
 	StdDev         float64          `json:"stdDev"`
@@ -77,7 +77,11 @@ func (frame *BenchmarkFramework) Run(ctx context.Context) {
 		}
 		testDriver.calculateStats()
 		if testDriver.AfterFunction != nil {
-			testDriver.AfterFunction()
+			err := testDriver.AfterFunction()
+			if err != nil {
+				fmt.Printf("After function error: %v\n", err)
+			}
+
 		}
 	}
 

--- a/benchmark/framework/parser/file_access.go
+++ b/benchmark/framework/parser/file_access.go
@@ -1,0 +1,177 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package bparser
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+var (
+	outputDir           = "./output/"
+	FileAccessDir       = outputDir + "file_access_logs/"
+	sociLogs            = outputDir + "soci-snapshotter-stderr"
+	containerdLogs      = outputDir + "containerd-stderr"
+	sociLogsFuseMessage = "FUSE operation"
+)
+
+type FileAccessPatterns struct {
+	ImageName           string         `json:"ImageName"`
+	ContainerStartTime  time.Time      `json:"containerStartTime"`
+	TotalOperationCount map[string]int `json:"TotalOperationCounts"`
+	Operations          []Operation    `json:"operations"`
+}
+
+type SociLog struct {
+	Msg string `json:"msg"`
+}
+type BaseOperation struct {
+	Level     string    `json:"level"`
+	Msg       string    `json:"msg"`
+	Operation string    `json:"operation"`
+	Path      string    `json:"path"`
+	Time      time.Time `json:"time"`
+}
+
+type Operation struct {
+	Operation                 string `json:"operation"`
+	Path                      string `json:"path"`
+	FirstAccessTimeAfterStart string `json:"firstAccessTimeAfterStart"`
+	Count                     int    `json:"count"`
+}
+
+func ParseFileAccesses(imageName string) error {
+	startTime, err := getTaskStartTime()
+	if err != nil {
+		return err
+	}
+	totalCounts := make(map[string]int)
+	fa := FileAccessPatterns{
+		ImageName:           imageName,
+		ContainerStartTime:  *startTime,
+		TotalOperationCount: totalCounts,
+	}
+	file, err := os.Open(sociLogs)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	b, err := io.ReadAll(file)
+	if err != nil {
+		return err
+	}
+
+	logs := strings.Split(string(b), "\n")
+
+	m := make(map[string]Operation)
+	for _, log := range logs {
+		sociLog := SociLog{}
+		if log != "" {
+			err := json.Unmarshal([]byte(log), &sociLog)
+			if err != nil {
+				return err
+			}
+
+		}
+		if sociLog.Msg == sociLogsFuseMessage {
+			var tempOperation BaseOperation
+			err := json.Unmarshal([]byte(log), &tempOperation)
+			if err != nil {
+				return err
+			}
+			op := tempOperation.Operation + tempOperation.Path
+
+			val, ok := m[op]
+
+			if ok {
+				val.Count = val.Count + 1
+				m[op] = val
+
+			} else {
+				m[op] = Operation{
+					Operation:                 tempOperation.Operation,
+					Path:                      tempOperation.Path,
+					FirstAccessTimeAfterStart: tempOperation.Time.Sub(fa.ContainerStartTime).String(),
+					Count:                     1,
+				}
+			}
+			count, ok := fa.TotalOperationCount[tempOperation.Operation]
+			if ok {
+				fa.TotalOperationCount[tempOperation.Operation] = count + 1
+			} else {
+				fa.TotalOperationCount[tempOperation.Operation] = 1
+			}
+		}
+	}
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.SliceStable(keys, func(i, j int) bool {
+		t1, _ := time.ParseDuration(m[keys[i]].FirstAccessTimeAfterStart)
+		t2, _ := time.ParseDuration(m[keys[j]].FirstAccessTimeAfterStart)
+		return t1 < t2
+	})
+
+	for _, key := range keys {
+		fa.Operations = append(fa.Operations, m[key])
+	}
+	json, err := json.MarshalIndent(fa, "", " ")
+	if err != nil {
+		return err
+	}
+	imageFileAccessLogPath := FileAccessDir + imageName + "_access_patterns"
+	err = os.WriteFile(imageFileAccessLogPath, json, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getTaskStartTime() (*time.Time, error) {
+	var taskStartTime time.Time
+	file, err := os.Open(containerdLogs)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	logs := strings.Split(string(data), "\n")
+	for i := len(logs) - 1; i >= 0; i-- {
+		log := logs[i]
+		if strings.Contains(log, "/tasks/start") {
+			l := strings.Split(log, " ")
+			temp := strings.ReplaceAll(l[0], "time=", "")
+			taskStartTime, err = time.Parse(time.RFC3339, temp[1:len(temp)-1])
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return &taskStartTime, nil
+}


### PR DESCRIPTION
Added a parser to the benchmark framework to collect fuse file access patterns.

This can be enabled by first adding `log_fuse_operations = true` to the soci_config.toml found within the benchmark framework to enable file access info collection. You can then add the optional flag `-parseFileAccessPatterns` or `-parseFileAccessPatterns=true` to the start of the `make benchmarks`  target and this will enable the parsing and logging of access patterns. This will run once for each image in the test set and output the results into a directory `.../performanceTest/output/file_access_logs` wherein there will be a parsed log file for each image. Each log will be named `<image name>_access_patterns`.

The parsed file access logs for an image will look like:

```
{
 "ImageName": "Rabbitmq",
 "containerStartTime": "2022-12-08T18:01:47.723749763Z",
 "TotalOperationCounts": {
  "Getattr": 6036,
  "Getxattr": 12671,
  "Listxattr": 4,
  "Open": 1943,
  "Read": 1443,
  "ReadLink": 428,
  "Readdir": 4872
 },
 "operations": [
     ...
     {
      "operation": "Getattr",
      "path": "usr/lib/x86_64-linux-gnu/libc-2.31.so",
      "firstAccessTimeAfterStart": "317.842289ms",
      "count": 8
    },
  ...
  ]
}
```

The parser will collect every *unique* fuse operation (a specific operation on a specific path) and note the amount of times that the fuse operation was called. It will also log the the amount of time after the the container start event in which the operation was invoked. The log file will be sorted by `firstAccessTimeAfterStart` with the first fuse operation at the top of log. The total count for each fuse operation will also be logged.

*Note*: make sure the soci grpc server was started with `--log-level debug` set. 

*Note:* It is worth noting that there will be negative values for `firstAccessTimeAfterStart` for the first few fuse operations. This is because there are still fuse operations happening before the invocation of `task.Start`. 

Signed-off-by: Yasin Turan <turyasin@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
