### PR TITLE
Refactor/deduplicate intergration test code

### DIFF
--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -29,8 +29,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-const blobStorePath = "/var/lib/soci-snapshotter-grpc/content/blobs/sha256"
-
 func TestSociCreateSparseIndex(t *testing.T) {
 	sh, done := newSnapshotterBaseShell(t)
 	defer done()

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -103,32 +103,32 @@ func TestSociCreate(t *testing.T) {
 		platform       string
 	}{
 		{
-			name:           "test create for ubuntu:latest",
-			containerImage: "ubuntu:latest",
+			name:           "test create for ubuntu",
+			containerImage: ubuntuImage,
 		},
 		{
-			name:           "test create for nginx:latest",
-			containerImage: "nginx:latest",
+			name:           "test create for nginx",
+			containerImage: nginxImage,
 		},
 		{
-			name:           "test create for alpine:latest",
-			containerImage: "alpine:latest",
+			name:           "test create for alpine",
+			containerImage: alpineImage,
 		},
 		{
-			name:           "test create for drupal:latest",
-			containerImage: "drupal:latest",
+			name:           "test create for drupal",
+			containerImage: drupalImage,
 		},
 		// The following two tests guarantee that we have tested at least
 		// 2 different platforms. Depending on what host they run on, one
 		// might be a duplicate of the earlier test using the default platform
 		{
-			name:           "test create for ubuntu:latest amd64",
-			containerImage: "ubuntu:latest",
+			name:           "test create for ubuntu amd64",
+			containerImage: ubuntuImage,
 			platform:       "linux/amd64",
 		},
 		{
-			name:           "test create for ubuntu:latest arm64",
-			containerImage: "ubuntu:latest",
+			name:           "test create for ubuntu arm64",
+			containerImage: ubuntuImage,
 			platform:       "linux/arm64",
 		},
 	}

--- a/integration/index_test.go
+++ b/integration/index_test.go
@@ -39,19 +39,19 @@ type testImageIndex struct {
 func prepareSociIndices(t *testing.T, sh *dockershell.Shell) []testImageIndex {
 	testImages := []testImageIndex{
 		{
-			imgName:  "ubuntu:latest",
+			imgName:  ubuntuImage,
 			platform: "linux/arm64",
 		},
 		{
-			imgName:  "alpine:latest",
+			imgName:  alpineImage,
 			platform: "linux/amd64",
 		},
 		{
-			imgName:  "nginx:latest",
+			imgName:  nginxImage,
 			platform: "linux/arm64",
 		},
 		{
-			imgName:  "drupal:latest",
+			imgName:  drupalImage,
 			platform: "linux/amd64",
 		},
 	}

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -128,7 +128,7 @@ disable_verification = %v
 	}{
 		{
 			name:  "image with all layers having ztocs and no fs.Mount error results in 0 overlay fallback",
-			image: "rabbitmq:latest",
+			image: rabbitmqImage,
 			indexDigestFn: func(sh *shell.Shell, image imageInfo) string {
 				return optimizeImageWithOpts(sh, image, 1<<22, 0)
 			},
@@ -136,7 +136,7 @@ disable_verification = %v
 		},
 		{
 			name:  "image with some layers not having ztoc and no fs.Mount results in 0 overlay fallback",
-			image: "rabbitmq:latest",
+			image: rabbitmqImage,
 			indexDigestFn: func(sh *shell.Shell, image imageInfo) string {
 				return optimizeImageWithOpts(sh, image, 1<<22, 10<<20)
 			},
@@ -144,7 +144,7 @@ disable_verification = %v
 		},
 		{
 			name:  "image with fs.Mount errors results in non-zero overlay fallback",
-			image: "rabbitmq:latest",
+			image: rabbitmqImage,
 			indexDigestFn: func(_ *shell.Shell, _ imageInfo) string {
 				return "dwadwadawdad"
 			},

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -97,15 +97,15 @@ func TestOptimizeConsistentSociArtifact(t *testing.T) {
 	}{
 		{
 			name:           "soci artifact is consistently built for ubuntu",
-			containerImage: "ubuntu:latest",
+			containerImage: ubuntuImage,
 		},
 		{
 			name:           "soci artifact is consistently built for nginx",
-			containerImage: "nginx:latest",
+			containerImage: nginxImage,
 		},
 		{
 			name:           "soci artifact is consistently built for alpine",
-			containerImage: "alpine:latest",
+			containerImage: alpineImage,
 		},
 	}
 	for _, tt := range tests {

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -151,45 +151,13 @@ func TestOptimizeConsistentSociArtifact(t *testing.T) {
 func TestLazyPullWithSparseIndex(t *testing.T) {
 	regConfig := newRegistryConfig()
 	// Prepare config for containerd and snapshotter
-	getContainerdConfigYaml := func(disableVerification bool) []byte {
-		additionalConfig := ""
-		if !isTestingBuiltinSnapshotter() {
-			additionalConfig = proxySnapshotterConfig
-		}
-		return []byte(testutil.ApplyTextTemplate(t, `
-version = 2
 
-[plugins."io.containerd.snapshotter.v1.soci"]
-root_path = "/var/lib/soci-snapshotter-grpc/"
-disable_verification = {{.DisableVerification}}
-
-[plugins."io.containerd.snapshotter.v1.soci".blob]
-check_always = true
-
-[debug]
-format = "json"
-level = "debug"
-
-{{.AdditionalConfig}}
-`, struct {
-			DisableVerification bool
-			AdditionalConfig    string
-		}{
-			DisableVerification: disableVerification,
-			AdditionalConfig:    additionalConfig,
-		}))
-	}
-	getSnapshotterConfigYaml := func(disableVerification bool) []byte {
-		return []byte(fmt.Sprintf("disable_verification = %v", disableVerification))
-	}
-
-	// Setup environment
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
 	}
-	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
 	}
 
@@ -276,45 +244,13 @@ func checkLayersInSnapshottersContentStore(t *testing.T, sh *shell.Shell, layers
 func TestLazyPull(t *testing.T) {
 	regConfig := newRegistryConfig()
 	// Prepare config for containerd and snapshotter
-	getContainerdConfigYaml := func(disableVerification bool) []byte {
-		additionalConfig := ""
-		if !isTestingBuiltinSnapshotter() {
-			additionalConfig = proxySnapshotterConfig
-		}
-		return []byte(testutil.ApplyTextTemplate(t, `
-version = 2
 
-[plugins."io.containerd.snapshotter.v1.soci"]
-root_path = "/var/lib/soci-snapshotter-grpc/"
-disable_verification = {{.DisableVerification}}
-
-[plugins."io.containerd.snapshotter.v1.soci".blob]
-check_always = true
-
-[debug]
-format = "json"
-level = "debug"
-
-{{.AdditionalConfig}}
-`, struct {
-			DisableVerification bool
-			AdditionalConfig    string
-		}{
-			DisableVerification: disableVerification,
-			AdditionalConfig:    additionalConfig,
-		}))
-	}
-	getSnapshotterConfigYaml := func(disableVerification bool) []byte {
-		return []byte(fmt.Sprintf("disable_verification = %v", disableVerification))
-	}
-
-	// Setup environment
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
 	}
-	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
 	}
 
@@ -395,46 +331,16 @@ level = "debug"
 // TestLazyPull tests if lazy pulling works when no index digest is provided (makes a Referrers API call)
 func TestLazyPullNoIndexDigest(t *testing.T) {
 	// Prepare config for containerd and snapshotter
-	getContainerdConfigYaml := func(disableVerification bool) []byte {
-		additionalConfig := ""
-		if !isTestingBuiltinSnapshotter() {
-			additionalConfig = proxySnapshotterConfig
-		}
-		return []byte(testutil.ApplyTextTemplate(t, `
-version = 2
 
-[plugins."io.containerd.snapshotter.v1.soci"]
-root_path = "/var/lib/soci-snapshotter-grpc/"
-disable_verification = {{.DisableVerification}}
-
-[plugins."io.containerd.snapshotter.v1.soci".blob]
-check_always = true
-
-[debug]
-format = "json"
-level = "debug"
-
-{{.AdditionalConfig}}
-`, struct {
-			DisableVerification bool
-			AdditionalConfig    string
-		}{
-			DisableVerification: disableVerification,
-			AdditionalConfig:    additionalConfig,
-		}))
-	}
-	getSnapshotterConfigYaml := func(disableVerification bool) []byte {
-		return []byte(fmt.Sprintf("disable_verification = %v", disableVerification))
-	}
 	regConfig := newRegistryConfig()
 
 	// Setup environment
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
 	}
-	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
 	}
 
@@ -502,45 +408,14 @@ level = "debug"
 // to the snapshotter mounting the layer as a normal overlayfs mount.
 func TestPullWithAribtraryBlobInvalidZtocFormat(t *testing.T) {
 	regConfig := newRegistryConfig()
-	getContainerdConfigYaml := func(disableVerification bool) []byte {
-		additionalConfig := ""
-		if !isTestingBuiltinSnapshotter() {
-			additionalConfig = proxySnapshotterConfig
-		}
-		return []byte(testutil.ApplyTextTemplate(t, `
-version = 2
-
-[plugins."io.containerd.snapshotter.v1.soci"]
-root_path = "/var/lib/soci-snapshotter-grpc/"
-disable_verification = {{.DisableVerification}}
-
-[plugins."io.containerd.snapshotter.v1.soci".blob]
-check_always = true
-
-[debug]
-format = "json"
-level = "debug"
-
-{{.AdditionalConfig}}
-`, struct {
-			DisableVerification bool
-			AdditionalConfig    string
-		}{
-			DisableVerification: disableVerification,
-			AdditionalConfig:    additionalConfig,
-		}))
-	}
-	getSnapshotterConfigYaml := func(disableVerification bool) []byte {
-		return []byte(fmt.Sprintf("disable_verification = %v", disableVerification))
-	}
 
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
 
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
 	}
-	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
 	}
 
@@ -647,49 +522,19 @@ level = "debug"
 func TestLazyPullNoBackgroundFetch(t *testing.T) {
 	regConfig := newRegistryConfig()
 	// Prepare config for containerd and snapshotter
-	getContainerdConfigYaml := func(disableVerification bool) []byte {
-		additionalConfig := ""
-		if !isTestingBuiltinSnapshotter() {
-			additionalConfig = proxySnapshotterConfig
-		}
-		return []byte(testutil.ApplyTextTemplate(t, `
-version = 2
 
-[plugins."io.containerd.snapshotter.v1.soci"]
-root_path = "/var/lib/soci-snapshotter-grpc/"
-disable_verification = {{.DisableVerification}}
-
-[plugins."io.containerd.snapshotter.v1.soci".blob]
-check_always = true
-
-[debug]
-format = "json"
-level = "debug"
-
-{{.AdditionalConfig}}
-`, struct {
-			DisableVerification bool
-			AdditionalConfig    string
-		}{
-			DisableVerification: disableVerification,
-			AdditionalConfig:    additionalConfig,
-		}))
-	}
-	getSnapshotterConfigYaml := func() []byte {
-		// return []byte(fmt.Sprintf("disable_verification = %v", disableVerification))
-		return []byte(`
+	backgroundFetcherConfig := `
 [background_fetch]
 disable = true
-`)
-	}
+`
 
 	// Setup environment
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
 	}
-	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false, backgroundFetcherConfig), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
 	}
 
@@ -862,53 +707,26 @@ services:
 	}
 	sh := shell.New(de, reporter)
 
-	// Initialize config files for containerd and snapshotter
-	additionalConfig := ""
-	if !isTestingBuiltinSnapshotter() {
-		additionalConfig = proxySnapshotterConfig
-	}
-	containerdConfigYaml := testutil.ApplyTextTemplate(t, `
-version = 2
-
-[plugins."io.containerd.snapshotter.v1.soci"]
-root_path = "/var/lib/soci-snapshotter-grpc/"
-
-[plugins."io.containerd.snapshotter.v1.soci".blob]
-check_always = true
-
-[[plugins."io.containerd.snapshotter.v1.soci".resolver.host."{{.RegistryHost}}".mirrors]]
-host = "{{.RegistryAltHost}}"
+	containerdMirrorConfig := fmt.Sprintf(`
+[[plugins."io.containerd.snapshotter.v1.soci".resolver.host."%s".mirrors]]
+host = "%s"
 insecure = true
-{{.AdditionalConfig}}
-`, struct {
-		RegistryHost     string
-		RegistryAltHost  string
-		AdditionalConfig string
-	}{
-		RegistryHost:     regConfig.host,
-		RegistryAltHost:  regAltConfig.hostWithPort(),
-		AdditionalConfig: additionalConfig,
-	})
-	snapshotterConfigYaml := testutil.ApplyTextTemplate(t, `
+`, regConfig.host, regAltConfig.hostWithPort())
+
+	snapshotterMirrorConfig := fmt.Sprintf(`
 [blob]
 check_always = true
 
-[[resolver.host."{{.RegistryHost}}".mirrors]]
-host = "{{.RegistryAltHost}}"
+[[resolver.host."%s".mirrors]]
+host = "%s"
 insecure = true
-`, struct {
-		RegistryHost    string
-		RegistryAltHost string
-	}{
-		RegistryHost:    regConfig.host,
-		RegistryAltHost: regAltConfig.hostWithPort(),
-	})
+`, regConfig.host, regAltConfig.hostWithPort())
 
 	// Setup environment
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, []byte(containerdConfigYaml), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false, containerdMirrorConfig), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
 	}
