### PR TITLE
Clean up makefile and move to scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
           go-version: '>=1.18.0'
       - run: wget https://github.com/google/flatbuffers/releases/download/v22.9.29/Linux.flatc.binary.g++-10.zip
       - run: unzip Linux.flatc.binary.g++-10.zip
-      - run: make install-check-tools
-      - run: make check-ltag
-      - run: make check-dco
-      - run: make check-lint
-      - run: PATH=$PATH:$(pwd) make check-flatc
+      - run: ./scripts/install-check-tools.sh
+      - run: ./scripts/check-ltag.sh
+      - run: ./scripts/check-dco.sh
+      - run: ./scripts/check-lint.sh
+      - run: PATH=$PATH:$(pwd) ./scripts/check-flatc.sh
   test:
     runs-on: ubuntu-20.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,6 @@
 CMD_DESTDIR ?= /usr/local
 GO111MODULE_VALUE=auto
 OUTDIR ?= $(CURDIR)/out
-UTIL_CFLAGS=-I${CURDIR}/c -L${OUTDIR} -lz
-UTIL_LDFLAGS=-L${OUTDIR} -lz
 PKG=github.com/awslabs/soci-snapshotter
 VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
@@ -33,7 +31,7 @@ CMD=soci-snapshotter-grpc soci
 
 CMD_BINARIES=$(addprefix $(OUTDIR)/,$(CMD))
 
-.PHONY: all build check check-ltag check-dco check-lint check-flatc install-check-tools add-ltag install install-cmake install-flatc install-zlib uninstall clean test integration
+.PHONY: all build add-ltag install uninstall clean test integration
 
 all: build
 
@@ -47,54 +45,9 @@ soci-snapshotter-grpc: FORCE
 soci: FORCE
 	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) ./soci
 
-
-install-cmake:
-	@wget https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1-Linux-x86_64.sh -O cmake.sh
-	@sh cmake.sh --prefix=/usr/local/ --exclude-subdir
-	@rm -rf cmake.sh
-
-install-flatc:
-	wget https://github.com/google/flatbuffers/archive/refs/tags/v2.0.8.tar.gz -O flatbuffers.tar.gz
-	tar xzvf flatbuffers.tar.gz
-	cd flatbuffers-2.0.8 && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release && make && make install
-	rm -f flatbuffers.tar.gz
-	rm -rf flatbuffers-2.0.8
-
-install-zlib:
-	@wget https://zlib.net/fossils/zlib-1.2.12.tar.gz
-	@tar xzvf zlib-1.2.12.tar.gz
-	@cd zlib-1.2.12; ./configure; sudo make install
-	@rm -rf zlib-1.2.12
-	@rm -f zlib-1.2.12.tar.gz
-
-check: check-ltag check-dco check-lint check-flatc
-
 flatc:
 	rm -rf $(CURDIR)/ztoc/fbs/ztoc
 	flatc -o $(CURDIR)/ztoc/fbs -g $(FBS_FILE_PATH)
-
-# check if flatbuffers needs to be generated again
-check-flatc:
-	$(eval TMPDIR := $(shell mktemp -d))
-	flatc -o $(TMPDIR) -g $(FBS_FILE_PATH)
-	diff -qr $(TMPDIR)/ztoc $(CURDIR)/ztoc/fbs/ztoc || (printf "\n\nThe Ztoc schema seems to be modified. Please run 'make flatc' to re-generate Go files\n\n"; exit 1)
-	rm -rf $(TMPDIR)
-
-check-lint: 
-	GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
-	cd ./cmd ; GO111MODULE=$(GO111MODULE_VALUE) $(shell go env GOPATH)/bin/golangci-lint run
-
-check-ltag:
-	$(shell go env GOPATH)/bin/ltag $(LTAG_TEMPLATE_FLAG) -check -v || (echo "The files listed above are missing a licence header. Please run make add-ltag"; exit 1)
-
-# the very first auto-commit doesn't have a DCO and the first real commit has a slightly different format. Exclude those when doing the check.
-check-dco:
-	$(shell go env GOPATH)/bin/git-validation -run DCO -range HEAD~20..HEAD
-
-install-check-tools:
-	@curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.49.0
-	go install github.com/kunalkushwaha/ltag@v0.2.3
-	go install github.com/vbatts/git-validation@v1.1.0
 
 install:
 	@echo "$@"
@@ -104,9 +57,6 @@ install:
 uninstall:
 	@echo "$@"
 	@rm -f $(addprefix $(CMD_DESTDIR)/bin/,$(notdir $(CMD_BINARIES)))
-
-add-ltag:
-	$(shell go env GOPATH)/bin/ltag $(LTAG_TEMPLATE_FLAG) -v
 
 clean:
 	rm -rf $(OUTDIR)

--- a/scripts/add-ltag.sh
+++ b/scripts/add-ltag.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eux -o pipefail
+
+CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOCI_SNAPSHOTTER_PROJECT_ROOT="${CUR_DIR}/.."
+
+pushd ${SOCI_SNAPSHOTTER_PROJECT_ROOT}
+$(go env GOPATH)/bin/ltag -v -t ${SOCI_SNAPSHOTTER_PROJECT_ROOT}/.headers
+popd

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eux -o pipefail
+
+./check-dco.sh
+./check-flatc.sh
+./check-ltag.sh
+./check-lint.sh

