### PR TITLE
Add fuse operation failure metrics

### DIFF
--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -71,6 +71,17 @@ const (
 	SynchronousReadRegistryFetchCount = "synchronous_read_remote_registry_fetch_count" // TODO revisit (wrong place)
 	SynchronousBytesServed            = "synchronous_bytes_served"
 
+	// fuse operation failure metrics
+	FuseNodeGetattrFailureCount     = "fuse_node_getattr_failure_count"
+	FuseNodeListxattrFailureCount   = "fuse_node_listxattr_failure_count"
+	FuseNodeLookupFailureCount      = "fuse_node_lookup_failure_count"
+	FuseNodeOpenFailureCount        = "fuse_node_open_failure_count"
+	FuseNodeReaddirFailureCount     = "fuse_node_readdir_failure_count"
+	FuseFileReadFailureCount        = "fuse_file_read_failure_count"
+	FuseFileGetattrFailureCount     = "fuse_file_getattr_failure_count"
+	FuseWhiteoutGetattrFailureCount = "fuse_whiteout_getattr_failure_count"
+	FuseUnknownFailureCount         = "fuse_unknown_operation_failure_count"
+
 	// TODO this metric is not available now. This needs to go down to BlobReader where the actuall http call is issued
 	SynchronousBytesFetched = "synchronous_bytes_fetched"
 
@@ -122,7 +133,7 @@ var (
 		[]string{"operation_type", "layer"},
 	)
 
-	// bytesCount reflects the number of bytes served as the part of specitic operation type per layer sha.
+	// bytesCount reflects the number of bytes served as the part of specific operation type per layer sha.
 	bytesCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -17,13 +17,22 @@
 package integration
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"math"
+	"strconv"
 	"strings"
 	"testing"
 
 	commonmetrics "github.com/awslabs/soci-snapshotter/fs/metrics/common"
+	"github.com/awslabs/soci-snapshotter/soci"
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
 	"github.com/awslabs/soci-snapshotter/util/testutil"
+	"github.com/awslabs/soci-snapshotter/ztoc"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (
@@ -156,5 +165,176 @@ func TestOverlayFallbackMetric(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestFuseOperationFailureMetrics(t *testing.T) {
+	regConfig := newRegistryConfig()
+
+	logFuseOperationConfig := `
+[fuse]
+log_fuse_operations = true
+`
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
+		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
+	}
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false, tcpMetricsConfig, logFuseOperationConfig), 0600); err != nil {
+		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
+	}
+
+	manipulateZtocMetadata := func(zt *ztoc.Ztoc) {
+		for i, md := range zt.TOC.Metadata {
+			md.UncompressedOffset += 2
+			md.UncompressedSize = math.MaxInt64
+			md.Xattrs = map[string]string{"foo": "bar"}
+			zt.TOC.Metadata[i] = md
+		}
+	}
+
+	testCases := []struct {
+		name                       string
+		image                      string
+		indexDigestFn              func(*testing.T, *shell.Shell, imageInfo) string
+		metricToCheck              string
+		expectFuseOperationFailure bool
+	}{
+		{
+			name:  "image with valid ztocs and index doesn't cause fuse file.read failures",
+			image: rabbitmqImage,
+			indexDigestFn: func(t *testing.T, sh *shell.Shell, image imageInfo) string {
+				return optimizeImageWithOpts(sh, image, 1<<22, 0)
+			},
+			// even a valid index/ztoc produces some fuse operation failures such as
+			// node.lookup and node.getxattr failures, so we only check a specific fuse failure metric.
+			metricToCheck:              commonmetrics.FuseFileReadFailureCount,
+			expectFuseOperationFailure: false,
+		},
+		{
+			name:  "image with valid-formatted but invalid-data ztocs causes fuse file.read failures",
+			image: rabbitmqImage,
+			indexDigestFn: func(t *testing.T, sh *shell.Shell, image imageInfo) string {
+				indexDigest, err := buildIndexByManipulatingZtocData(sh, optimizeImageWithOpts(sh, image, 1<<22, 0), manipulateZtocMetadata)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return indexDigest
+			},
+			metricToCheck:              commonmetrics.FuseFileReadFailureCount,
+			expectFuseOperationFailure: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rebootContainerd(t, sh, "", "")
+
+			imgInfo := dockerhub(tc.image)
+			sh.X("ctr", "i", "pull", imgInfo.ref)
+			indexDigest := tc.indexDigestFn(t, sh, imgInfo)
+
+			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
+			// this command may fail due to fuse operation failure, use XLog to avoid crashing shell
+			sh.XLog("ctr", "run", "--rm", "--snapshotter=soci", imgInfo.ref, "test", "echo", "hi")
+
+			curlOutput := string(sh.O("curl", tcpMetricsAddress+metricsPath))
+			checkFuseOperationFailureMetrics(t, curlOutput, tc.metricToCheck, tc.expectFuseOperationFailure)
+		})
+	}
+}
+
+// buildIndexByManipulatingZtocData produces a new soci index by manipulating
+// the ztocs of an existing index specified by `indexDigest`.
+//
+// The new index (and ztocs) are stored separately and the original index keeps unchanged.
+// The manipulated ztocs are (de)serializable but have meaningless ztoc data (manipuated by `manipulator`).
+// This helps test soci behaviors when ztocs have valid format but wrong/corrupted data.
+func buildIndexByManipulatingZtocData(sh *shell.Shell, indexDigest string, manipulator func(*ztoc.Ztoc)) (string, error) {
+	index, err := sociIndexFromDigest(sh, indexDigest)
+	if err != nil {
+		return "", err
+	}
+
+	var ztocDescs []ocispec.Descriptor
+	for _, blob := range index.Blobs {
+		ztocDigest := blob.Digest.String()
+		blobContent := fetchContentFromPath(sh, blobStorePath+"/"+trimSha256Prefix(ztocDigest))
+		zt, err := ztoc.Unmarshal(bytes.NewReader(blobContent))
+		if err != nil {
+			return "", fmt.Errorf("invalid ztoc %s from soci index %s: %v", ztocDigest, indexDigest, err)
+		}
+
+		// manipulate the ztoc
+		manipulator(zt)
+
+		ztocReader, ztocDesc, err := ztoc.Marshal(zt)
+		if err != nil {
+			return "", fmt.Errorf("unable to marshal ztoc %s: %s", ztocDesc.Digest.String(), err)
+		}
+		ztocBytes, err := io.ReadAll(ztocReader)
+		if err != nil {
+			return "", fmt.Errorf("unable to read bytes of ztoc %s: %s", ztocDesc.Digest.String(), err)
+		}
+
+		ztocPath := fmt.Sprintf("%s/%s", blobStorePath, trimSha256Prefix(ztocDesc.Digest.String()))
+		if err := testutil.WriteFileContents(sh, ztocPath, ztocBytes, 0600); err != nil {
+			return "", fmt.Errorf("cannot write ztoc %s to path %s: %s", ztocDesc.Digest.String(), ztocPath, err)
+		}
+
+		ztocDesc.MediaType = soci.SociLayerMediaType
+		ztocDesc.Annotations = blob.Annotations
+		ztocDescs = append(ztocDescs, ztocDesc)
+	}
+
+	newIndex := soci.Index{
+		MediaType:    soci.OCIArtifactManifestMediaType,
+		ArtifactType: soci.SociIndexArtifactType,
+		Blobs:        ztocDescs,
+		Subject: &ocispec.Descriptor{
+			MediaType: soci.OCIArtifactManifestMediaType,
+			Digest:    index.Subject.Digest,
+			Size:      index.Subject.Size,
+		},
+	}
+
+	b, err := json.Marshal(newIndex)
+	if err != nil {
+		return "", err
+	}
+
+	newIndexDigest := digest.FromBytes(b)
+	newIndexPath := fmt.Sprintf("%s/%s", blobStorePath, trimSha256Prefix(newIndexDigest.String()))
+	if err := testutil.WriteFileContents(sh, newIndexPath, b, 0600); err != nil {
+		return "", fmt.Errorf("cannot write index %s to path %s: %s", newIndexDigest, newIndexPath, err)
+	}
+	return strings.Trim(newIndexDigest.String(), "\n"), nil
+}
+
+// checkFuseOperationFailureMetrics checks if output from metrics endpoint includes
+// a specific fuse operation failure metrics (or any fuse op failure if an empty string is given)
+func checkFuseOperationFailureMetrics(t *testing.T, output string, metricToCheck string, expectOpFailure bool) {
+	metricCountSum := 0
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		// skip non-fuse and fuse_mount_failure_count metrics
+		if !strings.Contains(line, "fuse") || strings.Contains(line, commonmetrics.FuseMountFailureCount) {
+			continue
+		}
+
+		parts := strings.Split(line, " ")
+		if metricCount, err := strconv.Atoi(parts[len(parts)-1]); err == nil && metricCount != 0 {
+			t.Logf("fuse operation failure metric: %s", line)
+			if metricToCheck == "" || strings.Contains(line, metricToCheck) {
+				metricCountSum += metricCount
+			}
+		}
+	}
+
+	if (metricCountSum != 0) != expectOpFailure {
+		t.Fatalf("incorrect fuse operation failure metrics. metric: %s, total operation failure count: %d, expect fuse operation failure: %t",
+			metricToCheck, metricCountSum, expectOpFailure)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Jin Dong <jindon@amazon.com>

*Issue #, if available:*

Fix #274

*Description of changes:*

1. Add failure count metric for fuse operations
2. Format op name strings to const

*Testing performed:*

`make test && make check && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
