### PR TITLE
Add runtime configuration for minimum layer size for remote mount

### DIFF
--- a/fs/source/source.go
+++ b/fs/source/source.go
@@ -83,8 +83,8 @@ const (
 	// TargetDigestLabel is a label which contains layer digest.
 	TargetDigestLabel = "containerd.io/snapshot/remote/soci.digest"
 
-	// targetSizeLabel is a label which contains layer size.
-	targetSizeLabel = "containerd.io/snapshot/remote/soci.size"
+	// TargetSizeLabel is a label which contains layer size.
+	TargetSizeLabel = "containerd.io/snapshot/remote/soci.size"
 
 	// targetImageLayersDigestLabel is a label which contains layer digests contained in
 	// the target image.
@@ -130,7 +130,7 @@ func FromDefaultLabels(hosts RegistryHosts) GetSources {
 			return nil, err
 		}
 
-		targetSizeStr, ok := labels[targetSizeLabel]
+		targetSizeStr, ok := labels[TargetSizeLabel]
 		if !ok {
 			return nil, fmt.Errorf("layer size hasn't been passed")
 		}
@@ -209,7 +209,7 @@ func AppendDefaultLabelsHandlerWrapper(ref, indexDigest string) func(f images.Ha
 						c.Annotations[TargetImgManifestDigestLabel] = desc.Digest.String()
 						c.Annotations[TargetRefLabel] = ref
 						c.Annotations[TargetDigestLabel] = c.Digest.String()
-						c.Annotations[targetSizeLabel] = fmt.Sprintf("%d", c.Size)
+						c.Annotations[TargetSizeLabel] = fmt.Sprintf("%d", c.Size)
 						c.Annotations[TargetSociIndexDigestLabel] = indexDigest
 						var layerDigests string
 						var layerSizes string

--- a/service/config.go
+++ b/service/config.go
@@ -48,6 +48,9 @@ type Config struct {
 
 	// ResolverConfig is config for resolving registries.
 	ResolverConfig `toml:"resolver"`
+
+	// MinLayerSize skips remote mounting of smaller layers
+	MinLayerSize int `toml:"min_layer_size"`
 }
 
 // KubeconfigKeychainConfig is config for kubeconfig-based keychain.

--- a/service/service.go
+++ b/service/service.go
@@ -108,7 +108,12 @@ func NewSociSnapshotterService(ctx context.Context, root string, config *Config,
 
 	var snapshotter snapshots.Snapshotter
 
-	snapshotter, err = snbase.NewSnapshotter(ctx, snapshotterRoot(root), fs, snbase.AsynchronousRemove)
+	snOpts := []snbase.Opt{snbase.WithAsynchronousRemove}
+	if config.MinLayerSize > -1 {
+		snOpts = append(snOpts, snbase.WithMinLayerSize(config.MinLayerSize))
+	}
+
+	snapshotter, err = snbase.NewSnapshotter(ctx, snapshotterRoot(root), fs, snOpts...)
 	if err != nil {
 		log.G(ctx).WithError(err).Fatalf("failed to create new snapshotter")
 	}


### PR DESCRIPTION
*Issue #, if available:*
closes #172 

*Description of changes:*
Adds an option to `soci-snapshotter-grpc/config.toml` to set a minimum size for remote mounting. Smaller layers will always be locally mounted.

*Testing performed:*
Ran automated test, and manual similar tests with other images and thresholds, with and without new config.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.