--- a/scripts/check-dco.sh
+++ b/scripts/check-dco.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eux -o pipefail
+
+# the very first auto-commit doesn't have a DCO and the first real commit has a slightly different format. Exclude those when doing the check.
+$(go env GOPATH)/bin/git-validation -run DCO -range HEAD~20..HEAD

--- a/scripts/check-flatc.sh
+++ b/scripts/check-flatc.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eux -o pipefail
+
+CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOCI_SNAPSHOTTER_PROJECT_ROOT="${CUR_DIR}/.."
+FBS_FILE_PATH=${SOCI_SNAPSHOTTER_PROJECT_ROOT}/ztoc/fbs/ztoc.fbs
+
+# check if flatbuffers needs to be generated again
+TMPDIR=$(mktemp -d)
+flatc -o ${TMPDIR} -g ${FBS_FILE_PATH}
+diff -qr ${TMPDIR}/ztoc ${SOCI_SNAPSHOTTER_PROJECT_ROOT}/ztoc/fbs/ztoc || (printf "\n\nThe Ztoc schema seems to be modified. Please run 'make flatc' to re-generate Go files\n\n"; rm -rf ${TMPDIR}; exit 1)
+rm -rf ${TMPDIR}

--- a/scripts/check-lint.sh
+++ b/scripts/check-lint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eux -o pipefail
+
+CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOCI_SNAPSHOTTER_PROJECT_ROOT="${CUR_DIR}/.."
+GO111MODULE_VALUE=auto
+
+# check lint
+pushd ${SOCI_SNAPSHOTTER_PROJECT_ROOT}
+GO111MODULE=${GO111MODULE_VALUE} $(go env GOPATH)/bin/golangci-lint run
+pushd ./cmd
+GO111MODULE=${GO111MODULE_VALUE} $(go env GOPATH)/bin/golangci-lint run
+popd
+popd

--- a/scripts/check-ltag.sh
+++ b/scripts/check-ltag.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eux -o pipefail
+
+CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOCI_SNAPSHOTTER_PROJECT_ROOT="${CUR_DIR}/.."
+
+# check ltag
+pushd ${SOCI_SNAPSHOTTER_PROJECT_ROOT}
+$(go env GOPATH)/bin/ltag -t ${SOCI_SNAPSHOTTER_PROJECT_ROOT}/.headers -check -v || (echo "The files listed above are missing a licence header. Please run ./scripts/add-ltag.sh"; exit 1)
+popd

--- a/scripts/install-check-tools.sh
+++ b/scripts/install-check-tools.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+echo "Install soci check tools"
+set -eux -o pipefail
+
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
+go install github.com/kunalkushwaha/ltag@v0.2.3
+go install github.com/vbatts/git-validation@v1.1.0

--- a/scripts/install-dep.sh
+++ b/scripts/install-dep.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+echo "Install soci dependencies"
+set -eux -o pipefail
+
+# the installation shouldn't assume the script is executed in a specific directory.
+# move to tmp in case there is leftover while installing dependencies.
+TMPDIR=$(mktemp -d)
+pushd ${TMPDIR}
+
+# install cmake
+if ! command -v cmake &> /dev/null
+then
+    wget https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1-Linux-x86_64.sh -O cmake.sh
+    sh cmake.sh --prefix=/usr/local/ --exclude-subdir
+    rm -rf cmake.sh
+else
+    echo "cmake is installed, skip..."
+fi
+
+# install flatc
+if ! command -v flatc &> /dev/null
+then
+    wget https://github.com/google/flatbuffers/archive/refs/tags/v2.0.8.tar.gz -O flatbuffers.tar.gz
+    tar xzvf flatbuffers.tar.gz
+    cd flatbuffers-2.0.8 && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release && make && sudo make install && cd ..
+    rm -f flatbuffers.tar.gz
+    rm -rf flatbuffers-2.0.8
+else
+    echo "flatc is installed, skip..."
+fi
+
+# install-zlib
+wget https://zlib.net/fossils/zlib-1.2.12.tar.gz
+tar xzvf zlib-1.2.12.tar.gz
+cd zlib-1.2.12 && ./configure && sudo make install && cd ..
+rm -rf zlib-1.2.12
+rm -f zlib-1.2.12.tar.gz
+
+popd


### PR DESCRIPTION
Signed-off-by: Jin Dong <jindon@amazon.com>

*Issue #, if available:* fix #69

*Description of changes:*

1. Move `check`, `install-dependency`, `install-check-tools` related make rules to scripts.
2. Fix existing bugs in these rules:
    1. `install-flatc` uses `make install` instead of `sudo make install` which will fail unless runned with `sudo`.
    2. `cd` into `flatc` and `zlib` to install them but didn't `cd ..` out before `rm`, which doesn't actually clean up downloaded files.

*Testing performed:*

make test, run scripts manually, check GH action output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
