### PR TITLE
Allow manually remove invalid snapshots on restore

### DIFF
--- a/service/config.go
+++ b/service/config.go
@@ -79,4 +79,10 @@ type ResolverConfig resolver.Config
 type SnapshotterConfig struct {
 	// MinLayerSize skips remote mounting of smaller layers
 	MinLayerSize int64 `toml:"min_layer_size"`
+
+	// AllowInvalidMountsOnRestart allows that there are snapshot mounts that cannot access to the
+	// data source when restarting the snapshotter.
+	// NOTE: User needs to manually remove the snapshots from containerd's metadata store using
+	//       ctr (e.g. `ctr snapshot rm`).
+	AllowInvalidMountsOnRestart bool `toml:"allow_invalid_mounts_on_restart"`
 }

--- a/service/service.go
+++ b/service/service.go
@@ -112,6 +112,9 @@ func NewSociSnapshotterService(ctx context.Context, root string, config *Config,
 	if config.MinLayerSize > -1 {
 		snOpts = append(snOpts, snbase.WithMinLayerSize(config.MinLayerSize))
 	}
+	if config.SnapshotterConfig.AllowInvalidMountsOnRestart {
+		snOpts = append(snOpts, snbase.AllowInvalidMountsOnRestart)
+	}
 
 	snapshotter, err = snbase.NewSnapshotter(ctx, snapshotterRoot(root), fs, snOpts...)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:* closes #93
The problem that #93 tries to fix is that if the snapshotter crashes, it won't be able to restart because the snapshotter won't be able to restore the remote snapshots ([this](https://github.com/awslabs/soci-snapshotter/blob/main/snapshot/snapshot.go#L177) will error out), so it will crash again and again.

*Description of changes:*
cherry-pick https://github.com/containerd/stargz-snapshotter/pull/901

*Testing performed:*
I was not able to reproduce the problem (details above) by killing (SIGKILL-ing) the soci-snapshotter-grpc process when the container is running.  I might have repro'd once... so I was not able to verify this PR fixes the problem. But I think this PR is still worth merging considering 1) it's defensive programming 2) it's cherrypicked from stargz repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
