### PR TITLE
Decouple ztoc creation and compression algorithm

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.15.14 // indirect
+	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/moby/locker v1.0.1 // indirect

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -983,8 +983,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.15.14 h1:i7WCKDToww0wA+9qrUZ1xOjp218vfFo3nTU6UHp+gOc=
-github.com/klauspost/compress v1.15.14/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
+github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hanwen/go-fuse/v2 v2.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.2
+	github.com/klauspost/compress v1.15.15
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/montanaflynn/stats v0.7.0
 	github.com/opencontainers/go-digest v1.0.0
@@ -64,7 +65,6 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.15.14 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/moby/locker v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -970,8 +970,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.15.14 h1:i7WCKDToww0wA+9qrUZ1xOjp218vfFo3nTU6UHp+gOc=
-github.com/klauspost/compress v1.15.14/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
+github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/ztoc/testutils.go
+++ b/ztoc/testutils.go
@@ -36,7 +36,7 @@ func BuildZtocReader(ents []testutil.TarEntry, compressionLevel int, spanSize in
 	defer os.Remove(tarFileName)
 
 	sr := io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData)))
-	ztoc, err := BuildZtoc(tarFileName, spanSize, "test")
+	ztoc, err := NewBuilder("test").BuildZtoc(tarFileName, spanSize)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build sample ztoc: %v", err)
 	}

--- a/ztoc/toc_builder_test.go
+++ b/ztoc/toc_builder_test.go
@@ -1,0 +1,111 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ztoc
+
+import (
+	"compress/gzip"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/util/testutil"
+	"github.com/klauspost/compress/zstd"
+)
+
+func TestTocBuilder(t *testing.T) {
+	t.Parallel()
+
+	tarEntries := []testutil.TarEntry{
+		testutil.File("test1", string(testutil.RandomByteData(10000000))),
+		testutil.File("test2", string(testutil.RandomByteData(20000000))),
+	}
+
+	tarReader := func(entries []testutil.TarEntry) io.Reader {
+		return testutil.BuildTar(entries)
+	}
+
+	gzipTarReader := func(entries []testutil.TarEntry) io.Reader {
+		return testutil.BuildTarGz(entries, gzip.BestCompression)
+	}
+
+	zstdTarReader := func(entries []testutil.TarEntry) io.Reader {
+		return testutil.BuildTarZstd(entries, int(zstd.SpeedDefault))
+	}
+
+	testCases := []struct {
+		name          string
+		algorithm     string
+		tarEntries    []testutil.TarEntry
+		makeTarReader func(entries []testutil.TarEntry) io.Reader
+		expectErr     bool
+	}{
+		{
+			name:          "TocBuilder supports gzip",
+			algorithm:     CompressionGzip,
+			tarEntries:    tarEntries,
+			makeTarReader: gzipTarReader,
+			expectErr:     false,
+		},
+		{
+			name:          "TocBuilder supports zstd",
+			algorithm:     CompressionZstd,
+			tarEntries:    tarEntries,
+			makeTarReader: zstdTarReader,
+			expectErr:     false,
+		},
+		{
+			name:          "TocBuilder doesn't support foobar",
+			algorithm:     "foobar",
+			tarEntries:    tarEntries,
+			makeTarReader: tarReader,
+			expectErr:     true,
+		},
+		{
+			name:          "TocBuilder returns error if given tar file and algorithm mismatch",
+			algorithm:     CompressionZstd,
+			tarEntries:    tarEntries,
+			makeTarReader: gzipTarReader,
+			expectErr:     true,
+		},
+	}
+
+	builder := NewTocBuilder()
+	builder.RegisterTarProvider(CompressionGzip, TarProviderGzip)
+	builder.RegisterTarProvider(CompressionZstd, TarProviderZstd)
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tarReader := tt.makeTarReader(tt.tarEntries)
+			tarFile, _, err := testutil.WriteTarToTempFile("toc_builder", tarReader)
+			if err != nil {
+				t.Fatalf("failed to write content to tar file: %v", err)
+			}
+			defer os.Remove(tarFile)
+
+			if toc, _, err := builder.TocFromFile(tt.algorithm, tarFile); err != nil {
+				if !tt.expectErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if len(toc.Metadata) != len(tt.tarEntries) {
+					t.Fatalf("count of file metadata mismatch, expect: %d, actual: %d", len(tt.tarEntries), len(toc.Metadata))
+				}
+			}
+		})
+	}
+}

