### PR TITLE
"soci index rm" returns error if the index doesn't exist

### DIFF
--- a/integration/index_test.go
+++ b/integration/index_test.go
@@ -265,4 +265,12 @@ func TestSociIndexRemove(t *testing.T) {
 			t.Fatalf("\"soci index rm $(soci index ls -q)\" doesn't remove all soci indices, remaining indices: %s", indices)
 		}
 	})
+
+	t.Run("soci index rm with an invalid index digest", func(t *testing.T) {
+		invalidDgst := "digest"
+		_, err := sh.OLog("soci", "index", "rm", invalidDgst)
+		if err == nil {
+			t.Fatalf("failed to return err")
+		}
+	})
 }

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -222,7 +222,7 @@ func (db *ArtifactsDb) RemoveArtifactEntryByIndexDigest(digest string) error {
 
 		dgstBucket := bucket.Bucket([]byte(digest))
 		if dgstBucket == nil {
-			return nil
+			return fmt.Errorf("the index of the digest %v doesn't exist", digest)
 		}
 
 		if indexBucket(dgstBucket) {


### PR DESCRIPTION
*Issue #, if available:* #252

*Description of changes:*

*Testing performed:*
Added integration test for this change. Verified the integration test pass via``make integration``

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
