### PR TITLE
`soci ztoc info` reports additional information

### DIFF
--- a/cmd/soci/commands/ztoc/list.go
+++ b/cmd/soci/commands/ztoc/list.go
@@ -28,6 +28,7 @@ import (
 var listCommand = cli.Command{
 	Name:        "list",
 	Description: "list ztocs",
+	Aliases:     []string{"ls"},
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "digest",

--- a/compression/gzip_zinfo.go
+++ b/compression/gzip_zinfo.go
@@ -89,6 +89,11 @@ func (i *GzipZinfo) MaxSpanID() SpanID {
 	return SpanID(C.get_max_span_id(i.cZinfo))
 }
 
+// SpanSize returns the span size of the constructed ztoc.
+func (i *GzipZinfo) SpanSize() Offset {
+	return Offset(i.cZinfo.span_size)
+}
+
 // UncompressedOffsetToSpanID returns the ID of the span containing the data pointed by uncompressed offset.
 func (i *GzipZinfo) UncompressedOffsetToSpanID(offset Offset) SpanID {
 	return SpanID(C.pt_index_from_ucmp_offset(i.cZinfo, C.long(offset)))


### PR DESCRIPTION
Signed-off-by: Rishabh Singhvi <rdpsin@amazon.com>

*Issue #, if available:*

*Description of changes:*

*Testing performed:*

Example

```
% sudo ./soci ztoc info sha256:951fd618f3c6d61944b0fe2fe2c06ce7d43c6f0454d42f51000f37f31bb1e39e
{
  "version": "0.9",
  "build_tool": "AWS SOCI CLI v0.1",
  "span_size": 4000000,
  "max_span_id": 1,
  "num_files": 522,
  "num_multi_span_files": 1,
  "files": [
    {
      "filename": "bin/",
      "offset": 512,
      "size": 0,
      "type": "dir",
      "start_span": 0,
      "end_span": 0
    },
    {
      "filename": "bin/arch",
      "offset": 1024,
      "size": 0,
      "type": "symlink",
      "start_span": 0,
      "end_span": 0
    },
    {
      "filename": "bin/ash",
      "offset": 1536,
      "size": 0,
      "type": "symlink",
      "start_span": 0,
      "end_span": 0
    },
    {
      "filename": "bin/base64",
      "offset": 2048,
      "size": 0,
      "type": "symlink",
      "start_span": 0,
      "end_span": 0
    },
    {
      "filename": "bin/bbconfig",
      "offset": 2560,
      "size": 0,
      "type": "symlink",
      "start_span": 0,
      "end_span": 0
    },
    {
      "filename": "bin/busybox",
      "offset": 3072,
      "size": 841392,
      "type": "reg",
      "start_span": 0,
      "end_span": 0
    },
...
`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
