### PR TITLE
Remove soci go build `-v` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ build: $(CMD)
 FORCE:
 
 soci-snapshotter-grpc: FORCE
-	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) -v ./soci-snapshotter-grpc
+	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) ./soci-snapshotter-grpc
 
 soci: FORCE
-	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) -v ./soci
+	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) ./soci
 
 
 install-cmake:


### PR DESCRIPTION
Signed-off-by: Jin Dong <jindon@amazon.com>

*Issue #, if available:*

*Description of changes:*

When building soci grpc and cli, we use `-v` flag to [print all the package names as they're compiled](https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies):

```
-v
	print the names of packages as they are compiled.
```

I didn't see other projects (containerd, nerdctl, runc) using this flag and also don't feel much benefit from it. Instead, it makes our integration output almost unreadable since we build soci for every integration test which prints a lot of useless output lines.

*Testing performed:*

```shell
# containerd make output
➜  containerd git:(main) make
+ bin/ctr
go build  -gcflags=-trimpath=/home/ec2-user/go/src -buildmode=pie  -o bin/ctr -ldflags '-X github.com/containerd/containerd/version.Version=v1.7.0-beta.0-501-g753bfd657 -X github.com/containerd/containerd/version.Revision=753bfd6575ece15de49b3df786a9e60fc24cbf55 -X github.com/containerd/containerd/version.Package=github.com/containerd/containerd -s -w ' -tags "urfave_cli_no_docs"  ./cmd/ctr
+ bin/containerd
go build  -gcflags=-trimpath=/home/ec2-user/go/src -buildmode=pie  -o bin/containerd -ldflags '-X github.com/containerd/containerd/version.Version=v1.7.0-beta.0-501-g753bfd657 -X github.com/containerd/containerd/version.Revision=753bfd6575ece15de49b3df786a9e60fc24cbf55 -X github.com/containerd/containerd/version.Package=github.com/containerd/containerd -s -w ' -tags "urfave_cli_no_docs"  ./cmd/containerd
+ bin/containerd-stress
go build  -gcflags=-trimpath=/home/ec2-user/go/src -buildmode=pie  -o bin/containerd-stress -ldflags '-X github.com/containerd/containerd/version.Version=v1.7.0-beta.0-501-g753bfd657 -X github.com/containerd/containerd/version.Revision=753bfd6575ece15de49b3df786a9e60fc24cbf55 -X github.com/containerd/containerd/version.Package=github.com/containerd/containerd -s -w ' -tags "urfave_cli_no_docs"  ./cmd/containerd-stress
+ bin/containerd-shim
+ bin/containerd-shim-runc-v1
+ bin/containerd-shim-runc-v2
+ binaries

# nerdctl make output
➜  nerdctl git:(main) make
GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w -X github.com/containerd/nerdctl/pkg/version.Version=v1.1.0-255-gb0701ba -X github.com/containerd/nerdctl/pkg/version.Revision=b0701ba875880db5a6e7585df148f0eaea36283a"  -o /home/ec2-user/code/nerdctl/_output/nerdctl github.com/containerd/nerdctl/cmd/nerdctl

# soci make output (before remove)
➜  soci-snapshotter git:(main) make
rm -rf /home/ec2-user/code/soci-snapshotter/out
cd cmd/ ; GO111MODULE=auto go build -o /home/ec2-user/code/soci-snapshotter/out/soci-snapshotter-grpc  -ldflags '-s -w -X github.com/awslabs/soci-snapshotter/version.Version=ac67c40 -X github.com/awslabs/soci-snapshotter/version.Revision=ac67c40d4d3ed229985ab3d751914fd3647fec0c ' -v ./soci-snapshotter-grpc
github.com/awslabs/soci-snapshotter/fs/config
golang.org/x/sys/unix
google.golang.org/protobuf/internal/detrand
google.golang.org/protobuf/internal/pragma
google.golang.org/protobuf/internal/version
github.com/awslabs/soci-snapshotter/
...

# soci make output (after remove)
➜  soci-snapshotter git:(clean-soci-make-output) make
cd cmd/ ; GO111MODULE=auto go build -o /home/ec2-user/code/soci-snapshotter/out/soci-snapshotter-grpc  -ldflags '-s -w -X github.com/awslabs/soci-snapshotter/version.Version=e417ab2 -X github.com/awslabs/soci-snapshotter/version.Revision=e417ab20f8d30358a68fbb8ab29bcef9e51ecf11 ' ./soci-snapshotter-grpc
cd cmd/ ; GO111MODULE=auto go build -o /home/ec2-user/code/soci-snapshotter/out/soci  -ldflags '-s -w -X github.com/awslabs/soci-snapshotter/version.Version=e417ab2 -X github.com/awslabs/soci-snapshotter/version.Revision=e417ab20f8d30358a68fbb8ab29bcef9e51ecf11 ' ./soci
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
