### PR TITLE
Parameterize artifacts db

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -97,6 +97,11 @@ var CreateCommand = cli.Command{
 			return err
 		}
 
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath())
+		if err != nil {
+			return err
+		}
+
 		builderOpts := []soci.BuildOption{
 			soci.WithMinLayerSize(minLayerSize),
 			soci.WithSpanSize(spanSize),
@@ -106,7 +111,7 @@ var CreateCommand = cli.Command{
 			builderOpts = append(builderOpts, soci.WithLegacyRegistrySupport)
 		}
 		for _, plat := range ps {
-			builder, err := soci.NewIndexBuilder(cs, blobStore, append(builderOpts, soci.WithPlatform(plat))...)
+			builder, err := soci.NewIndexBuilder(cs, blobStore, artifactsDb, append(builderOpts, soci.WithPlatform(plat))...)
 
 			if err != nil {
 				return err
@@ -117,7 +122,7 @@ var CreateCommand = cli.Command{
 				return err
 			}
 
-			err = soci.WriteSociIndex(ctx, sociIndexWithMetadata, blobStore)
+			err = soci.WriteSociIndex(ctx, sociIndexWithMetadata, blobStore, builder.ArtifactsDb)
 			if err != nil {
 				return err
 			}

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -41,7 +41,7 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		db, err := soci.NewDB()
+		db, err := soci.NewDB(soci.ArtifactsDbPath())
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/list.go
+++ b/cmd/soci/commands/index/list.go
@@ -132,7 +132,7 @@ var listCommand = cli.Command{
 			f = anyMatch(filters)
 		}
 
-		db, err := soci.NewDB()
+		db, err := soci.NewDB(soci.ArtifactsDbPath())
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/rm.go
+++ b/cmd/soci/commands/index/rm.go
@@ -43,7 +43,7 @@ var rmCommand = cli.Command{
 			return fmt.Errorf("please provide either index digests or image ref, but not both")
 		}
 
-		db, err := soci.NewDB()
+		db, err := soci.NewDB(soci.ArtifactsDbPath())
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -87,8 +87,13 @@ if they are available in the snapshotter's local content store.
 			return err
 		}
 
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath())
+		if err != nil {
+			return err
+		}
+
 		for _, platform := range ps {
-			indexDescriptors, err := soci.GetIndexDescriptorCollection(ctx, cs, img, []ocispec.Platform{platform})
+			indexDescriptors, err := soci.GetIndexDescriptorCollection(ctx, cs, artifactsDb, img, []ocispec.Platform{platform})
 			if err != nil {
 				return err
 			}

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -115,7 +115,7 @@ func getZtoc(ctx context.Context, d digest.Digest) (*ztoc.Ztoc, error) {
 }
 
 func getLayer(ctx context.Context, ztocDigest digest.Digest, cs content.Store) (content.ReaderAt, error) {
-	metadata, err := soci.NewDB()
+	metadata, err := soci.NewDB(soci.ArtifactsDbPath())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -60,7 +60,7 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		db, err := soci.NewDB()
+		db, err := soci.NewDB(soci.ArtifactsDbPath())
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/list.go
+++ b/cmd/soci/commands/ztoc/list.go
@@ -48,7 +48,7 @@ var listCommand = cli.Command{
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
-		db, err := soci.NewDB()
+		db, err := soci.NewDB(soci.ArtifactsDbPath())
 		if err != nil {
 			return err
 		}

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -51,6 +51,10 @@ type ArtifactsDb struct {
 // ArtifactEntryType is the type of SOCI artifact represented by the ArtifactEntry
 type ArtifactEntryType string
 
+const (
+	artifactsDbName = "artifacts.db"
+)
+
 var (
 	bucketKeySociArtifacts  = []byte("soci_artifacts")
 	bucketKeySize           = []byte("size")
@@ -62,7 +66,6 @@ var (
 	bucketKeyMediaType      = []byte("media_type")
 	bucketKeyCreatedAt      = []byte("created_at")
 
-	artifactsDbName = "artifacts.db"
 	// ArtifactEntryTypeIndex indicates that an ArtifactEntry is a SOCI index artifact
 	ArtifactEntryTypeIndex ArtifactEntryType = "soci_index"
 	// ArtifactEntryTypeLayer indicates that an ArtifactEntry is a SOCI layer artifact
@@ -71,6 +74,11 @@ var (
 	db   *ArtifactsDb
 	once sync.Once
 )
+
+// Get the default artifacts db path
+func ArtifactsDbPath() string {
+	return path.Join(config.SociSnapshotterRootPath, artifactsDbName)
+}
 
 // ArtifactEntry is a metadata object for a SOCI artifact.
 type ArtifactEntry struct {
@@ -96,34 +104,9 @@ type ArtifactEntry struct {
 	CreatedAt time.Time
 }
 
-func getIndexArtifactEntries(indexDigest string) ([]ArtifactEntry, error) {
-	artifacts, err := NewDB()
-	if err != nil {
-		return nil, err
-	}
-	return artifacts.getIndexArtifactEntries(indexDigest)
-}
-
-func getArtifactEntry(sociDigest string) (*ArtifactEntry, error) {
-	artifacts, err := NewDB()
-	if err != nil {
-		return nil, err
-	}
-	return artifacts.GetArtifactEntry(sociDigest)
-}
-
-func writeArtifactEntry(entry *ArtifactEntry) error {
-	artifacts, err := NewDB()
-	if err != nil {
-		return err
-	}
-	return artifacts.WriteArtifactEntry(entry)
-}
-
 // NewDB returns an instance of an ArtifactsDB
-func NewDB() (*ArtifactsDb, error) {
+func NewDB(path string) (*ArtifactsDb, error) {
 	once.Do(func() {
-		path := path.Join(config.SociSnapshotterRootPath, artifactsDbName)
 		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 		if err != nil {
 			log.G(context.Background()).Errorf("can't create or open the file %s", path)

--- a/soci/artifacts_test.go
+++ b/soci/artifacts_test.go
@@ -97,32 +97,10 @@ func TestGetIndexArtifactEntries(t *testing.T) {
 	}
 }
 
-func TestGetArtifactEntry_ArtifactDB_DoesNotExist(t *testing.T) {
-	dgst := "sha256:80d6aec48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
-	_, err := getArtifactEntry(dgst)
+func TestArtifactDB_DoesNotExist(t *testing.T) {
+	_, err := NewDB(ArtifactsDbPath())
 	if err == nil {
 		t.Fatalf("getArtifactEntry should fail since artifacts.db doesn't exist")
-	}
-}
-
-func TestWriteArtifactEntry_ArtifactDB_DoesNotExist(t *testing.T) {
-	var (
-		dgst         = "sha256:80d6aec48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
-		originalDgst = "sha256:1236aec48c0a74635a5f3dc666628c1673afaa21ed6e1270a9a44de66e811111"
-		imageDigest  = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
-		platform     = "linux/amd64"
-	)
-	ae := &ArtifactEntry{
-		Size:           10,
-		Digest:         dgst,
-		OriginalDigest: originalDgst,
-		Location:       "/var/soci-snapshotter/test",
-		ImageDigest:    imageDigest,
-		Platform:       platform,
-	}
-	err := writeArtifactEntry(ae)
-	if err == nil {
-		t.Fatalf("writeArtifactEntry should fail since artifacts.db doesn't exist")
 	}
 }
 

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -138,7 +138,8 @@ func TestBuildSociIndexNotLayer(t *testing.T) {
 	ctx := context.Background()
 	cs := newFakeContentStore()
 	blobStore := memory.New()
-	builder, err := NewIndexBuilder(cs, blobStore, WithSpanSize(spanSize), WithMinLayerSize(0))
+	artifactsDb, _ := NewDB(ArtifactsDbPath())
+	builder, err := NewIndexBuilder(cs, blobStore, artifactsDb, WithSpanSize(spanSize), WithMinLayerSize(0))
 
 	if err != nil {
 		t.Fatalf("cannot create index builer: %v", err)
@@ -206,7 +207,8 @@ func TestBuildSociIndexWithLimits(t *testing.T) {
 			}
 			spanSize := int64(65535)
 			blobStore := memory.New()
-			builder, _ := NewIndexBuilder(cs, blobStore, WithSpanSize(spanSize), WithMinLayerSize(tc.minLayerSize))
+			artifactsDb, _ := NewDB(ArtifactsDbPath())
+			builder, _ := NewIndexBuilder(cs, blobStore, artifactsDb, WithSpanSize(spanSize), WithMinLayerSize(tc.minLayerSize))
 			ztoc, err := builder.buildSociLayer(ctx, desc)
 			if tc.ztocGenerated {
 				// we check only for build skip, which is indicated as nil value for ztoc and nil value for error


### PR DESCRIPTION
Currently artifacts db path is hard-coded at "/var/lib/soci-snapshotter-grpc/artifacts.db". It's problematic in Lambda environment as "/var/lib" is read-only in Lambda.

This commit adds an option to specify artifacts db the index builder initializer.

*Issue #, if available:* https://github.com/awslabs/soci-snapshotter/issues/307

*Description of changes:*
- Add a `path` parameter to the NewDB() initializer
- Add artifacts db path option to the soci index builder build option
 
*Testing performed:*
- Build and execute the `soci` cli locally
- Integrate soci_index module to a Lambda and test the Lambda

Signed-off-by: Dave Nguyen <dvnguyen@amazon.com>
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
