### PR TITLE
Improve "soci index info" command w/ ztoc digest as input

### DIFF
--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -18,10 +18,13 @@ package index
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/soci"
+
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
@@ -38,6 +41,17 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
+		db, err := soci.NewDB()
+		if err != nil {
+			return err
+		}
+		artifactType, err := db.GetArtifactType(digest.String())
+		if err != nil {
+			return err
+		}
+		if artifactType == soci.ArtifactEntryTypeLayer {
+			return fmt.Errorf("the provided digest is of ztoc not SOCI index. Use \"soci ztoc info\" command to get detailed info of ztoc")
+		}
 		storage, err := oci.New(config.SociContentStorePath)
 		if err != nil {
 			return err
@@ -52,6 +66,5 @@ var infoCommand = cli.Command{
 
 		_, err = io.Copy(os.Stdout, reader)
 		return err
-
 	},
 }

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -137,7 +137,7 @@ func TestOptimizeConsistentSociArtifact(t *testing.T) {
 					// skipping artifacts.db, since this is bbolt file and we have no control over its internals
 					continue
 				}
-				out := sh.OLog("cmp", filepath.Join("soci", fn), filepath.Join("copy", "soci", fn))
+				out, _ := sh.OLog("cmp", filepath.Join("soci", fn), filepath.Join("copy", "soci", fn))
 				if string(out) != "" {
 					t.Fatalf("the artifact is different: %v", string(out))
 				}

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -203,6 +203,15 @@ func (db *ArtifactsDb) GetArtifactEntry(digest string) (*ArtifactEntry, error) {
 	return &entry, nil
 }
 
+// GetArtifactType gets Type of an ArtifactEntry from the ArtifactsDB by digest
+func (db *ArtifactsDb) GetArtifactType(digest string) (ArtifactEntryType, error) {
+	ae, err := db.GetArtifactEntry(digest)
+	if err != nil {
+		return "", err
+	}
+	return ae.Type, nil
+}
+
 // RemoveArtifactEntryByIndexDigest removes an index's artifact entry using its digest
 func (db *ArtifactsDb) RemoveArtifactEntryByIndexDigest(digest string) error {
 	return db.db.Update(func(tx *bolt.Tx) error {

--- a/util/dockershell/shell.go
+++ b/util/dockershell/shell.go
@@ -323,13 +323,13 @@ func (s *Shell) O(args ...string) []byte {
 
 // OLog executes a command and return the stdout. Stdio is streamed to Reporter. When the command fails, different from O,
 // the error is reported via Reporter.Logf and this Shell still *accepts* further command execution.
-func (s *Shell) OLog(args ...string) []byte {
+func (s *Shell) OLog(args ...string) ([]byte, error) {
 	if s.IsInvalid() {
-		return nil
+		return nil, fmt.Errorf("invalid shell")
 	}
 	if len(args) < 1 {
 		s.fatal("no command to run")
-		return nil
+		return nil, fmt.Errorf("no command to run")
 	}
 	s.r.Logf(">>> Getting output of: %v\n", args)
 	cmd := s.Command(args[0], args[1:]...)
@@ -337,8 +337,9 @@ func (s *Shell) OLog(args ...string) []byte {
 	out, err := cmd.Output()
 	if err != nil {
 		s.r.Logf("failed to run for getting output from %v: %v", args, err)
+		return out, err
 	}
-	return out
+	return out, nil
 }
 
 // R executes a command. Stdio is returned as io.Reader. streamed to Reporter.


### PR DESCRIPTION
*Issue #, if available:* #258

*Description of changes:*
When given a ztoc digest as input, "soci index info" command returns an error message pointing users to use "soci ztoc info" instead.

*Testing performed:*
make test, make integration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
