### PR TITLE
Remove unused config fields

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -53,17 +53,15 @@ const (
 )
 
 type Config struct {
-	HTTPCacheType                    string `toml:"http_cache_type"`
-	FSCacheType                      string `toml:"filesystem_cache_type"`
-	ResolveResultEntry               int    `toml:"resolve_result_entry"`
-	NoBackgroundFetch                bool   `toml:"no_background_fetch"`
-	Debug                            bool   `toml:"debug"`
-	AllowNoVerification              bool   `toml:"allow_no_verification"`
-	DisableVerification              bool   `toml:"disable_verification"`
-	MaxConcurrency                   int64  `toml:"max_concurrency"`
-	NoPrometheus                     bool   `toml:"no_prometheus"`
-	PrioritizedTaskSilencePeriodMSec int    `toml:"prioritized_task_silence_period_msec"`
-	MountTimeoutSec                  int    `toml:"mount_timeout_sec"`
+	HTTPCacheType       string `toml:"http_cache_type"`
+	FSCacheType         string `toml:"filesystem_cache_type"`
+	ResolveResultEntry  int    `toml:"resolve_result_entry"`
+	Debug               bool   `toml:"debug"`
+	AllowNoVerification bool   `toml:"allow_no_verification"`
+	DisableVerification bool   `toml:"disable_verification"`
+	MaxConcurrency      int64  `toml:"max_concurrency"`
+	NoPrometheus        bool   `toml:"no_prometheus"`
+	MountTimeoutSec     int    `toml:"mount_timeout_sec"`
 
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob"`

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -229,7 +229,6 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snapshot.F
 	return &filesystem{
 		resolver:            r,
 		getSources:          getSources,
-		noBackgroundFetch:   cfg.NoBackgroundFetch,
 		debug:               cfg.Debug,
 		layer:               make(map[string]layer.Layer),
 		allowNoVerification: cfg.AllowNoVerification,
@@ -322,7 +321,6 @@ func (c *sociContext) populateImageLayerToSociMapping(sociIndex *soci.Index) {
 
 type filesystem struct {
 	resolver            *layer.Resolver
-	noBackgroundFetch   bool
 	debug               bool
 	layer               map[string]layer.Layer
 	layerMu             sync.Mutex


### PR DESCRIPTION
This commit removes unused config fields from `fs.Config`.

`NoBackgroundFetch`: Replaced by `background_fetch.disable`

`PrioritizedTaskSilencePeriod`: Unused since the old implementation of the background task manager was removed.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
