### PR TITLE
Get blob size from layer descriptors and remove redundant HTTP round trip

### DIFF
--- a/fs/remote/resolver_test.go
+++ b/fs/remote/resolver_test.go
@@ -143,20 +143,6 @@ func TestMirror(t *testing.T) {
 			wantHost: "backendexample.com",
 		},
 		{
-			name: "invalid-redirected-mirror",
-			tr: &sampleRoundTripper{
-				withCode: map[string]int{
-					"backendexample.com": http.StatusInternalServerError,
-				},
-				redirectURL: map[string]string{
-					regexp.QuoteMeta(fmt.Sprintf("mirrorexample.com%s", blobPath)): "https://backendexample.com/blobs/" + blobDigest.String(),
-				},
-				okURLs: []string{`.*`},
-			},
-			mirrors:  []string{"mirrorexample.com"},
-			wantHost: refHost,
-		},
-		{
 			name:     "fail-all",
 			tr:       &sampleRoundTripper{},
 			mirrors:  []string{"mirrorexample.com"},
@@ -180,7 +166,7 @@ func TestMirror(t *testing.T) {
 				}
 				return
 			}
-			fetcher, _, err := newHTTPFetcher(context.Background(), &fetcherConfig{
+			fetcher, err := newHTTPFetcher(context.Background(), &fetcherConfig{
 				hosts:   hosts,
 				refspec: refspec,
 				desc:    ocispec.Descriptor{Digest: blobDigest},


### PR DESCRIPTION
*Issue #, if available:* #229

*Description of changes:*
Removed the HTTP round trip call that is just for getting blob size when resolving blobs.

Instead, we get blob sizes from layer descriptors. Create a new label "targetImageLayersSizeLabel" to add blob sizes to layers' labels/annotations. The label is parsed during layer mount to get blob sizes.

*Testing performed:*
``make test``
``make integration``

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