-	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, []byte(snapshotterConfigYaml), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false, snapshotterMirrorConfig), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
 	}
 	if err := testutil.WriteFileContents(sh, filepath.Join(caCertDir, "domain.crt"), crt, 0600); err != nil {
@@ -1093,29 +911,8 @@ func TestRpullImageThenRemove(t *testing.T) {
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
 
-	// Initialize config files for containerd and snapshotter
-	additionalConfig := ""
-	if !isTestingBuiltinSnapshotter() {
-		additionalConfig = proxySnapshotterConfig
-	}
-	containerdConfigYaml := testutil.ApplyTextTemplate(t, `
-version = 2
-
-[plugins."io.containerd.snapshotter.v1.soci"]
-root_path = "/var/lib/soci-snapshotter-grpc/"
-
-[plugins."io.containerd.snapshotter.v1.soci".blob]
-check_always = true
-
-{{.AdditionalConfig}}
-`, struct {
-		AdditionalConfig string
-	}{
-		AdditionalConfig: additionalConfig,
-	})
-
 	// Setup environment
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, []byte(containerdConfigYaml), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
 	}
 	sh.

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -48,7 +48,6 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/rs/xid"
 )
 
 // TestSnapshotterStartup tests to run containerd + snapshotter and check plugin is
@@ -842,67 +841,6 @@ func buildSparseIndex(sh *shell.Shell, src imageInfo, minLayerSize int64) string
 		X("soci", "create", src.ref, "--min-layer-size", fmt.Sprintf("%d", minLayerSize), "--platform", platforms.Format(src.platform)).
 		O("soci", "index", "list", "-q", "--ref", src.ref, "--platform", platforms.Format(src.platform)) // this will make SOCI artifact available locally
 	return strings.Trim(string(indexDigest), "\n")
