### PR TITLE
Add metrics for overlayfs fallback

### DIFF
--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -73,6 +73,10 @@ const (
 
 	// TODO this metric is not available now. This needs to go down to BlobReader where the actuall http call is issued
 	SynchronousBytesFetched = "synchronous_bytes_fetched"
+
+	// Number of times the snapshotter falls back to use a normal overlay mount instead of mounting the layer as a FUSE mount.
+	// Note that a layer not having a ztoc is NOT classified as an error, even though `fs.Mount` returns an error in that case.
+	FuseMountFailureCount = "fuse_mount_failure_count"
 )
 
 var (

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -16,7 +16,15 @@
 
 package integration
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	commonmetrics "github.com/awslabs/soci-snapshotter/fs/metrics/common"
+	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
+	"github.com/awslabs/soci-snapshotter/util/testutil"
+)
 
 const (
 	tcpMetricsAddress  = "localhost:1338"
@@ -63,4 +71,124 @@ func TestMetrics(t *testing.T) {
 		})
 	}
 
+}
+
+func TestOverlayFallbackMetric(t *testing.T) {
+	regConfig := newRegistryConfig()
+	getContainerdConfigYaml := func(disableVerification bool) []byte {
+		additionalConfig := ""
+		if !isTestingBuiltinSnapshotter() {
+			additionalConfig = proxySnapshotterConfig
+		}
+		return []byte(testutil.ApplyTextTemplate(t, `
+version = 2
+
+[plugins."io.containerd.snapshotter.v1.soci"]
+root_path = "/var/lib/soci-snapshotter-grpc/"
+disable_verification = {{.DisableVerification}}
+
+[plugins."io.containerd.snapshotter.v1.soci".blob]
+check_always = true
+
+[debug]
+format = "json"
+level = "debug"
+
+{{.AdditionalConfig}}
+`, struct {
+			DisableVerification bool
+			AdditionalConfig    string
+		}{
+			DisableVerification: disableVerification,
+			AdditionalConfig:    additionalConfig,
+		}))
+	}
+	getSnapshotterConfigYaml := func(disableVerification bool) []byte {
+		return []byte(fmt.Sprintf(`
+metrics_address = "localhost:6060"
+disable_verification = %v
+`, disableVerification))
+	}
+
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(false), 0600); err != nil {
+		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
+	}
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(false), 0600); err != nil {
+		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
+	}
+
+	testCases := []struct {
+		name                  string
+		image                 string
+		indexDigestFn         func(*shell.Shell, imageInfo) string
+		expectedFallbackCount int
+	}{
+		{
+			name:  "image with all layers having ztocs and no fs.Mount error results in 0 overlay fallback",
+			image: "rabbitmq:latest",
+			indexDigestFn: func(sh *shell.Shell, image imageInfo) string {
+				return optimizeImageWithOpts(sh, image, 1<<22, 0)
+			},
+			expectedFallbackCount: 0,
+		},
+		{
+			name:  "image with some layers not having ztoc and no fs.Mount results in 0 overlay fallback",
+			image: "rabbitmq:latest",
+			indexDigestFn: func(sh *shell.Shell, image imageInfo) string {
+				return optimizeImageWithOpts(sh, image, 1<<22, 10<<20)
+			},
+			expectedFallbackCount: 0,
+		},
+		{
+			name:  "image with fs.Mount errors results in non-zero overlay fallback",
+			image: "rabbitmq:latest",
+			indexDigestFn: func(_ *shell.Shell, _ imageInfo) string {
+				return "dwadwadawdad"
+			},
+			expectedFallbackCount: 10,
+		},
+	}
+
+	checkOverlayFallbackCount := func(output string, expected int) error {
+		lines := strings.Split(output, "\n")
+		for _, line := range lines {
+			if !strings.Contains(line, commonmetrics.FuseMountFailureCount) {
+				continue
+			}
+			var got int
+			_, err := fmt.Sscanf(line, `soci_fs_operation_count{layer="",operation_type="fuse_mount_failure_count"} %d`, &got)
+			if err != nil {
+				return err
+			}
+			if got != expected {
+				return fmt.Errorf("unexpected overlay fallbacks: got %d, expected %d", got, expected)
+			}
+			return nil
+		}
+		if expected != 0 {
+			return fmt.Errorf("expected %d overlay fallbacks but got 0", expected)
+		}
+		return nil
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rebootContainerd(t, sh, "", "")
+
+			imgInfo := dockerhub(tc.image)
+
+			sh.X("ctr", "i", "pull", imgInfo.ref)
+			indexDigest := tc.indexDigestFn(sh, imgInfo)
+
+			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
+			curlOutput := string(sh.O("curl", "localhost:6060/metrics"))
+
+			if err := checkOverlayFallbackCount(curlOutput, tc.expectedFallbackCount); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This commit adds a metric `overlay_mount_fallback_count` for when the snapshotter falls back to using overlayfs instead of FUSE mount for mounting the layer.

Note that a layer not having a corresponding ztoc is NOT classified as an error, even though `fs.Mount` returns an error in that case and the layer is mounted as a normal overlayfs mount.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*
Resolves #263 


*Testing performed:*

1) Pulling an image with some layers not having corresponding ztoc does not increase metric.

