### PR TITLE
Refactor integ test `buildIndex`

### DIFF
--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -63,7 +63,7 @@ func TestSociCreateSparseIndex(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rebootContainerd(t, sh, "", "")
 			imgInfo := dockerhub(containerImage)
-			indexDigest := buildSparseIndex(sh, imgInfo, tt.minLayerSize, defaultSpanSize)
+			indexDigest := buildIndex(sh, imgInfo, withMinLayerSize(tt.minLayerSize))
 			checkpoints := fetchContentFromPath(sh, blobStorePath+"/"+trimSha256Prefix(indexDigest))
 
 			index, err := soci.NewIndexFromReader(bytes.NewReader(checkpoints))

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -106,7 +106,7 @@ func TestOverlayFallbackMetric(t *testing.T) {
 			name:  "image with all layers having ztocs and no fs.Mount error results in 0 overlay fallback",
 			image: rabbitmqImage,
 			indexDigestFn: func(sh *shell.Shell, image imageInfo) string {
-				return buildSparseIndex(sh, image, 0, defaultSpanSize)
+				return buildIndex(sh, image, withMinLayerSize(0))
 			},
 			expectedFallbackCount: 0,
 		},
@@ -114,7 +114,7 @@ func TestOverlayFallbackMetric(t *testing.T) {
 			name:  "image with some layers not having ztoc and no fs.Mount results in 0 overlay fallback",
 			image: rabbitmqImage,
 			indexDigestFn: func(sh *shell.Shell, image imageInfo) string {
-				return buildSparseIndex(sh, image, defaultMinLayerSize, defaultSpanSize)
+				return buildIndex(sh, image, withMinLayerSize(defaultMinLayerSize))
 			},
 			expectedFallbackCount: 0,
 		},
@@ -184,7 +184,7 @@ log_fuse_operations = true
 			name:  "image with valid ztocs and index doesn't cause fuse file.read failures",
 			image: rabbitmqImage,
 			indexDigestFn: func(t *testing.T, sh *shell.Shell, image imageInfo) string {
-				return buildSparseIndex(sh, image, 0, defaultSpanSize)
+				return buildIndex(sh, image)
 			},
 			// even a valid index/ztoc produces some fuse operation failures such as
 			// node.lookup and node.getxattr failures, so we only check a specific fuse failure metric.
@@ -195,7 +195,7 @@ log_fuse_operations = true
 			name:  "image with valid-formatted but invalid-data ztocs causes fuse file.read failures",
 			image: rabbitmqImage,
 			indexDigestFn: func(t *testing.T, sh *shell.Shell, image imageInfo) string {
-				indexDigest, err := buildIndexByManipulatingZtocData(sh, buildSparseIndex(sh, image, 0, defaultSpanSize), manipulateZtocMetadata)
+				indexDigest, err := buildIndexByManipulatingZtocData(sh, buildIndex(sh, image), manipulateZtocMetadata)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -165,7 +165,7 @@ func TestLazyPullWithSparseIndex(t *testing.T) {
 
 	rebootContainerd(t, sh, "", "")
 	copyImage(sh, dockerhub(imageName), regConfig.mirror(imageName))
-	indexDigest := buildSparseIndex(sh, regConfig.mirror(imageName), minLayerSize, defaultSpanSize)
+	indexDigest := buildIndex(sh, regConfig.mirror(imageName), withMinLayerSize(minLayerSize))
 
 	fromNormalSnapshotter := func(image string) tarPipeExporter {
 		return func(t *testing.T, tarExportArgs ...string) {
@@ -204,7 +204,7 @@ func TestLazyPullWithSparseIndex(t *testing.T) {
 			test: func(t *testing.T, tarExportArgs ...string) {
 				image := regConfig.mirror(imageName).ref
 				rebootContainerd(t, sh, "", "")
-				buildSparseIndex(sh, regConfig.mirror(imageName), minLayerSize, defaultSpanSize)
+				buildIndex(sh, regConfig.mirror(imageName), withMinLayerSize(minLayerSize))
 				sh.X("ctr", "i", "rm", imageName)
 				export(sh, image, tarExportArgs)
 				checkFuseMounts(t, sh, remoteSnapshotsExpectedCount)

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -122,7 +122,7 @@ func TestPushAlwaysMostRecentlyCreatedIndex(t *testing.T) {
 			copyImage(sh, dockerhub(tc.image), regConfig.mirror(tc.image))
 
 			for _, opt := range tc.opts {
-				index := buildSparseIndex(sh, regConfig.mirror(tc.image), opt.minLayerSize, opt.spanSize)
+				index := buildIndex(sh, regConfig.mirror(tc.image), withMinLayerSize(opt.minLayerSize), withSpanSize(opt.spanSize))
 				index = strings.Split(index, "\n")[0]
 				out := sh.O("soci", "push", "--user", regConfig.creds(), regConfig.mirror(tc.image).ref, "-q")
 				pushedIndex := strings.Trim(string(out), "\n")


### PR DESCRIPTION
Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*
partial implementation of #349 

*Description of changes:*
This change refactors `buildIndex` to use functional arguments.

This makes the call site clearer since the positional arguments are replaced with function names that specifically highlight what they are changing. It also makes it easier to add additional arguments without changing the call sites. Finally, it makes the tests more explicit about which arguments are relvant to the test (since they only need to be set if they are relevant)


*Testing performed:*
`make check && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
