### PR TITLE
Change local and remote snapshot success log level to Info 

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -285,7 +285,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 			err := o.commit(ctx, true, target, key, append(opts, snapshots.WithLabels(base.Labels))...)
 			if err == nil || errdefs.IsAlreadyExists(err) {
 				// count also AlreadyExists as "success"
-				log.G(lCtx).WithField(remoteSnapshotLogKey, prepareSucceeded).Debug("prepared remote snapshot")
+				log.G(lCtx).WithField(remoteSnapshotLogKey, prepareSucceeded).Info("Remote snapshot successfully prepared.")
 				return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "target snapshot %q", target)
 			}
 			log.G(lCtx).WithField(remoteSnapshotLogKey, prepareFailed).
@@ -308,7 +308,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 				// count also AlreadyExists as "success"
 				// there's no need to provide any details on []mount.Mount because mounting is already taken care of
 				// by snapshotter
-				log.G(lCtx).WithField(remoteSnapshotLogKey, prepareSucceeded).Debug("prepared local snapshot")
+				log.G(lCtx).WithField(remoteSnapshotLogKey, prepareSucceeded).Info("Local snapshot successfully prepared")
 				return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "target snapshot %q", target)
 			}
 			log.G(lCtx).WithField(remoteSnapshotLogKey, prepareFailed).


### PR DESCRIPTION
~~Added log statement to `Mounts()` function that will print if mount returns are successful on an active snapshot when a container is created/run.~~

Changed the log-level of success logs for remote or local snapshots to `Info` from `Debug` as `Info` is used by default.

Signed-off-by: Yasin Turan <turyasin@amazon.com>

*Issue #, if available:*
Fixes : https://github.com/awslabs/soci-snapshotter/issues/271

*Testing performed:*

`make test` && `make integration`

Log:
```
{
  "key": "default/1/extract-503501741-XIir sha256:0002c93bdb3704dd9e36ce5153ef637f84de253015f3ee330468dccdeacad60b",
  "level": "info",
  "msg": "Remote snapshot successfully prepared.",
  "parent": "",
  "remote-snapshot-prepared": "true",
  "time": "2023-01-10T21:26:05.821705631Z"
}

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
