### PR TITLE
Remove leftover optimizeImageWithOpts usage in integration tests after refactor

### DIFF
--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -349,7 +349,7 @@ func TestSpanManagerRetries(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			entries := []testutil.TarEntry{
-				testutil.File("test", string(genRandomByteData(10000000))),
+				testutil.File("test", string(testutil.RandomByteData(10000000))),
 			}
 			ztoc, sr, err := ztoc.BuildZtocReader(entries, gzip.DefaultCompression, 100000)
 			if err != nil {

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -184,7 +184,7 @@ log_fuse_operations = true
 			name:  "image with valid ztocs and index doesn't cause fuse file.read failures",
 			image: rabbitmqImage,
 			indexDigestFn: func(t *testing.T, sh *shell.Shell, image imageInfo) string {
-				return optimizeImageWithOpts(sh, image, 1<<22, 0)
+				return buildSparseIndex(sh, image, 0, defaultSpanSize)
 			},
 			// even a valid index/ztoc produces some fuse operation failures such as
 			// node.lookup and node.getxattr failures, so we only check a specific fuse failure metric.
@@ -195,7 +195,7 @@ log_fuse_operations = true
 			name:  "image with valid-formatted but invalid-data ztocs causes fuse file.read failures",
 			image: rabbitmqImage,
 			indexDigestFn: func(t *testing.T, sh *shell.Shell, image imageInfo) string {
-				indexDigest, err := buildIndexByManipulatingZtocData(sh, optimizeImageWithOpts(sh, image, 1<<22, 0), manipulateZtocMetadata)
+				indexDigest, err := buildIndexByManipulatingZtocData(sh, buildSparseIndex(sh, image, 0, defaultSpanSize), manipulateZtocMetadata)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
Signed-off-by: Jin Dong <jindon@amazon.com>

*Issue #, if available:*

*Description of changes:*

https://github.com/awslabs/soci-snapshotter/pull/309 removed `optimizeImageWithOpts` and after its CI success and before merge, other merged PRs used the removed func.

*Testing performed:*

make test && make integraion

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
