### PR TITLE
Remove github.com/pkg/errors in favor of errors

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -43,7 +43,6 @@ import (
 	"github.com/awslabs/soci-snapshotter/util/lrucache"
 	"github.com/awslabs/soci-snapshotter/util/namedmutex"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -238,7 +237,7 @@ func (dc *directoryCache) Get(key string, opts ...Option) (Reader, error) {
 	//       or simply report the cache miss?
 	file, err := os.Open(dc.cachePath(key))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open blob file for %q", key)
+		return nil, fmt.Errorf("failed to open blob file for %q: %w", key, err)
 	}
 
 	// If "direct" option is specified, do not cache the file on memory.
@@ -295,7 +294,7 @@ func (dc *directoryCache) Add(key string, opts ...Option) (Writer, error) {
 					allErr = multierror.Append(allErr, err)
 				}
 				return multierror.Append(allErr,
-					errors.Wrapf(err, "failed to create cache directory %q", c))
+					fmt.Errorf("failed to create cache directory %q: %w", c, err))
 			}
 			return os.Rename(wip.Name(), c)
 		},

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/pelletier/go-toml v1.9.5
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/urfave/cli v1.22.11
 	go.etcd.io/bbolt v1.3.6
@@ -69,6 +68,7 @@ require (
 	github.com/opencontainers/runc v1.1.4 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.10.2 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -1036,7 +1036,7 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
+github.com/montanaflynn/stats v0.7.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -17,13 +17,13 @@
 package commands
 
 import (
+	"errors"
 	"os"
 
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
 	"github.com/awslabs/soci-snapshotter/fs/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/containerd/containerd/cmd/ctr/commands"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"oras.land/oras-go/v2/content/oci"
 )

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -44,6 +44,7 @@ package fs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"sync"
@@ -69,7 +70,6 @@ import (
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	orascontent "oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/oci"
@@ -209,7 +209,7 @@ func NewFilesystem(root string, cfg config.Config, opts ...Option) (_ snapshot.F
 
 	r, err := layer.NewResolver(root, cfg, fsOpts.resolveHandlers, metadataStore, store, fsOpts.overlayOpaqueType, bgFetcher)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to setup resolver")
+		return nil, fmt.Errorf("failed to setup resolver: %w", err)
 	}
 
 	var ns *metrics.Namespace
@@ -598,8 +598,8 @@ func (fs *filesystem) check(ctx context.Context, l layer.Layer, labels map[strin
 			}
 			log.G(ctx).WithError(err).Warnf("failed to refresh the layer %q from %q",
 				s.Target.Digest, s.Name)
-			rErr = errors.Wrapf(rErr, "failed(layer:%q, ref:%q): %v",
-				s.Target.Digest, s.Name, err)
+			rErr = fmt.Errorf("failed(layer:%q, ref:%q): %v: %w",
+				s.Target.Digest, s.Name, err, rErr)
 		}
 	}
 

--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -50,7 +50,6 @@ import (
 	"github.com/awslabs/soci-snapshotter/fs/source"
 	"github.com/containerd/containerd/reference"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 var contentRangeRegexp = regexp.MustCompile(`bytes ([0-9]+)-([0-9]+)/([0-9]+|\\*)`)
@@ -246,7 +245,7 @@ func (b *blob) fetchRegion(reg region, w io.Writer, fetched bool, opts *options)
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return errors.Wrapf(err, "failed to read multipart resp")
+			return fmt.Errorf("failed to read multipart resp: %w", err)
 		}
 
 		if _, err := io.CopyN(w, p, reg.size()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/montanaflynn/stats v0.7.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rs/xid v1.4.0
 	github.com/sirupsen/logrus v1.9.0
@@ -70,6 +69,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.10.2 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/metadata/db/db.go
+++ b/metadata/db/db.go
@@ -40,7 +40,6 @@ import (
 	"github.com/awslabs/soci-snapshotter/compression"
 	"github.com/awslabs/soci-snapshotter/metadata"
 	"github.com/awslabs/soci-snapshotter/util/dbutil"
-	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -232,7 +231,7 @@ func writeAttr(b *bolt.Bucket, attr *metadata.Attr) error {
 				}
 			}
 			if err := xbkt.Put([]byte(k), v); err != nil {
-				return errors.Wrapf(err, "failed to set xattr %q=%q", k, string(v))
+				return fmt.Errorf("failed to set xattr %q=%q: %w", k, string(v), err)
 			}
 		}
 	}