--- a/ztoc/zinfo_builder.go
+++ b/ztoc/zinfo_builder.go
@@ -1,0 +1,115 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ztoc
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/awslabs/soci-snapshotter/compression"
+	"github.com/opencontainers/go-digest"
+)
+
+// ZinfoBuilder builds the `zinfo` part of a ztoc. This interface should be
+// implemented for each compression algorithm we support.
+type ZinfoBuilder interface {
+	// ZinfoFromFile builds zinfo given a compressed tar filename and span size, and calculate the size of the file.
+	ZinfoFromFile(filename string, spanSize int64) (zinfo CompressionInfo, fs compression.Offset, err error)
+}
+
+type gzipZinfoBuilder struct{}
+
+// ZinfoFromFile creates zinfo for a gzip file. The underlying zinfo object (i.e. `GzipZinfo`)
+// is stored in `CompressionInfo.Checkpoints` as byte slice.
+func (gzb gzipZinfoBuilder) ZinfoFromFile(filename string, spanSize int64) (zinfo CompressionInfo, fs compression.Offset, err error) {
+	index, err := compression.NewGzipZinfoFromFile(filename, spanSize)
+	if err != nil {
+		return
+	}
+	defer index.Close()
+
+	fs, err = getFileSize(filename)
+	if err != nil {
+		return
+	}
+
+	digests, err := getPerSpanDigests(filename, int64(fs), index)
+	if err != nil {
+		return
+	}
+
+	checkpoints, err := index.Bytes()
+	if err != nil {
+		return
+	}
+
+	return CompressionInfo{
+		MaxSpanID:   index.MaxSpanID(),
+		SpanDigests: digests,
+		Checkpoints: checkpoints,
+	}, fs, nil
+}
+
+func getPerSpanDigests(filename string, fileSize int64, index *compression.GzipZinfo) ([]digest.Digest, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("could not open file for reading: %w", err)
+	}
+	defer file.Close()
+
+	var digests []digest.Digest
+	var i compression.SpanID
+	maxSpanID := index.MaxSpanID()
+	for i = 0; i <= maxSpanID; i++ {
+		var (
+			startOffset = index.SpanIDToCompressedOffset(i)
+			endOffset   compression.Offset
+		)
+
+		if index.HasBits(i) {
+			startOffset--
+		}
+
+		if i == maxSpanID {
+			endOffset = compression.Offset(fileSize)
+		} else {
+			endOffset = index.SpanIDToCompressedOffset(i + 1)
+		}
+
+		section := io.NewSectionReader(file, int64(startOffset), int64(endOffset-startOffset))
+		dgst, err := digest.FromReader(section)
+		if err != nil {
+			return nil, fmt.Errorf("unable to compute digest for section; start=%d, end=%d, file=%s, size=%d", startOffset, endOffset, filename, fileSize)
+		}
+		digests = append(digests, dgst)
+	}
+	return digests, nil
+}
+
+func getFileSize(file string) (compression.Offset, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return compression.Offset(st.Size()), nil
+}

--- a/ztoc/ztoc.go
+++ b/ztoc/ztoc.go
@@ -28,6 +28,14 @@ import (
 	"github.com/awslabs/soci-snapshotter/compression"
 )
 
+// Compression algorithms used by an image layer. They should be kept consistent
+// with the return of `DiffCompression` from containerd.
+// https://github.com/containerd/containerd/blob/v1.7.0-beta.3/images/mediatypes.go#L66
+const (
+	CompressionGzip = "gzip"
+	CompressionZstd = "zstd"
+)
+
 // Ztoc is a table of contents for compressed data which consists 2 parts:
 //
 // (1). toc (`TOC`): a table of contents containing file metadata and its

