### PR TITLE
Deduplicate some test setup code, move config file setup into rebootContainerd params

### DIFF
--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/awslabs/soci-snapshotter/soci"
-	"github.com/awslabs/soci-snapshotter/util/testutil"
 	"github.com/containerd/containerd/platforms"
 )
 
@@ -29,13 +28,6 @@ func TestSociArtifactsPushAndPull(t *testing.T) {
 	regConfig := newRegistryConfig()
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
-
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
-		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
-	}
-	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false), 0600); err != nil {
-		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
-	}
 
 	tests := []struct {
 		Name     string
@@ -53,7 +45,7 @@ func TestSociArtifactsPushAndPull(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			rebootContainerd(t, sh, "", "")
+			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
 
 			platform, err := platforms.Parse(tt.Platform)
 			if err != nil {
@@ -81,13 +73,6 @@ func TestPushAlwaysMostRecentlyCreatedIndex(t *testing.T) {
 	regConfig := newRegistryConfig()
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
-
-	if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
-		t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
-	}
-	if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false), 0600); err != nil {
-		t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
-	}
 
 	type buildOpts struct {
 		spanSize     int64
@@ -118,7 +103,7 @@ func TestPushAlwaysMostRecentlyCreatedIndex(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			rebootContainerd(t, sh, "", "")
+			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
 
 			copyImage(sh, dockerhub(tc.image), regConfig.mirror(tc.image))
 
@@ -176,13 +161,7 @@ func TestLegacyOCI(t *testing.T) {
 			sh, done := newShellWithRegistry(t, regConfig, withRegistryImageRef(tc.registryImage))
 			defer done()
 
-			if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
-				t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
-			}
-			if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false), 0600); err != nil {
-				t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
-			}
-			rebootContainerd(t, sh, "", "")
+			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
 
 			imageName := ubuntuImage
 			copyImage(sh, dockerhub(imageName), regConfig.mirror(imageName))

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -40,7 +40,6 @@ import (
 	"testing"
 
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
-	"github.com/awslabs/soci-snapshotter/util/testutil"
 )
 
 // TestRunMultipleContainers runs multiple containers at the same time and performs a test in each
@@ -83,20 +82,7 @@ func TestRunMultipleContainers(t *testing.T) {
 			sh, done := newShellWithRegistry(t, regConfig)
 			defer done()
 
-			// Setup environment
-			if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, getContainerdConfigYaml(t, false), 0600); err != nil {
-				t.Fatalf("failed to write %v: %v", defaultContainerdConfigPath, err)
-			}
-
-			if err := testutil.WriteFileContents(sh, defaultSnapshotterConfigPath, getSnapshotterConfigYaml(t, false, tcpMetricsConfig), 0600); err != nil {
-				t.Fatalf("failed to write %v: %v", defaultSnapshotterConfigPath, err)
-			}
-
-			sh.
-				X("update-ca-certificates").
-				Retry(100, "nerdctl", "login", "-u", regConfig.user, "-p", regConfig.pass, regConfig.host)
-
-			rebootContainerd(t, sh, "", "")
+			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false, tcpMetricsConfig))
 			for _, container := range deduplicateByContainerImage(tt.containers) {
 				// Mirror image
 				copyImage(sh, dockerhub(container.containerImage), regConfig.mirror(container.containerImage))

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -107,20 +107,20 @@ level = "debug"
 {{.AdditionalConfig}}
 `
 
-// getContainerdConfigYaml creates a containerd config yaml, by appending all
+// getContainerdConfigToml creates a containerd config yaml, by appending all
 // `additionalConfigs` to the default `containerdConfigTemplate`.
-func getContainerdConfigYaml(t *testing.T, disableVerification bool, additionalConfigs ...string) []byte {
+func getContainerdConfigToml(t *testing.T, disableVerification bool, additionalConfigs ...string) string {
 	if !isTestingBuiltinSnapshotter() {
 		additionalConfigs = append(additionalConfigs, proxySnapshotterConfig)
 	}
 
-	return []byte(testutil.ApplyTextTemplate(t, containerdConfigTemplate, struct {
+	return testutil.ApplyTextTemplate(t, containerdConfigTemplate, struct {
 		DisableVerification bool
 		AdditionalConfig    string
 	}{
 		DisableVerification: disableVerification,
 		AdditionalConfig:    strings.Join(additionalConfigs, "\n"),
-	}))
+	})
 }
 
 const snapshotterConfigTemplate = `
@@ -129,14 +129,14 @@ disable_verification = {{.DisableVerification}}
 {{.AdditionalConfig}}
 `
 
-func getSnapshotterConfigYaml(t *testing.T, disableVerification bool, additionalConfigs ...string) []byte {
-	return []byte(testutil.ApplyTextTemplate(t, snapshotterConfigTemplate, struct {
+func getSnapshotterConfigToml(t *testing.T, disableVerification bool, additionalConfigs ...string) string {
+	return testutil.ApplyTextTemplate(t, snapshotterConfigTemplate, struct {
 		DisableVerification bool
 		AdditionalConfig    string
 	}{
 		DisableVerification: disableVerification,
 		AdditionalConfig:    strings.Join(additionalConfigs, "\n"),
-	}))
+	})
 }
 
 func trimSha256Prefix(s string) string {


### PR DESCRIPTION
*Issue #, if available:*
Closes #372 

*Description of changes:*
Move some newRegistryConfig calls into newShellWithRegistry params.
Rename get\*ConfigYaml to get\*ConfigToml
Change return type of get\*ConfigToml from byte[] to string
Move calls to get\*ConfigYaml from WriteFileContents calls (which are eliminated) into rebootContainerd params (where they will produce temp files and be passed to containerd and soci-snapshotter-grpc as command line params)

Minor const-ness changes to some test config, and making some comments and test setup code more consistent.

*Testing performed:*
Ran tests, and again with intentional failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.