### PR TITLE
Allow metrics to listen on a unix socket

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -1,0 +1,66 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import "testing"
+
+const (
+	tcpMetricsAddress  = "localhost:1338"
+	unixMetricsAddress = "/var/lib/soci-snapshotter-grpc/metrics.sock"
+	metricsPath        = "/metrics"
+)
+
+const tcpMetricsConfig = `
+metrics_address="` + tcpMetricsAddress + `"
+`
+
+const unixMetricsConfig = `
+metrics_address="` + unixMetricsAddress + `"
+metrics_network="unix"
+`
+
+func TestMetrics(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		command []string
+	}{
+		{
+			name:    "tcp",
+			config:  tcpMetricsConfig,
+			command: []string{"curl", "--fail", tcpMetricsAddress + metricsPath},
+		},
+		{
+			name:    "unix",
+			config:  unixMetricsConfig,
+			command: []string{"curl", "--fail", "--unix-socket", unixMetricsAddress, "http://localhost" + metricsPath},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sh, done := newSnapshotterBaseShell(t)
+			defer done()
+			rebootContainerd(t, sh, "", tt.config)
+			sh.X(tt.command...)
+			if err := sh.Err(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION


*Issue #, if available:*
closes #256 

*Description of changes:*
This change allows the snapshotter to be configured to listen on a unix socket for serving metrics. This can be useful when the snapshotter runs in an environment where we don't want to consume a port (e.g. because we expect another program to bind 0.0.0.0 to the same port).

Signed-off-by: Kern Walster <walster@amazon.com>

*Testing performed:*
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
