### PR TITLE
Fix race in TestRpullImageThenRemove

### DIFF
--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -840,8 +840,8 @@ func TestRpullImageThenRemove(t *testing.T) {
 
 	checkFuseMounts(t, sh, len(sociIndex.Blobs))
 
-	sh.X("ctr", "image", "rm", regConfig.mirror(containerImage).ref)
-	sh.X("ctr", "image", "rm", dockerhub(containerImage).ref)
+	sh.X("ctr", "image", "rm", "--sync", regConfig.mirror(containerImage).ref)
+	sh.X("ctr", "image", "rm", "--sync", dockerhub(containerImage).ref)
 
 	checkFuseMounts(t, sh, 0)
 }


### PR DESCRIPTION


Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*
closes #347 

*Description of changes:*
TestRpullImageThenRemove rpulls and image, verifies that there is a fuse mount for each image layer, removes the image, and verifies that all the fust mounts are removed. Containerd removes snapshots asynchronously via its garbage collector by default after an image is removed. This can race with the final mount check and cause the test to fail. Instead, we should synchronously clean up fuse mounts when removing the image.

*Testing performed:*
`make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
