### PR TITLE
Support Oci 1.0

### DIFF
--- a/cmd/soci/commands/index/list.go
+++ b/cmd/soci/commands/index/list.go
@@ -155,7 +155,7 @@ var listCommand = cli.Command{
 		}
 
 		writer := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
-		writer.Write([]byte("DIGEST\tSIZE\tIMAGE REF\tPLATFORM\tCREATED\t\n"))
+		writer.Write([]byte("DIGEST\tSIZE\tIMAGE REF\tPLATFORM\tMEDIA TYPE\tCREATED\t\n"))
 
 		for _, ae := range artifacts {
 			imgs, _ := is.List(ctx, fmt.Sprintf("target.digest==%s", ae.ImageDigest))
@@ -174,11 +174,12 @@ var listCommand = cli.Command{
 
 func writeArtifactEntry(w io.Writer, ae *soci.ArtifactEntry, imageRef string) {
 	w.Write([]byte(fmt.Sprintf(
-		"%s\t%d\t%s\t%s\t%s\t\n",
+		"%s\t%d\t%s\t%s\t%s\t%s\t\n",
 		ae.Digest,
 		ae.Size,
 		imageRef,
 		ae.Platform,
+		ae.MediaType,
 		getDuration(ae.CreatedAt),
 	)))
 }

--- a/cmd/soci/commands/internal/spec.go
+++ b/cmd/soci/commands/internal/spec.go
@@ -1,0 +1,31 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import "github.com/urfave/cli"
+
+const (
+	LegacyRegistryFlagName = "legacy-registry"
+)
+
+var LegacyRegistryFlag = cli.BoolFlag{
+	Name: LegacyRegistryFlagName,
+	Usage: `Whether to create the SOCI index for a legacy registry. OCI 1.1 added support for associating artifacts such as soci indices with images.
+     There is a mechanism to emulate this behavior with OCI 1.0 registries by pretending that the SOCI index
+     is itself an image. This option should only be use if the SOCI index will be pushed to a
+     registry which does not support OCI 1.1 features.`,
+}

--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -183,13 +182,14 @@ func FetchSociArtifacts(ctx context.Context, refspec reference.Spec, indexDesc o
 	cw := new(ioutils.CountWriter)
 	tee := io.TeeReader(indexReader, cw)
 
-	index, err := soci.NewIndexFromReader(tee)
+	var index soci.Index
+	err = soci.DecodeIndex(tee, &index)
 	if err != nil {
 		return nil, fmt.Errorf("cannot deserialize byte data to index: %w", err)
 	}
 
 	if !local {
-		b, err := json.Marshal(index)
+		b, err := soci.MarshalIndex(&index)
 		if err != nil {
 			return nil, err
 		}
@@ -223,5 +223,5 @@ func FetchSociArtifacts(ctx context.Context, refspec reference.Spec, indexDesc o
 		return nil, err
 	}
 
-	return index, nil
+	return &index, nil
 }

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -66,7 +66,8 @@ func TestSociCreateSparseIndex(t *testing.T) {
 			indexDigest := buildIndex(sh, imgInfo, withMinLayerSize(tt.minLayerSize))
 			checkpoints := fetchContentFromPath(sh, blobStorePath+"/"+trimSha256Prefix(indexDigest))
 
-			index, err := soci.NewIndexFromReader(bytes.NewReader(checkpoints))
+			var index soci.Index
+			err := soci.DecodeIndex(bytes.NewReader(checkpoints), &index)
 			if err != nil {
 				t.Fatalf("cannot get index data: %v", err)
 			}
@@ -84,7 +85,7 @@ func TestSociCreateSparseIndex(t *testing.T) {
 				}
 			}
 
-			validateSociIndex(t, sh, *index, manifestDigest, includedLayers)
+			validateSociIndex(t, sh, index, manifestDigest, includedLayers)
 		})
 	}
 }
@@ -145,7 +146,8 @@ func TestSociCreate(t *testing.T) {
 			imgInfo := dockerhub(tt.containerImage, withPlatform(platform))
 			indexDigest := buildIndex(sh, imgInfo, withMinLayerSize(0))
 			checkpoints := fetchContentFromPath(sh, blobStorePath+"/"+trimSha256Prefix(indexDigest))
-			sociIndex, err := soci.NewIndexFromReader(bytes.NewReader(checkpoints))
+			var sociIndex soci.Index
+			err := soci.DecodeIndex(bytes.NewReader(checkpoints), &sociIndex)
 			if err != nil {
 				t.Fatalf("cannot get soci index: %v", err)
 			}
@@ -155,7 +157,7 @@ func TestSociCreate(t *testing.T) {
 				t.Fatalf("failed to get manifest digest: %v", err)
 			}
 
-			validateSociIndex(t, sh, *sociIndex, m, nil)
+			validateSociIndex(t, sh, sociIndex, m, nil)
 		})
 	}
 }

--- a/integration/index_test.go
+++ b/integration/index_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -280,7 +279,7 @@ func sociIndexFromDigest(sh *shell.Shell, indexDigest string) (index soci.Index,
 	if err != nil {
 		return
 	}
-	if err = json.Unmarshal(rawSociIndexJSON, &index); err != nil {
+	if err = soci.UnmarshalIndex(rawSociIndexJSON, &index); err != nil {
 		err = fmt.Errorf("invalid soci index from digest %s: %s", indexDigest, err)
 	}
 	return

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -828,7 +828,7 @@ func TestRpullImageThenRemove(t *testing.T) {
 
 	rawJSON := sh.O("soci", "index", "info", indexDigest)
 	var sociIndex soci.Index
-	if err := json.Unmarshal(rawJSON, &sociIndex); err != nil {
+	if err := soci.UnmarshalIndex(rawJSON, &sociIndex); err != nil {
 		t.Fatalf("invalid soci index from digest %s: %v", indexDigest, rawJSON)
 	}
 

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -28,6 +28,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/util/dbutil"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -254,7 +255,7 @@ func (db *ArtifactsDb) RemoveArtifactEntryByImageDigest(digest string) error {
 // Determines whether a bucket represents an index, as opposed to a zTOC
 func indexBucket(b *bolt.Bucket) bool {
 	mt := string(b.Get(bucketKeyMediaType))
-	return mt == OCIArtifactManifestMediaType
+	return mt == OCIArtifactManifestMediaType || mt == ocispec.MediaTypeImageManifest
 }
 
 // Determines whether a bucket's image digest is the same as digest


### PR DESCRIPTION
*Issue #, if available:*

closes #339 

*Description of changes:*
Support OCI 1.0
    
    SOCI relies on being able to associate an index with an image. This
    capability was introduced in OCI distribution and image specs version
    1.1 as Artifacts and the Referrers API respectively.
    
    In order to drive adoption, an OCI 1.0 compatible fallback was added
    that encodes artifacts as Image Manifests and stores the Referrers API
    content in an Image Index.
    
    This PR adds the ability to serialize and deserialize SOCI indices as
    either OCI Artifacts or OCI Images. There is no automatic OCI 1.0
    fallback when creating images. The user of the CLI/library must
    explicitly request an OCI 1.0 compatible Image Manifest. The snapshotter
    will be able to automatically load a SOCI index in either serialized
    form.



*Testing performed:*
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