-}
-
-func rebootContainerd(t *testing.T, sh *shell.Shell, customContainerdConfig, customSnapshotterConfig string) *testutil.RemoteSnapshotMonitor {
-	var (
-		containerdRoot    = "/var/lib/containerd/"
-		containerdStatus  = "/run/containerd/"
-		snapshotterSocket = "/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"
-		snapshotterRoot   = "/var/lib/soci-snapshotter-grpc/"
-	)
-
-	// cleanup directories
-	testutil.KillMatchingProcess(sh, "containerd")
-	testutil.KillMatchingProcess(sh, "soci-snapshotter-grpc")
-	removeDirContents(sh, containerdRoot)
-	if isDirExists(sh, containerdStatus) {
-		removeDirContents(sh, containerdStatus)
-	}
-	if isFileExists(sh, snapshotterSocket) {
-		sh.X("rm", snapshotterSocket)
-	}
-	if snDir := filepath.Join(snapshotterRoot, "/snapshotter/snapshots"); isDirExists(sh, snDir) {
-		sh.X("find", snDir, "-maxdepth", "1", "-mindepth", "1", "-type", "d",
-			"-exec", "umount", "{}/fs", ";")
-	}
-	removeDirContents(sh, snapshotterRoot)
-
-	// run containerd and snapshotter
-	var m *testutil.RemoteSnapshotMonitor
-	containerdCmds := shell.C("containerd", "--log-level", "debug")
-	if customContainerdConfig != "" {
-		containerdCmds = addConfig(t, sh, customContainerdConfig, containerdCmds...)
-	}
-	sh.Gox(containerdCmds...)
-	snapshotterCmds := shell.C("/usr/local/bin/soci-snapshotter-grpc", "--log-level", "debug",
-		"--address", snapshotterSocket)
-	if customSnapshotterConfig != "" {
-		snapshotterCmds = addConfig(t, sh, customSnapshotterConfig, snapshotterCmds...)
-	}
-	outR, errR, err := sh.R(snapshotterCmds...)
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
-	m = testutil.NewRemoteSnapshotMonitor(testutil.NewTestingReporter(t), outR, errR)
-
-	// make sure containerd and soci-snapshotter-grpc are up-and-running
-	sh.Retry(100, "ctr", "snapshots", "--snapshotter", "soci",
-		"prepare", "connectiontest-dummy-"+xid.New().String(), "")
-
-	return m
-}
-
-func removeDirContents(sh *shell.Shell, dir string) {
-	sh.X("find", dir+"/.", "!", "-name", ".", "-prune", "-exec", "rm", "-rf", "{}", "+")
-}
-
-func addConfig(t *testing.T, sh *shell.Shell, conf string, cmds ...string) []string {
-	configPath := strings.TrimSpace(string(sh.O("mktemp")))
-	if err := testutil.WriteFileContents(sh, configPath, []byte(conf), 0600); err != nil {
-		t.Fatalf("failed to add config to %v: %v", configPath, err)
-	}
-	return append(cmds, "--config", configPath)
 }
 
 // TestRpullImageThenRemove pulls and rpulls an image then removes it to confirm fuse mounts are unmounted

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -32,42 +32,10 @@ func TestSociArtifactsPushAndPull(t *testing.T) {
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
 
-	getContainerdConfigYaml := func(disableVerification bool) []byte {
-		additionalConfig := ""
-		if !isTestingBuiltinSnapshotter() {
-			additionalConfig = proxySnapshotterConfig
-		}
-		return []byte(testutil.ApplyTextTemplate(t, `
-version = 2
-
-[plugins."io.containerd.snapshotter.v1.soci"]
-root_path = "/var/lib/soci-snapshotter-grpc/"
-disable_verification = {{.DisableVerification}}
-
-[plugins."io.containerd.snapshotter.v1.soci".blob]
-check_always = true
-
-[debug]
-format = "json"
-level = "debug"
-
-{{.AdditionalConfig}}
-`, struct {
-			DisableVerification bool
-			AdditionalConfig    string
-		}{
-			DisableVerification: disableVerification,
-			AdditionalConfig:    additionalConfig,
-		}))
-	}
-	getSnapshotterConfigYaml := func(disableVerification bool) []byte {
-		return []byte(fmt.Sprintf("disable_verification = %v", disableVerification))
-	}
-
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
 	}