@@ -319,10 +318,10 @@ func writeMetadataEntry(md *bolt.Bucket, m *metadataEntry) error {
 			break
 		}
 		if err := md.Put(bucketKeyChildID, encodeID(firstChild.id)); err != nil {
-			return errors.Wrapf(err, "failed to put id of first child %q", firstChildName)
+			return fmt.Errorf("failed to put id of first child %q: %w", firstChildName, err)
 		}
 		if err := md.Put(bucketKeyChildName, []byte(firstChildName)); err != nil {
-			return errors.Wrapf(err, "failed to put name first child %q", firstChildName)
+			return fmt.Errorf("failed to put name first child %q: %w", firstChildName, err)
 		}
 		if len(m.children) > 1 {
 			var cbkt *bolt.Bucket
@@ -344,13 +343,13 @@ func writeMetadataEntry(md *bolt.Bucket, m *metadataEntry) error {
 					}
 				}
 				if err := cbkt.Put([]byte(c.base), encodeID(c.id)); err != nil {
-					return errors.Wrapf(err, "failed to add child ID %q", c.id)
+					return fmt.Errorf("failed to add child ID %q: %w", c.id, err)
 				}
 			}
 		}
 	}
 	if err := putFileSize(md, bucketKeyUncompressedOffset, m.UncompressedOffset); err != nil {
-		return errors.Wrapf(err, "failed to set UncompressedOffset value %d", m.UncompressedOffset)
+		return fmt.Errorf("failed to set UncompressedOffset value %d: %w", m.UncompressedOffset, err)
 	}
 
 	return nil

--- a/service/keychain/cri/cri.go
+++ b/service/keychain/cri/cri.go
@@ -34,6 +34,8 @@ package cri
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -41,7 +43,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
 	distribution "github.com/containerd/containerd/reference/docker"
