### PR TITLE
Add test to confirm image removal results in fuse unmounting

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/util/testutil"
 )
 
-// TestRunMultipleContainers multiple containers at the same time and performs a test in each
+// TestRunMultipleContainers runs multiple containers at the same time and performs a test in each
 func TestRunMultipleContainers(t *testing.T) {
 
 	tests := []struct {


### PR DESCRIPTION
*Issue #, if available:*
closes #175 

*Description of changes:*
Add an integration test that pulls and rpulls an image, confirms the presence of fuse mounts, then removes the image and confirms the fuse mounts have been unmounted.

*Testing performed:*
Ran the test with additional debug logging to check status of image and mounts between test steps.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.