### PR TITLE
Metrics bookkeeping

### DIFF
--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -436,8 +436,8 @@ var _ = (fusefs.FileReader)((*file)(nil))
 
 func (f *file) Read(ctx context.Context, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
 	f.n.logOperation(ctx, "Read")
-	defer commonmetrics.MeasureLatencyInMicroseconds(commonmetrics.ReadOnDemand, f.n.fs.layerDigest, time.Now()) // measure time for on-demand file reads (in microseconds)
-	defer commonmetrics.IncOperationCount(commonmetrics.OnDemandReadAccessCount, f.n.fs.layerDigest)             // increment the counter for on-demand file accesses
+	defer commonmetrics.MeasureLatencyInMicroseconds(commonmetrics.SynchronousRead, f.n.fs.layerDigest, time.Now()) // measure time for synchronous file reads (in microseconds)
+	defer commonmetrics.IncOperationCount(commonmetrics.SynchronousReadCount, f.n.fs.layerDigest)                   // increment the counter for synchronous file reads
 	n, err := f.ra.ReadAt(dest, off)
 	if err != nil && err != io.EOF {
 		f.n.fs.s.report(fmt.Errorf("file.Read: %v", err))

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -65,12 +65,14 @@ const (
 	RemoteRegistryGet = "remote_registry_get"
 	NodeReaddir       = "node_readdir"
 	InitMetadataStore = "init_metadata_store"
-	ReadOnDemand      = "read_on_demand"
+	SynchronousRead   = "synchronous_read"
 
-	OnDemandReadAccessCount          = "on_demand_read_access_count"
-	OnDemandRemoteRegistryFetchCount = "on_demand_remote_registry_fetch_count"
-	OnDemandBytesServed              = "on_demand_bytes_served"
-	OnDemandBytesFetched             = "on_demand_bytes_fetched"
+	SynchronousReadCount              = "synchronous_read_count"
+	SynchronousReadRegistryFetchCount = "synchronous_read_remote_registry_fetch_count" // TODO revisit (wrong place)
+	SynchronousBytesServed            = "synchronous_bytes_served"
+
+	// TODO this metric is not available now. This needs to go down to BlobReader where the actuall http call is issued
+	SynchronousBytesFetched = "synchronous_bytes_fetched"
 )
 
 var (

--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -227,14 +227,15 @@ func (sf *file) ReadAt(p []byte, offset int64) (int, error) {
 		return 0, errors.Wrap(err, "failed to read the file")
 	}
 
-	commonmetrics.IncOperationCount(commonmetrics.OnDemandRemoteRegistryFetchCount, sf.gr.layerSha) // increment the number of on demand file fetches from remote registry
+	// TODO this is not the right place for this metric to be. It needs to go down the BlobReader, when the HTTP request is issued
+	commonmetrics.IncOperationCount(commonmetrics.SynchronousReadRegistryFetchCount, sf.gr.layerSha) // increment the number of on demand file fetches from remote registry
 	sf.gr.setLastReadTime(time.Now())
 
 	n, err := io.ReadFull(r, p[0:expectedSize])
 	if err != nil {
 		return 0, fmt.Errorf("unexpected copied data size for on-demand fetch. read = %d, expected = %d", n, expectedSize)
 	}
-	commonmetrics.AddBytesCount(commonmetrics.OnDemandBytesServed, sf.gr.layerSha, int64(n)) // measure the number of on demand bytes served
+	commonmetrics.AddBytesCount(commonmetrics.SynchronousBytesServed, sf.gr.layerSha, int64(n)) // measure the number of bytes served synchronously
 
 	return n, nil
 }


### PR DESCRIPTION
Signed-off-by: Viktor Kuznietsov <vkuzniet@amazon.com>

*Issue #, if available:*
#153 

*Description of changes:*
Renaming the metrics starting with `OnDemand` to `Synchronous`, which is much better naming and was suggested in #185.

Also this PR identifies two metrics, which do not correspond reality anymore:
1. SynchronousReadRegistryFetchCount (is in the wrong place)
2. SynchronousBytesFetched does not exist in the code base anymore.
Both metrics need to reside within BlobReader to be recorded when doing the actual HTTP call. 

*Testing performed:*
- `make test && make check && make integration` pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
