### PR TITLE
Add integration test for arbitrary ztoc blobs

### DIFF
--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -442,3 +442,9 @@ func getManifestDigest(sh *shell.Shell, ref string, platform spec.Platform) (str
 	}
 	return "", fmt.Errorf("could not find manifest for %s for platform %s", ref, platforms.Format(platform))
 }
+
+func genRandomByteData(size int64) []byte {
+	b := make([]byte, size)
+	rand.Read(b)
+	return b
+}


### PR DESCRIPTION
This commit adds an integration test to verify snapshotter functionality when an arbitrary blob is passed as a ztoc to the snapshotter. In this case, instead of mounting the layer as a FUSE mount for lazy-loading, the snapshotter will download the entire layer and mount it as a normal overlayfs mount.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