```
% sudo ./soci create docker.io/library/rabbitmq:latest
layer sha256:cae1c228689d2f294439828746d67d06536e5cf331393d0529e18ce4c8f222f8 -> ztoc skipped
layer sha256:2fa407913eb6838a8d49fffcfb8a03cf3c0baa23f3744a8e40947031171c97a6 -> ztoc skipped
layer sha256:92e035229b114a43bd976252b210632f191d41ae606b4eafaf029f0d06c0f454 -> ztoc skipped
layer sha256:c17f6444939027393a0458ce0a87ed947fc83abeb8f29f24ee93a418d33b141c -> ztoc skipped
layer sha256:34bc881cb21a868fef333c95673b993c83a9c9ce4f62d320e73191cb453ef582 -> ztoc skipped
layer sha256:dd3bdcc0ac44e0e8e87eb1f7f7703302579ca7016343eb675cfd96dffb00ff01 -> ztoc skipped
layer sha256:03dea6b5e70e630bb5bf621528463788e46cf2571f98f3f591e10633f1b650d9 -> ztoc skipped
layer sha256:c07a0c5fb44ca573ef37ad94dc3c0456f08c49b4e7591a9fde8a04dd2e29c143 -> ztoc sha256:4311ab5a6df31034221275c229463cdd07102971a2ffd9873f8fed7486e12233
layer sha256:846c0b181fff0c667d9444f8378e8fcfa13116da8d308bf21673f7e4bea8d580 -> ztoc sha256:38902e5b8587d142e2dbc2f16bbcb045e02a8de9ad38f7c91427fbe62a937f1c
layer sha256:3ddf939b446499c0937604d712f7e13340db9687e710d61c8b0b278700ba9e38 -> ztoc sha256:1ab89fcafc5d2353b92cfb73d3ffde91ed3e5a272309e132dde828f0bd5cca15

% sudo ./soci index ls
DIGEST                                                                     SIZE    IMAGE REF                            PLATFORM       CREATED    
sha256:f117044f3ed73c5fb9780ca4a2ba50dc2f1bfa1aaf320738bb007cb73982df6a    1436    docker.io/library/rabbitmq:latest    linux/amd64    25s ago    

sudo ./soci image rpull --soci-index-digest sha256:f117044f3ed73c5fb9780ca4a2ba50dc2f1bfa1aaf320738bb007cb73982df6a docker.io/library/rabbitmq:latest
fetching sha256:90c62dd5... application/vnd.docker.distribution.manifest.list.v2+json
fetching sha256:603be6b7... application/vnd.docker.distribution.manifest.v2+json
fetching sha256:3ddcc140... application/vnd.docker.container.image.v1+json

% curl localhost:6060/metrics | grep fallback_count
 // Empty output, equivalent to 0
 ```
 
 2) Pulling an image with invalid SOCI digest results in non-zero metrics count.
 
 ```
 % sudo ./soci image rpull --soci-index-digest fafafafafafafa docker.io/library/rabbitmq:latest
fetching sha256:90c62dd5... application/vnd.docker.distribution.manifest.list.v2+json
fetching sha256:603be6b7... application/vnd.docker.distribution.manifest.v2+json
fetching sha256:3ddcc140... application/vnd.docker.container.image.v1+json


% curl localhost:6060/metrics | grep fallback_count 
soci_fs_operation_count{layer="",operation_type="overlay_mount_fallback_count"} 10 // number of layers pulled synchronously
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
