### PR TITLE
Add test coverage for errors.Is

### DIFF
--- a/metadata/db/reader.go
+++ b/metadata/db/reader.go
@@ -68,6 +68,8 @@ type reader struct {
 	initG   *errgroup.Group
 }
 
+var errFailedToGetUniqueId = fmt.Errorf("failed to get a unique id for metadata reader")
+
 func (r *reader) nextID() (uint32, error) {
 	r.curIDMu.Lock()
 	defer r.curIDMu.Unlock()
@@ -134,7 +136,7 @@ func (r *reader) init(ztoc *ztoc.Ztoc, rOpts metadata.Options) (retErr error) {
 		break
 	}
 	if !ok {
-		return fmt.Errorf("failed to get a unique id for metadata reader")
+		return errFailedToGetUniqueId
 	}
 
 	if err := r.initNodes(ztoc); err != nil {


### PR DESCRIPTION
*Issue #, if available:*
#326 

*Description of changes:*
Current status: Second draft of first test, of `reader.init` `errors.Is(err, bolt.ErrBucketExists)`, is failing. My efforts to pseudo-mock the necessary method to return the error have not been successful.

*Testing performed:*
TBD

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.