-	"github.com/pkg/errors"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -154,7 +155,7 @@ func (in *instrumentedService) ImageFsInfo(ctx context.Context, r *runtime.Image
 func parseReference(ref string) (reference.Spec, error) {
 	namedRef, err := distribution.ParseDockerRef(ref)
 	if err != nil {
-		return reference.Spec{}, errors.Wrapf(err, "failed to parse image reference %q", ref)
+		return reference.Spec{}, fmt.Errorf("failed to parse image reference %q: %w", ref, err)
 	}
 	return reference.Parse(namedRef.String())
 }

--- a/service/plugin/plugin.go
+++ b/service/plugin/plugin.go
@@ -33,6 +33,8 @@
 package plugin
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -48,7 +50,6 @@ import (
 	"github.com/containerd/containerd/pkg/dialer"
 	"github.com/containerd/containerd/platforms"
 	ctdplugin "github.com/containerd/containerd/plugin"
-	"github.com/pkg/errors"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials/insecure"
@@ -133,16 +134,16 @@ func init() {
 				runtime.RegisterImageServiceServer(rpc, criServer)
 				// Prepare the directory for the socket
 				if err := os.MkdirAll(filepath.Dir(addr), 0700); err != nil {
-					return nil, errors.Wrapf(err, "failed to create directory %q", filepath.Dir(addr))
+					return nil, fmt.Errorf("failed to create directory %q: %w", filepath.Dir(addr), err)
 				}
 				// Try to remove the socket file to avoid EADDRINUSE
 				if err := os.RemoveAll(addr); err != nil {
-					return nil, errors.Wrapf(err, "failed to remove %q", addr)
+					return nil, fmt.Errorf("failed to remove %q: %w", addr, err)
 				}
 				// Listen and serve
 				l, err := net.Listen("unix", addr)
 				if err != nil {
-					return nil, errors.Wrapf(err, "error on listen socket %q", addr)
+					return nil, fmt.Errorf("error on listen socket %q: %w", addr, err)
 				}
 				go func() {
 					if err := rpc.Serve(l); err != nil {

--- a/service/resolver/cri.go
+++ b/service/resolver/cri.go
@@ -43,6 +43,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -57,7 +58,6 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	dconfig "github.com/containerd/containerd/remotes/docker/config"
 	rhttp "github.com/hashicorp/go-retryablehttp"
-	"github.com/pkg/errors"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -144,12 +144,12 @@ func RegistryHostsFromCRIConfig(ctx context.Context, config Registry, credsFuncs
 
 		endpoints, err := registryEndpoints(config, host)
 		if err != nil {
-			return nil, errors.Wrap(err, "get registry endpoints")
+			return nil, fmt.Errorf("get registry endpoints: %w", err)
 		}
 		for _, e := range endpoints {
 			u, err := url.Parse(e)
 			if err != nil {
-				return nil, errors.Wrapf(err, "parse registry endpoint %q from mirrors", e)
+				return nil, fmt.Errorf("parse registry endpoint %q from mirrors: %w", e, err)
 			}
 
 			var (
@@ -163,7 +163,7 @@ func RegistryHostsFromCRIConfig(ctx context.Context, config Registry, credsFuncs
 				if tr, ok := rclient.HTTPClient.Transport.(*http.Transport); ok {
 					tr.TLSClientConfig, err = getTLSConfig(*config.TLS)
 					if err != nil {
-						return nil, errors.Wrapf(err, "get TLSConfig for registry %q", e)
+						return nil, fmt.Errorf("get TLSConfig for registry %q: %w", e, err)
 					}
 				} else {
 					return nil, errors.New("TLS config cannot be applied; Client.Transport is not *http.Transport")
@@ -232,15 +232,15 @@ func getTLSConfig(registryTLSConfig TLSConfig) (*tls.Config, error) {
 		err       error
 	)
 	if registryTLSConfig.CertFile != "" && registryTLSConfig.KeyFile == "" {
-		return nil, errors.Errorf("cert file %q was specified, but no corresponding key file was specified", registryTLSConfig.CertFile)
+		return nil, fmt.Errorf("cert file %q was specified, but no corresponding key file was specified", registryTLSConfig.CertFile)
 	}
 	if registryTLSConfig.CertFile == "" && registryTLSConfig.KeyFile != "" {
-		return nil, errors.Errorf("key file %q was specified, but no corresponding cert file was specified", registryTLSConfig.KeyFile)
+		return nil, fmt.Errorf("key file %q was specified, but no corresponding cert file was specified", registryTLSConfig.KeyFile)
 	}
 	if registryTLSConfig.CertFile != "" && registryTLSConfig.KeyFile != "" {
 		cert, err = tls.LoadX509KeyPair(registryTLSConfig.CertFile, registryTLSConfig.KeyFile)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to load cert file")
+			return nil, fmt.Errorf("failed to load cert file: %w", err)
 		}
 		if len(cert.Certificate) != 0 {
 			tlsConfig.Certificates = []tls.Certificate{cert}
@@ -251,11 +251,11 @@ func getTLSConfig(registryTLSConfig TLSConfig) (*tls.Config, error) {
 	if registryTLSConfig.CAFile != "" {
 		caCertPool, err := x509.SystemCertPool()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to get system cert pool")
+			return nil, fmt.Errorf("failed to get system cert pool: %w", err)
 		}
 		caCert, err := os.ReadFile(registryTLSConfig.CAFile)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to load CA file")
+			return nil, fmt.Errorf("failed to load CA file: %w", err)
 		}
 		caCertPool.AppendCertsFromPEM(caCert)
 		tlsConfig.RootCAs = caCertPool
@@ -308,19 +308,19 @@ func registryEndpoints(config Registry, host string) ([]string, error) {
 	}
 	defaultHost, err := docker.DefaultHost(host)
 	if err != nil {
-		return nil, errors.Wrap(err, "get default host")
+		return nil, fmt.Errorf("get default host: %w", err)
 	}
 	for i := range endpoints {
 		en, err := addDefaultScheme(endpoints[i])
 		if err != nil {
-			return nil, errors.Wrap(err, "parse endpoint url")
+			return nil, fmt.Errorf("parse endpoint url: %w", err)
 		}
 		endpoints[i] = en
 	}
 	for _, e := range endpoints {
 		u, err := url.Parse(e)
 		if err != nil {
-			return nil, errors.Wrap(err, "parse endpoint url")
+			return nil, fmt.Errorf("parse endpoint url: %w", err)
 		}
 		if u.Host == host {
 			// Do not add default if the endpoint already exists.
@@ -341,7 +341,7 @@ func ParseAuth(auth *runtime.AuthConfig, host string) (string, string, error) {
 		// Do not return the auth info when server address doesn't match.
 		u, err := url.Parse(auth.ServerAddress)
 		if err != nil {
-			return "", "", errors.Wrap(err, "parse server address")
+			return "", "", fmt.Errorf("parse server address: %w", err)
 		}
 		if host != u.Host {
 			return "", "", nil
@@ -362,7 +362,7 @@ func ParseAuth(auth *runtime.AuthConfig, host string) (string, string, error) {
 		}
 		fields := strings.SplitN(string(decoded), ":", 2)
 		if len(fields) != 2 {
-			return "", "", errors.Errorf("invalid decoded auth: %q", decoded)
+			return "", "", fmt.Errorf("invalid decoded auth: %q", decoded)
 		}
 		user, passwd := fields[0], fields[1]
 		return user, strings.Trim(passwd, "\x00"), nil

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -34,7 +34,7 @@ package snapshot
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -52,7 +52,6 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/moby/sys/mountinfo"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
@@ -176,7 +175,7 @@ func NewSnapshotter(ctx context.Context, root string, targetFs FileSystem, opts 
 	}
 
 	if err := o.restoreRemoteSnapshot(ctx); err != nil {
-		return nil, errors.Wrap(err, "failed to restore remote snapshot")
+		return nil, fmt.Errorf("failed to restore remote snapshot: %w", err)
 	}
 
 	return o, nil
@@ -278,7 +277,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 		if err := o.prepareRemoteSnapshot(lCtx, key, base.Labels); err != nil {
 			log.G(lCtx).WithField(remoteSnapshotLogKey, prepareFailed).
 				WithError(err).Warn("failed to prepare remote snapshot")
-			if !goerrors.Is(err, ErrNoZtoc) {
+			if !errors.Is(err, ErrNoZtoc) {
 				commonmetrics.IncOperationCount(commonmetrics.FuseMountFailureCount, digest.Digest(""))
 			}
 		} else {
@@ -287,7 +286,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 			if err == nil || errdefs.IsAlreadyExists(err) {
 				// count also AlreadyExists as "success"
 				log.G(lCtx).WithField(remoteSnapshotLogKey, prepareSucceeded).Info("Remote snapshot successfully prepared.")
-				return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "target snapshot %q", target)
+				return nil, fmt.Errorf("target snapshot %q: %w", target, errdefs.ErrAlreadyExists)
 			}
 			log.G(lCtx).WithField(remoteSnapshotLogKey, prepareFailed).
 				WithError(err).Warn("failed to internally commit remote snapshot")
@@ -311,7 +310,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 				// there's no need to provide any details on []mount.Mount because mounting is already taken care of
 				// by snapshotter
 				log.G(lCtx).WithField(remoteSnapshotLogKey, prepareSucceeded).Info("Local snapshot successfully prepared")
-				return nil, errors.Wrapf(errdefs.ErrAlreadyExists, "target snapshot %q", target)
+				return nil, fmt.Errorf("target snapshot %q: %w", target, errdefs.ErrAlreadyExists)
 			}
 			log.G(lCtx).WithField(remoteSnapshotLogKey, prepareFailed).
 				WithError(err).Warn("failed to internally commit local snapshot")
@@ -343,7 +342,7 @@ func (o *snapshotter) Mounts(ctx context.Context, key string) ([]mount.Mount, er
 	s, err := storage.GetSnapshot(ctx, key)
 	t.Rollback()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get active mount")
+		return nil, fmt.Errorf("failed to get active mount: %w", err)
 	}
 	return o.mounts(ctx, s, key)
 }
@@ -381,7 +380,7 @@ func (o *snapshotter) commit(ctx context.Context, isRemote bool, name, key strin
 	}
 
 	if _, err = storage.CommitActive(ctx, key, name, usage, opts...); err != nil {
-		return errors.Wrap(err, "failed to commit snapshot")
+		return fmt.Errorf("failed to commit snapshot: %w", err)
 	}
 
 	return t.Commit()
@@ -405,7 +404,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 
 	_, _, err = storage.Remove(ctx, key)
 	if err != nil {
-		return errors.Wrap(err, "failed to remove")
+		return fmt.Errorf("failed to remove: %w", err)
 	}
 
 	if !o.asyncRemove {
@@ -413,7 +412,7 @@ func (o *snapshotter) Remove(ctx context.Context, key string) (err error) {
 		const cleanupCommitted = false
 		removals, err = o.getCleanupDirectories(ctx, t, cleanupCommitted)
 		if err != nil {
-			return errors.Wrap(err, "unable to get directories for removal")
+			return fmt.Errorf("unable to get directories for removal: %w", err)
 		}
 
 		// Remove directories after the transaction is closed, failures must not
@@ -520,7 +519,7 @@ func (o *snapshotter) cleanupSnapshotDirectory(ctx context.Context, dir string) 
 		log.G(ctx).WithError(err).WithField("dir", mp).Debug("failed to unmount")
 	}
 	if err := os.RemoveAll(dir); err != nil {
-		return errors.Wrapf(err, "failed to remove directory %q", dir)
+		return fmt.Errorf("failed to remove directory %q: %w", dir, err)
 	}
 	return nil
 }
@@ -542,7 +541,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 			if path != "" {
 				if err1 := o.cleanupSnapshotDirectory(ctx, path); err1 != nil {
 					log.G(ctx).WithError(err1).WithField("path", path).Error("failed to reclaim snapshot directory, directory may need removal")
-					err = errors.Wrapf(err, "failed to remove path: %v", err1)
+					err = fmt.Errorf("failed to remove path: %v: %w", err1, err)
 				}
 			}
 		}
@@ -554,7 +553,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 		if rerr := t.Rollback(); rerr != nil {
 			log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
 		}
-		return storage.Snapshot{}, errors.Wrap(err, "failed to create prepare snapshot dir")
+		return storage.Snapshot{}, fmt.Errorf("failed to create prepare snapshot dir: %w", err)
 	}
 	rollback := true
 	defer func() {
@@ -567,13 +566,13 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 
 	s, err := storage.CreateSnapshot(ctx, kind, key, parent, opts...)
 	if err != nil {
-		return storage.Snapshot{}, errors.Wrap(err, "failed to create snapshot")
+		return storage.Snapshot{}, fmt.Errorf("failed to create snapshot: %w", err)
 	}
 
 	if len(s.ParentIDs) > 0 {
 		st, err := os.Stat(o.upperPath(s.ParentIDs[0]))
 		if err != nil {
-			return storage.Snapshot{}, errors.Wrap(err, "failed to stat parent")
+			return storage.Snapshot{}, fmt.Errorf("failed to stat parent: %w", err)
 		}
 
 		stat := st.Sys().(*syscall.Stat_t)
@@ -582,19 +581,19 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 			if rerr := t.Rollback(); rerr != nil {
 				log.G(ctx).WithError(rerr).Warn("failed to rollback transaction")
 			}
-			return storage.Snapshot{}, errors.Wrap(err, "failed to chown")
+			return storage.Snapshot{}, fmt.Errorf("failed to chown: %w", err)
 		}
 	}
 
 	path = filepath.Join(snapshotDir, s.ID)
 	if err = os.Rename(td, path); err != nil {
-		return storage.Snapshot{}, errors.Wrap(err, "failed to rename")
+		return storage.Snapshot{}, fmt.Errorf("failed to rename: %w", err)
 	}
 	td = ""
 
 	rollback = false
 	if err = t.Commit(); err != nil {
-		return storage.Snapshot{}, errors.Wrap(err, "commit failed")
+		return storage.Snapshot{}, fmt.Errorf("commit failed: %w", err)
 	}
 
 	return s, nil
@@ -603,7 +602,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, kind snapshots.Kind) (string, error) {
 	td, err := os.MkdirTemp(snapshotDir, "new-")
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create temp dir")
+		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
 	if err := os.Mkdir(filepath.Join(td, "fs"), 0711); err != nil {
@@ -622,7 +621,7 @@ func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 func (o *snapshotter) mounts(ctx context.Context, s storage.Snapshot, checkKey string) ([]mount.Mount, error) {
 	// Make sure that all layers lower than the target layer are available
 	if checkKey != "" && !o.checkAvailability(ctx, checkKey) {
-		return nil, errors.Wrapf(errdefs.ErrUnavailable, "layer %q unavailable", s.ID)
+		return nil, fmt.Errorf("layer %q unavailable: %w", s.ID, errdefs.ErrUnavailable)
 	}
 
 	if len(s.ParentIDs) == 0 {
@@ -787,7 +786,7 @@ func (o *snapshotter) restoreRemoteSnapshot(ctx context.Context) error {
 	for _, m := range mounts {
 		if strings.HasPrefix(m.Mountpoint, filepath.Join(o.root, "snapshots")) {
 			if err := syscall.Unmount(m.Mountpoint, syscall.MNT_FORCE); err != nil {
-				return errors.Wrapf(err, "failed to unmount %s", m.Mountpoint)
+				return fmt.Errorf("failed to unmount %s: %w", m.Mountpoint, err)
 			}
 		}
 	}
@@ -803,7 +802,7 @@ func (o *snapshotter) restoreRemoteSnapshot(ctx context.Context) error {
 	}
 	for _, info := range task {
 		if err := o.prepareRemoteSnapshot(ctx, info.Name, info.Labels); err != nil {
-			return errors.Wrapf(err, "failed to prepare remote snapshot: %s", info.Name)
+			return fmt.Errorf("failed to prepare remote snapshot %s: %w", info.Name, err)
 		}
 	}
 

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -33,7 +34,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	orascontent "oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"

--- a/util/dockershell/exec/cmd.go
+++ b/util/dockershell/exec/cmd.go
@@ -33,10 +33,9 @@
 package exec
 
 import (
+	"fmt"
 	"io"
 	"os/exec"
-
-	"github.com/pkg/errors"
 )
 
 // Supported checks if this pkg can run on the current system.
@@ -55,7 +54,7 @@ type Exec struct {
 // New creates a new Exec for the specified container.
 func New(containerName string) (*Exec, error) {
 	if err := exec.Command("docker", "inspect", containerName).Run(); err != nil {
-		return nil, errors.Wrapf(err, "container %v is unavailable", containerName)
+		return nil, fmt.Errorf("container %v is unavailable: %w", containerName, err)
 	}
 	return &Exec{containerName}, nil
 }
@@ -69,7 +68,7 @@ func (e Exec) Command(name string, arg ...string) *Cmd {
 		containerName: e.ContainerName,
 	}
 	if lp, err := exec.LookPath("docker"); err != nil {
-		cmd.lookPathErr = errors.Wrap(err, "docker command not found")
+		cmd.lookPathErr = fmt.Errorf("docker command not found: %w", err)
 	} else {
 		cmd.dockerExec.Path = lp
 	}

--- a/util/testutil/ensurehello.go
+++ b/util/testutil/ensurehello.go
@@ -35,6 +35,7 @@ package testutil
 import (
 	"compress/gzip"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -44,7 +45,6 @@ import (
 	"github.com/containerd/containerd/images/archive"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -89,7 +89,7 @@ func EnsureHello(ctx context.Context) (*ocispec.Descriptor, content.Store, error
 	}
 	resp.Body.Close()
 	if d := sha256Digester.Digest().String(); d != HelloArchiveDigest {
-		err = errors.Errorf("expected digest of %q to be %q, got %q", HelloArchiveURL, HelloArchiveDigest, d)
+		err = fmt.Errorf("expected digest of %q to be %q, got %q", HelloArchiveURL, HelloArchiveDigest, d)
 		return nil, nil, err
 	}
 	return &desc, cs, nil

--- a/util/testutil/util.go
+++ b/util/testutil/util.go
@@ -43,8 +43,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -56,7 +54,7 @@ const (
 // TestingL is a Logger instance used during testing. This allows tests to prints logs in realtime.
 var TestingL = log.New(os.Stdout, "testing: ", log.Ldate|log.Ltime)
 
-// TestingLlogDest returns Writes of Testing.T.
+// TestingLogDest returns Writes of Testing.T.
 func TestingLogDest() (io.Writer, io.Writer) {
 	return TestingL.Writer(), TestingL.Writer()
 }
@@ -68,7 +66,7 @@ func StreamTestingLogToFile(destPath string) (func() error, error) {
 	}
 	f, err := os.Create(destPath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create %v", destPath)
+		return nil, fmt.Errorf("failed to create %v: %w", destPath, err)
 	}
 	TestingL.SetOutput(io.MultiWriter(f, os.Stdout))
 	return f.Close, nil


### PR DESCRIPTION
Signed-off-by: Jin Dong <jindon@amazon.com>

*Issue #, if available:*

Fix #321

*Description of changes:*

Remove archived `github.com/pkg/errors` package and use `errors`.

`errors.Is(err, ...)` -> `errors.Is(err, ...)` (golang's `errors` pkg has the same func)

`errors.Wrap(err)` -> `fmt.Errorf("%w", err)`

A behavior difference is that, `errors.Wrap(nil)` returns `nil`, whereas `fmt.Errorf("%w", nil)` returns a non-nil error (%!w(<nil>)). That means we should check if `err != nil` before using `fmt.Errorf("%w", err)`.

It makes sense to me since it makes error-handling more explicit. An example is:

https://github.com/awslabs/soci-snapshotter/blob/235146bfc76f92a39a40e54b382fa88b1f9224cb/metadata/db/reader.go#L339-L342

*Testing performed:*

make test && make integration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