-	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
 	}
 
@@ -116,42 +84,10 @@ func TestPushAlwaysMostRecentlyCreatedIndex(t *testing.T) {
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
 
-	getContainerdConfigYaml := func(disableVerification bool) []byte {
-		additionalConfig := ""
-		if !isTestingBuiltinSnapshotter() {
-			additionalConfig = proxySnapshotterConfig
-		}
-		return []byte(testutil.ApplyTextTemplate(t, `
-version = 2
-
-[plugins."io.containerd.snapshotter.v1.soci"]
-root_path = "/var/lib/soci-snapshotter-grpc/"
-disable_verification = {{.DisableVerification}}
-
-[plugins."io.containerd.snapshotter.v1.soci".blob]
-check_always = true
-
-[debug]
-format = "json"
-level = "debug"
-
-{{.AdditionalConfig}}
-`, struct {
-			DisableVerification bool
-			AdditionalConfig    string
-		}{
-			DisableVerification: disableVerification,
-			AdditionalConfig:    additionalConfig,
-		}))
-	}
-	getSnapshotterConfigYaml := func(disableVerification bool) []byte {
-		return []byte(fmt.Sprintf("disable_verification = %v", disableVerification))
-	}
-
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
 	}
-	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(false), 0600); err != nil {
+	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false), 0600); err != nil {
 		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
 	}
 

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -83,29 +83,8 @@ func TestRunMultipleContainers(t *testing.T) {
 			sh, done := newShellWithRegistry(t, regConfig)
 			defer done()
 
-			// Initialize config files for containerd and snapshotter
-			additionalConfig := ""
-			if !isTestingBuiltinSnapshotter() {
-				additionalConfig = proxySnapshotterConfig
-			}
-			containerdConfigYaml := testutil.ApplyTextTemplate(t, `
-version = 2
-
-[plugins."io.containerd.snapshotter.v1.soci"]
-root_path = "/var/lib/soci-snapshotter-grpc/"
-
-[plugins."io.containerd.snapshotter.v1.soci".blob]
-check_always = true
-
-{{.AdditionalConfig}}
-`, struct {
-				AdditionalConfig string
-			}{
-				AdditionalConfig: additionalConfig,
-			})
-
 			// Setup environment
-			if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, []byte(containerdConfigYaml), 0600); err != nil {
+			if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
 				t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
 			}
 			sh.

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -68,10 +68,11 @@ const (
 )
 
 const (
-	alpineImage = "alpine:latest"
-	nginxImage  = "nginx:latest"
-	ubuntuImage = "ubuntu:latest"
-	drupalImage = "drupal:latest"
+	alpineImage   = "alpine:latest"
+	nginxImage    = "nginx:latest"
+	ubuntuImage   = "ubuntu:latest"
+	drupalImage   = "drupal:latest"
+	rabbitmqImage = "rabbitmq:latest"
 )
 
 const proxySnapshotterConfig = `


### PR DESCRIPTION
*Issue #, if available:*

Part of #247

*Description of changes:*

It has 3 commits, each for an independent integration test refactor:

1. Use const for image names instead of plain strings.
2. Refactor containerd and snapshotter config creation: after the refactor, we should only use the helper function and pass the specific `additional config`. As an example: [`containerdMirrorConfig`](https://github.com/awslabs/soci-snapshotter/blob/ac0838de498d0aa9b26ba249a19265f17b7d0167/integration/pull_test.go#L709-L722), [`snapshotterMetricsConfig`](https://github.com/awslabs/soci-snapshotter/blob/ac0838de498d0aa9b26ba249a19265f17b7d0167/integration/metrics_test.go#L35-L42).
3. Move rebootContainerd to testutil: it's not related to `test_pull.go` and used almost by every integraion test.

*Testing performed:*

make test && make check && make integration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
