### PR TITLE
Configurable layer mount timeout

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	MaxConcurrency                   int64  `toml:"max_concurrency"`
 	NoPrometheus                     bool   `toml:"no_prometheus"`
 	PrioritizedTaskSilencePeriodMSec int    `toml:"prioritized_task_silence_period_msec"`
+	MountTimeoutSec                  int    `toml:"mount_timeout_sec"`
 
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob"`


### PR DESCRIPTION
*Issue #, if available:* #249

*Description of changes:*
Make layer mount timeout configurable, defaulting to 30 seconds. It can be set in the config toml file of the snapshotter.

*Testing performed:*
- ``make test``, ``make integration``. 
- Set ``mount_timeout`` in the snapshotter's config file, made the layer resolving pending, and verified ``Mount`` timed out after ``mount_timeout`` seconds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
