### PR TITLE
Add retries in case of span verification failure

### DIFF
--- a/fs/backgroundfetcher/background_fetcher_test.go
+++ b/fs/backgroundfetcher/background_fetcher_test.go
@@ -112,7 +112,7 @@ func TestBackgroundFetcherRun(t *testing.T) {
 					t.Fatalf("error building span manager and section reader: %v", err)
 				}
 				cache := &countingCache{}
-				sm := spanmanager.New(ztoc, sr, cache)
+				sm := spanmanager.New(ztoc, sr, cache, 0)
 				infos = append(infos, testInfo{sm, cache, ztoc})
 			}
 

--- a/fs/backgroundfetcher/resolver_test.go
+++ b/fs/backgroundfetcher/resolver_test.go
@@ -48,7 +48,7 @@ func TestSequentialResolver(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error build ztoc and section reader: %v", err)
 			}
-			sm := spanmanager.New(ztoc, sr, cache.NewMemoryCache())
+			sm := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
 			sequentialResolver := NewSequentialResolver(digest.FromString("test"), sm)
 
 			var resolvedSpans []int

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -82,6 +82,10 @@ type BlobConfig struct {
 	MaxRetries           int   `toml:"max_retries"`
 	MinWaitMSec          int   `toml:"min_wait_msec"`
 	MaxWaitMSec          int   `toml:"max_wait_msec"`
+
+	// MaxSpanVerificationRetries defines the number of times fetch will be invoked in case of
+	// span verification failure.
+	MaxSpanVerificationRetries int `toml:"max_span_verification_retries"`
 }
 
 type DirectoryCacheConfig struct {

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -329,7 +329,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 	}
 	log.G(ctx).Debugf("[Resolver.Resolve]Initialized metadata store for layer sha=%v", desc.Digest)
 
-	spanManager := spanmanager.New(ztoc, sr, spanCache, cache.Direct())
+	spanManager := spanmanager.New(ztoc, sr, spanCache, r.config.BlobConfig.MaxSpanVerificationRetries, cache.Direct())
 	var bgLayerResolver backgroundfetcher.Resolver
 	if r.bgFetcher != nil {
 		bgLayerResolver = backgroundfetcher.NewSequentialResolver(desc.Digest, spanManager)

--- a/fs/layer/testutil.go
+++ b/fs/layer/testutil.go
@@ -176,7 +176,7 @@ func makeNodeReader(t *testing.T, contents []byte, spanSize int64, factory metad
 	if err != nil {
 		t.Fatalf("failed to create reader: %v", err)
 	}
-	spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache())
+	spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
 	vr, err := reader.NewReader(mr, digest.FromString(""), spanManager)
 	if err != nil {
 		mr.Close()
@@ -338,7 +338,7 @@ func testExistenceWithOpaque(t *testing.T, factory metadata.Store, opaque Overla
 					t.Fatalf("failed to create reader: %v", err)
 				}
 				defer mr.Close()
-				spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache())
+				spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
 				vr, err := reader.NewReader(mr, digest.FromString(""), spanManager)
 				if err != nil {
 					t.Fatalf("failed to make new reader: %v", err)

--- a/fs/reader/testutil.go
+++ b/fs/reader/testutil.go
@@ -155,7 +155,7 @@ func makeFile(t *testing.T, contents []byte, factory metadata.Store, spanSize in
 	if err != nil {
 		t.Fatalf("failed to create reader: %v", err)
 	}
-	spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache())
+	spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
 	vr, err := NewReader(mr, digest.FromString(""), spanManager)
 	if err != nil {
 		mr.Close()
@@ -211,7 +211,7 @@ func testFailReader(t *testing.T, factory metadata.Store) {
 			if !found {
 				t.Fatalf("free ID not found")
 			}
-			spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache())
+			spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
 			vr, err := NewReader(mr, digest.FromString(""), spanManager)
 			if err != nil {
 				mr.Close()


### PR DESCRIPTION
This commit adds retries to the span manager in case of span verification failure. The span manager will retry spanmanager.retries amount of times before returning an error. Added a config option span_manager.max_retries to set the retry value.

Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*
Resolves #286 

*Description of changes:*

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
