### PR TITLE
`soci push` always pushes the most recent index

### DIFF
--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -18,6 +18,7 @@ package integration
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
@@ -108,8 +109,111 @@ level = "debug"
 			}
 		})
 	}
-
 }
+
+func TestPushAlwaysMostRecentlyCreatedIndex(t *testing.T) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	getContainerdConfigYaml := func(disableVerification bool) []byte {
+		additionalConfig := ""
+		if !isTestingBuiltinSnapshotter() {
+			additionalConfig = proxySnapshotterConfig
+		}
+		return []byte(testutil.ApplyTextTemplate(t, `
+version = 2
+
+[plugins."io.containerd.snapshotter.v1.soci"]
+root_path = "/var/lib/soci-snapshotter-grpc/"
+disable_verification = {{.DisableVerification}}
+
+[plugins."io.containerd.snapshotter.v1.soci".blob]
+check_always = true
+
+[debug]
+format = "json"
+level = "debug"
+
+{{.AdditionalConfig}}
+`, struct {
+			DisableVerification bool
+			AdditionalConfig    string
+		}{
+			DisableVerification: disableVerification,
+			AdditionalConfig:    additionalConfig,
+		}))
+	}
+	getSnapshotterConfigYaml := func(disableVerification bool) []byte {
+		return []byte(fmt.Sprintf("disable_verification = %v", disableVerification))
+	}
+
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(false), 0600); err != nil {
+		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
+	}
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(false), 0600); err != nil {
+		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
+	}
+
+	type buildOpts struct {
+		spanSize     int
+		minLayerSize int
+	}
+
+	testCases := []struct {
+		name  string
+		image string
+		opts  []buildOpts
+	}{
+		{
+			name: "rabbitmq",
+			// Pinning a specific image, so that this test is guaranteed to fail in case of any regressions.
+			image: "rabbitmq@sha256:603be6b7fd5f1d8c6eab8e7a234ed30d664b9356ec1b87833f3a46bb6725458e",
+			opts: []buildOpts{
+				{
+					spanSize:     1 << 22,  // 4MiB
+					minLayerSize: 10 << 20, // 10MiB
+				},
+				{
+					spanSize:     128000,
+					minLayerSize: 10 << 20,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rebootContainerd(t, sh, "", "")
+
+			copyImage(sh, dockerhub(tc.image), regConfig.mirror(tc.image))
+
+			for _, opt := range tc.opts {
+				index := optimizeImageWithOpts(sh, regConfig.mirror(tc.image), opt.spanSize, opt.minLayerSize)
+				index = strings.Split(index, "\n")[0]
+				out := sh.O("soci", "push", "--user", regConfig.creds(), regConfig.mirror(tc.image).ref, "-q")
+				pushedIndex := strings.Trim(string(out), "\n")
+
+				if index != pushedIndex {
+					t.Fatalf("incorrect index pushed to remote registry; expected %s, got %s", index, pushedIndex)
+				}
+			}
+		})
+	}
+}
+
+// TODO: There is a bit of duplication going on here.
+// The `optimizeImage` function does not allow passing a specific span size.
+// Should refactor that function to do so and remove this function.
+func optimizeImageWithOpts(sh *shell.Shell, src imageInfo, spanSize, minLayerSize int) string {
+	pullOpts := encodeImageInfo(src)
+	indexDigest := sh.
+		X(append([]string{"ctr", "i", "pull", "--platform", platforms.Format(src.platform)}, pullOpts[0]...)...).
+		X("soci", "create", src.ref, "--min-layer-size", fmt.Sprintf("%d", minLayerSize), "--span-size", fmt.Sprintf("%d", spanSize), "--platform", platforms.Format(src.platform)).
+		O("soci", "index", "list", "-q", "--ref", src.ref, "--platform", platforms.Format(src.platform)) // this will make SOCI artifact available locally
+	return strings.Trim(string(indexDigest), "\n")
+}
+
 func getSociLocalStoreContentDigest(sh *shell.Shell) digest.Digest {
 	content := sh.O("ls", "/var/lib/soci-snapshotter-grpc/content/blobs/sha256")
 	return digest.FromBytes(content)

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/awslabs/soci-snapshotter/ztoc"
 	"github.com/containerd/containerd/content"
@@ -85,10 +86,12 @@ type IndexWithMetadata struct {
 	Index       *Index
 	Platform    *ocispec.Platform
 	ImageDigest digest.Digest
+	CreatedAt   time.Time
 }
 
 type IndexDescriptorInfo struct {
 	ocispec.Descriptor
+	CreatedAt time.Time
 }
 
 func GetIndexDescriptorCollection(ctx context.Context, cs content.Store, img images.Image, ps []ocispec.Platform) ([]IndexDescriptorInfo, error) {
@@ -119,6 +122,7 @@ func GetIndexDescriptorCollection(ctx context.Context, cs content.Store, img ima
 		}
 		descriptors = append(descriptors, IndexDescriptorInfo{
 			Descriptor: desc,
+			CreatedAt:  entry.CreatedAt,
 		})
 	}
 
@@ -242,6 +246,7 @@ func (b *IndexBuilder) Build(ctx context.Context, img images.Image) (*IndexWithM
 		Index:       index,
 		Platform:    &b.config.platform,
 		ImageDigest: img.Target.Digest,
+		CreatedAt:   time.Now(),
 	}, nil
 }
 