--- a/ztoc/ztoc_builder.go
+++ b/ztoc/ztoc_builder.go
@@ -17,55 +17,83 @@
 package ztoc
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"fmt"
-	"io"
-	"os"
-
-	"github.com/awslabs/soci-snapshotter/compression"
-	"github.com/opencontainers/go-digest"
 )
 
-func BuildZtoc(gzipFile string, span int64, buildToolIdentifier string) (*Ztoc, error) {
-	if gzipFile == "" {
-		return nil, fmt.Errorf("need to provide gzip file")
+// Builder holds a single `TocBuilder` that builds toc, and one `ZinfoBuilder`
+// *per* compression algorithm that builds zinfo. `TocBuilder` is shared by different
+// compression algorithms. Which `ZinfoBuilder` is used depends on the compression
+// algorithm used by the layer.
+type Builder struct {
+	tocBuilder    TocBuilder
+	zinfoBuilders map[string]ZinfoBuilder
+
+	buildToolIdentifier string
+}
+
+// NewBuilder creates a `Builder` used to build ztocs. By default it supports gzip,
+// user can register new compression algorithms by calling `RegisterCompressionAlgorithm`.
+func NewBuilder(buildToolIdentifier string) *Builder {
+	builder := Builder{
+		tocBuilder:          NewTocBuilder(),
+		zinfoBuilders:       make(map[string]ZinfoBuilder),
+		buildToolIdentifier: buildToolIdentifier,
+	}
+	builder.RegisterCompressionAlgorithm(CompressionGzip, TarProviderGzip, gzipZinfoBuilder{})
+
+	return &builder
+}
+
+// buildConfig contains configuration used when `ztoc.Builder` builds a `Ztoc`.
+type buildConfig struct {
+	algorithm string
+}
+
+// BuildOption specifies a change to `buildConfig` when building a ztoc.
+type BuildOption func(opt *buildConfig) error
+
+// WithCompression specifies which compression algorithm is used by the layer.
+func WithCompression(algorithm string) BuildOption {
+	return func(opt *buildConfig) error {
+		opt.algorithm = algorithm
+		return nil
+	}
+}
+
+// defaultBuildConfig creates a `buildConfig` with default values.
+func defaultBuildConfig() buildConfig {
+	return buildConfig{
+		algorithm: CompressionGzip, // use gzip by default
+	}
+}
+
+// BuildZtoc builds a `Ztoc` given the filename of a layer blob. By default it assumes
+// the layer is compressed using `gzip`, unless specified via `WithCompression`.
+func (b *Builder) BuildZtoc(filename string, span int64, options ...BuildOption) (*Ztoc, error) {
+	if filename == "" {
+		return nil, fmt.Errorf("need to provide a compressed filename")
 	}
 
-	index, err := compression.NewGzipZinfoFromFile(gzipFile, span)
+	opt := defaultBuildConfig()
+	for _, f := range options {
+		err := f(&opt)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if !b.CheckCompressionAlgorithm(opt.algorithm) {
+		return nil, fmt.Errorf("unsupported compression algorithm, supported: gzip, got: %s", opt.algorithm)
+	}
+
+	compressionInfo, fs, err := b.zinfoBuilders[opt.algorithm].ZinfoFromFile(filename, span)
 	if err != nil {
 		return nil, err
 	}
-	defer index.Close()
 
-	fm, uncompressedArchiveSize, err := getGzipFileMetadata(gzipFile, index)
+	toc, uncompressedArchiveSize, err := b.tocBuilder.TocFromFile(opt.algorithm, filename)
 	if err != nil {
 		return nil, err
-	}
-
-	fs, err := getFileSize(gzipFile)
-	if err != nil {
-		return nil, err
-	}
-
-	digests, err := getPerSpanDigests(gzipFile, int64(fs), index)
-	if err != nil {
-		return nil, err
-	}
-
-	checkpoints, err := index.Bytes()
-	if err != nil {
-		return nil, err
-	}
-
-	toc := TOC{
-		Metadata: fm,
-	}
-
-	compressionInfo := CompressionInfo{
-		MaxSpanID:   index.MaxSpanID(),
-		SpanDigests: digests,
-		Checkpoints: checkpoints,
 	}
 
 	return &Ztoc{
@@ -73,182 +101,26 @@ func BuildZtoc(gzipFile string, span int64, buildToolIdentifier string) (*Ztoc, 
 		TOC:                     toc,
 		CompressedArchiveSize:   fs,
 		UncompressedArchiveSize: uncompressedArchiveSize,
-		BuildToolIdentifier:     buildToolIdentifier,
+		BuildToolIdentifier:     b.buildToolIdentifier,
 		CompressionInfo:         compressionInfo,
 	}, nil
 }
 
-func getPerSpanDigests(gzipFile string, fileSize int64, index *compression.GzipZinfo) ([]digest.Digest, error) {
-	file, err := os.Open(gzipFile)
-	if err != nil {
-		return nil, fmt.Errorf("could not open file for reading: %w", err)
+// RegisterCompressionAlgorithm supports a new compression algorithm in `ztoc.Builder`.
+func (b *Builder) RegisterCompressionAlgorithm(name string, tarProvider TarProvider, zinfoBuilder ZinfoBuilder) {
+	if b.zinfoBuilders == nil {
+		b.zinfoBuilders = make(map[string]ZinfoBuilder)
 	}
-	defer file.Close()
-
-	var digests []digest.Digest
-	var i compression.SpanID
-	maxSpanID := index.MaxSpanID()
-	for i = 0; i <= maxSpanID; i++ {
-		var (
-			startOffset = index.SpanIDToCompressedOffset(i)
-			endOffset   compression.Offset
-		)
-
-		if index.HasBits(i) {
-			startOffset--
-		}
-
-		if i == maxSpanID {
-			endOffset = compression.Offset(fileSize)
-		} else {
-			endOffset = index.SpanIDToCompressedOffset(i + 1)
-		}
-
-		section := io.NewSectionReader(file, int64(startOffset), int64(endOffset-startOffset))
-		dgst, err := digest.FromReader(section)
-		if err != nil {
-			return nil, fmt.Errorf("unable to compute digest for section; start=%d, end=%d, file=%s, size=%d", startOffset, endOffset, gzipFile, fileSize)
-		}
-		digests = append(digests, dgst)
-	}
-	return digests, nil
+	b.zinfoBuilders[name] = zinfoBuilder
+	b.tocBuilder.RegisterTarProvider(name, tarProvider)
 }
 
-func getGzipFileMetadata(gzipFile string, index *compression.GzipZinfo) ([]FileMetadata, compression.Offset, error) {
-	file, err := os.Open(gzipFile)
-	if err != nil {
-		return nil, 0, fmt.Errorf("could not open file for reading: %v", err)
-	}
-	defer file.Close()
-
-	gzipRdr, err := gzip.NewReader(file)
-	if err != nil {
-		return nil, 0, fmt.Errorf("could not create gzip reader: %v", err)
-	}
-
-	f, sr, uncompressedArchiveSize, err := getTarReader(gzipRdr)
-
-	if err != nil {
-		return nil, 0, err
-	}
-	defer os.Remove(f.Name())
-
-	pt := &positionTrackerReader{r: sr}
-	tarRdr := tar.NewReader(pt)
-	var md []FileMetadata
-
-	for {
-		hdr, err := tarRdr.Next()
-		if err != nil {
-			if err == io.EOF {
-				break
-			} else {
-				return nil, 0, fmt.Errorf("error while reading tar header: %w", err)
-			}
-		}
-
-		fileType, err := getType(hdr)
-		if err != nil {
-			return nil, 0, err
-		}
-
-		metadataEntry := FileMetadata{
-			Name:               hdr.Name,
-			Type:               fileType,
-			UncompressedOffset: pt.CurrentPos(),
-			UncompressedSize:   compression.Offset(hdr.Size),
-			Linkname:           hdr.Linkname,
-			Mode:               hdr.Mode,
-			UID:                hdr.Uid,
-			GID:                hdr.Gid,
-			Uname:              hdr.Uname,
-			Gname:              hdr.Gname,
-			ModTime:            hdr.ModTime,
-			Devmajor:           hdr.Devmajor,
-			Devminor:           hdr.Devminor,
-			Xattrs:             hdr.PAXRecords,
-		}
-		md = append(md, metadataEntry)
-	}
-	return md, uncompressedArchiveSize, nil
-}
-
-func getFileSize(file string) (compression.Offset, error) {
-	f, err := os.Open(file)
-	if err != nil {
-		return 0, err
-	}
-	defer f.Close()
-	st, err := f.Stat()
-	if err != nil {
-		return 0, err
-	}
-	return compression.Offset(st.Size()), nil
-}
-
-func getTarReader(gzipReader io.Reader) (*os.File, *io.SectionReader, compression.Offset, error) {
-	file, err := os.CreateTemp("/tmp", "tempfile-ztoc-builder")
-	if err != nil {
-		return nil, nil, 0, err
-	}
-	_, err = io.Copy(file, gzipReader)
-	if err != nil {
-		os.Remove(file.Name())
-		return nil, nil, 0, err
-	}
-
-	tarRdr, uncompressedArchiveSize, err := tarSectionReaderFromFile(file)
-	if err != nil {
-		return nil, nil, 0, err
-	}
-
-	return file, tarRdr, uncompressedArchiveSize, nil
-}
-
-func getType(header *tar.Header) (fileType string, e error) {
-	switch header.Typeflag {
-	case tar.TypeLink:
-		fileType = "hardlink"
-	case tar.TypeSymlink:
-		fileType = "symlink"
-	case tar.TypeDir:
-		fileType = "dir"
-	case tar.TypeReg:
-		fileType = "reg"
-	case tar.TypeChar:
-		fileType = "char"
-	case tar.TypeBlock:
-		fileType = "block"
-	case tar.TypeFifo:
-		fileType = "fifo"
-	default:
-		return "", fmt.Errorf("unsupported input tar entry %q", header.Typeflag)
-	}
-	return
-}
-
-func tarSectionReaderFromFile(f *os.File) (*io.SectionReader, compression.Offset, error) {
-	st, err := f.Stat()
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return io.NewSectionReader(f, 0, st.Size()), compression.Offset(st.Size()), nil
-}
-
-type positionTrackerReader struct {
-	r   io.ReaderAt
-	pos compression.Offset
-}
-
-func (p *positionTrackerReader) Read(b []byte) (int, error) {
-	n, err := p.r.ReadAt(b, int64(p.pos))
-	if err == nil {
-		p.pos += compression.Offset(n)
-	}
-	return n, err
-}
-
-func (p *positionTrackerReader) CurrentPos() compression.Offset {
-	return p.pos
+// CheckCompressionAlgorithm checks if a compression algorithm is supported.
+//
+// The algorithm has to be supported by both (1) `tocBuilder` (straightforward,
+// create a tar reader from the compressed io.reader in compressionFileReader)
+// and (2) `zinfoBuilder` (require zinfo impl, see `compression/gzip_zinfo.go` as an example).
+func (b *Builder) CheckCompressionAlgorithm(algorithm string) bool {
+	_, ok := b.zinfoBuilders[algorithm]
+	return ok && b.tocBuilder.CheckCompressionAlgorithm(algorithm)
 }

--- a/ztoc/ztoc_test.go
+++ b/ztoc/ztoc_test.go
@@ -83,9 +83,11 @@ func TestDecompress(t *testing.T) {
 		},
 	}
 
+	ztocBuilder := NewBuilder("test")
+
 	for _, tc := range tests {
 		spansize := tc.spanSize
-		ztoc, err := BuildZtoc(tarGzFilePath, spansize, "test")
+		ztoc, err := ztocBuilder.BuildZtoc(tarGzFilePath, spansize)
 		if err != nil {
 			t.Fatalf("%s: can't build ztoc: %v", tc.name, err)
 		}
@@ -167,6 +169,8 @@ func TestZtocGenerationConsistency(t *testing.T) {
 		},
 	}
 
+	ztocBuilder := NewBuilder("test")
+
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			tarReader := testutil.BuildTarGz(tc.tarEntries, gzip.DefaultCompression)
@@ -180,7 +184,7 @@ func TestZtocGenerationConsistency(t *testing.T) {
 				t.Fatalf("failed to get targz files and their contents: %v", err)
 			}
 			spansize := tc.spanSize
-			ztoc1, err := BuildZtoc(tarGzFilePath, spansize, "test")
+			ztoc1, err := ztocBuilder.BuildZtoc(tarGzFilePath, spansize)
 			if err != nil {
 				t.Fatalf("can't build ztoc1: %v", err)
 			}
@@ -191,7 +195,7 @@ func TestZtocGenerationConsistency(t *testing.T) {
 				t.Fatalf("ztoc1 metadata file count mismatch. expected: %d, actual: %d", len(fileNames), len(ztoc1.TOC.Metadata))
 			}
 
-			ztoc2, err := BuildZtoc(tarGzFilePath, spansize, "test")
+			ztoc2, err := ztocBuilder.BuildZtoc(tarGzFilePath, spansize)
 			if err != nil {
 				t.Fatalf("can't build ztoc2: %v", err)
 			}
@@ -304,8 +308,7 @@ func TestZtocGeneration(t *testing.T) {
 				t.Fatalf("failed to get targz files and their contents: %v", err)
 			}
 			spansize := tc.spanSize
-
-			ztoc, err := BuildZtoc(tarGzFilePath, spansize, tc.buildTool)
+			ztoc, err := NewBuilder(tc.buildTool).BuildZtoc(tarGzFilePath, spansize)
 			if err != nil {
 				t.Fatalf("can't build ztoc: error=%v", err)
 			}
@@ -396,7 +399,7 @@ func TestZtocSerialization(t *testing.T) {
 				t.Fatalf("failed to get targz files and their contents: %v", err)
 			}
 			spansize := tc.spanSize
-			createdZtoc, err := BuildZtoc(tarGzFilePath, spansize, tc.buildTool)
+			createdZtoc, err := NewBuilder(tc.buildTool).BuildZtoc(tarGzFilePath, spansize)
 			if err != nil {
 				t.Fatalf("can't build ztoc: error=%v", err)
 			}


### PR DESCRIPTION
Signed-off-by: Jin Dong <jindon@amazon.com>

*Issue #, if available:* Fix #233

*Description of changes:*

Decouple ztoc creation and compression by adding a `ztoc.Builder` which has:

1. A single `ztoc.TocBuilder` that builds `TOC` and works with both gzip and zstd.
2. One `ztoc.ZinfoBuilder` per compression algorithm (currently, only `gzip`).

`ztoc.Builder` has one export func `BuildZtoc` which checks compression algorithm and builds `Ztoc`(`TOC` via `TocBuilder`, `Zinfo` via `ZinfoBuilder`).

`ztoc.TocBuilder` has one export func `TocFromFile` which creates `TOC` given compress algorithm and tar filename. It supports different compression by creating different tar readers through compression libraries (e.g., `gzip.NewReader`, `zstd.NewReader`). 

`ztoc.ZinfoBuilder` interface has one export func `ZinfoFromFile` which creates `Zinfo` given compress tar filename and span size. Currently it has one implementation for `gzip` (`gzipZinfoBuilder`).

*Testing performed:*

make test && make integration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
