### PR TITLE
Add stargz running container to benchmarking test

### DIFF
--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -184,11 +184,21 @@ func StargzFullRun(
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
-	_, cleanupContainer, err := stargzContainerdProc.CreateContainer(ctx, image, containerd.WithSnapshotter("stargz"))
+	container, cleanupContainer, err := stargzContainerdProc.CreateContainer(ctx, image, containerd.WithSnapshotter("stargz"))
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
 	defer cleanupContainer()
+	taskDetails, cleanupTask, err := containerdProcess.CreateTask(ctx, container)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	defer cleanupTask()
+	cleanupRun, err := containerdProcess.RunContainerTaskForReadyLine(ctx, taskDetails, readyLine)
+	if err != nil {
+		b.Fatalf("%s", err)
+	}
+	defer cleanupRun()
 	b.StopTimer()
 }
 


### PR DESCRIPTION
*Issue #, if available:* #183

*Description of changes:* 
Add the step of stargz running container task in  benchmarking tests. Stargz's rpull was previously added.

*Testing performed:*
Ran ``make benchmarks-stargz`` with stargz images. Verified the results in ``benchmark/stargzTest/output/results.json`` are in order

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