@@ -339,6 +344,7 @@ func (b *IndexBuilder) buildSociLayer(ctx context.Context, desc ocispec.Descript
 		Type:           ArtifactEntryTypeLayer,
 		Location:       desc.Digest.String(),
 		MediaType:      SociLayerMediaType,
+		CreatedAt:      time.Now(),
 	}
 	err = writeArtifactEntry(entry)
 	if err != nil {
@@ -415,6 +421,7 @@ func WriteSociIndex(ctx context.Context, indexWithMetadata *IndexWithMetadata, s
 		Location:       refers.Digest.String(),
 		Size:           size,
 		MediaType:      indexWithMetadata.Index.MediaType,
+		CreatedAt:      indexWithMetadata.CreatedAt,
 	}
 	return writeArtifactEntry(entry)
 }


### PR DESCRIPTION
This commit fixes a bug in `soci push` where it was not always guaranteed to push the most recently created index. Added a `CreatedAt` value to each entry in the artifacts db.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*
Fixes #242 

*Description of changes:*

*Testing performed:*

```
% sudo ./soci index ls 
DIGEST                                                                     SIZE    IMAGE REF                            PLATFORM

% sudo ./soci create docker.io/library/rabbitmq:latest

% sudo ./soci index ls
DIGEST                                                                     SIZE    IMAGE REF                            PLATFORM       CREATED      
sha256:f117044f3ed73c5fb9780ca4a2ba50dc2f1bfa1aaf320738bb007cb73982df6a    1436    docker.io/library/rabbitmq:latest    linux/amd64    5s ago   

% sudo ./soci push docker.io/library/rabbitmq:latest 
pushing soci index with digest: sha256:f117044f3ed73c5fb9780ca4a2ba50dc2f1bfa1aaf320738bb007cb73982df6a


% sudo ./soci index ls                                                   
DIGEST                                                                     SIZE    IMAGE REF                            PLATFORM       CREATED      
sha256:77ba6f5324398e1b3f1344339b74ec6fb66c8eff51d8e8caa66677070ea684da    1438    docker.io/library/rabbitmq:latest    linux/amd64    6s ago       
sha256:f117044f3ed73c5fb9780ca4a2ba50dc2f1bfa1aaf320738bb007cb73982df6a    1436    docker.io/library/rabbitmq:latest    linux/amd64    1m26s ago   

% sudo ./soci push docker.io/library/rabbitmq:latest                     
pushing soci index with digest: sha256:77ba6f5324398e1b3f1344339b74ec6fb66c8eff51d8e8caa66677070ea684da
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
