### PR TITLE
Deduplicate temp targz creation in ztoc/testutils.go.

### DIFF
--- a/util/testutil/util.go
+++ b/util/testutil/util.go
@@ -33,11 +33,11 @@
 package testutil
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -111,13 +111,29 @@ func RandomUInt64() (uint64, error) {
 	return binary.LittleEndian.Uint64(b), nil
 }
 
-// RandomByteData returns a byte slice with `size` random generated data
+// RandomByteData returns a byte slice with `size` populated with random generated data
 func RandomByteData(size int64) []byte {
 	b := make([]byte, size)
 	rand.Read(b)
 	return b
 }
 
+// RandomByteDataRange returns a byte slice with `size` between minBytes and maxBytes exclusive populated with random data
+func RandomByteDataRange(minBytes int, maxBytes int) []byte {
+	const charset = "abcdefghijklmnopqrstuvwxyz" +
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" + " "
+	const randSeed = 1658503010463818386
+
+	rand.Seed(randSeed)
+	randByteNum := rand.Intn(maxBytes-minBytes) + minBytes
+	randBytes := make([]byte, randByteNum)
+	for i := range randBytes {
+		randBytes[i] = charset[rand.Intn(len(charset))]
+	}
+	return randBytes
+}
+
+// RandomDigest generates a random digest from a random sequence of bytes
 func RandomDigest() string {
 	d := digest.FromBytes(RandomByteData(10))
 	return d.String()

--- a/ztoc/testutils.go
+++ b/ztoc/testutils.go
@@ -17,141 +17,18 @@
 package ztoc
 
 import (
-	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
-	"sort"
 
 	"github.com/awslabs/soci-snapshotter/util/testutil"
 )
 
-type TempDirMaker interface {
-	TempDir() string
-}
-
-type fileContent struct {
-	fileName string
-	content  []byte
-}
-
-func buildTempTarGz(contents []fileContent, targzName string) (*string, []string, error) {
-	// build a temporary directory with two files named file1 and file2
-	// the files will be filled in with the contents passed in the arguments
-	dir, err := os.MkdirTemp("", "test")
-	if err != nil {
-		return nil, nil, err
-	}
-	defer os.RemoveAll(dir)
-
-	resultingFileNames := []string{}
-
-	for _, fc := range contents {
-		file, err := os.CreateTemp(dir, fc.fileName)
-		if err != nil {
-			break
-		}
-		resultingFileNames = append(resultingFileNames, file.Name())
-		if _, err := file.Write(fc.content); err != nil {
-			break
-		}
-	}
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// build tar.gzip
-	name, err := tempTarGz(dir, targzName)
-	if err != nil {
-		return nil, nil, err
-	}
-	return name, resultingFileNames, nil
-}
-
-func writeTempTarGz(filePath string, tw *tar.Writer, fi os.FileInfo) error {
-	fr, err := os.Open(filePath)
-	if err != nil {
-		return err
-	}
-	defer fr.Close()
-
-	h := new(tar.Header)
-	h.Name = filePath
-	h.Size = fi.Size()
-	h.Mode = int64(fi.Mode())
-	h.ModTime = fi.ModTime()
-
-	err = tw.WriteHeader(h)
-	if err != nil {
-		return err
-	}
-
-	_, err = io.Copy(tw, fr)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func iterDirectory(dirPath string, tw *tar.Writer) error {
-	dir, err := os.Open(dirPath)
-	if err != nil {
-		return err
-	}
-	defer dir.Close()
-	fis, err := dir.Readdir(0)
-	if err != nil {
-		return err
-	}
-	sort.Slice(fis, func(i, j int) bool {
-		return fis[i].Name() < fis[j].Name()
-	})
-	for _, fi := range fis {
-		curPath := dirPath + "/" + fi.Name()
-		if fi.IsDir() {
-			iterDirectory(curPath, tw)
-		} else {
-			writeTempTarGz(curPath, tw, fi)
-		}
-	}
-
-	return nil
-}
-
-func tempTarGz(inputDir string, targzName string) (*string, error) {
-	// create an output file
-	fw, err := os.CreateTemp("", targzName)
-	if err != nil {
-		return nil, err
-	}
-	defer fw.Close()
-
-	gw := gzip.NewWriter(fw)
-	defer gw.Close()
-
-	tw := tar.NewWriter(gw)
-	defer tw.Close()
-
-	err = iterDirectory(inputDir, tw)
-	if err != nil {
-		return nil, err
-	}
-	outputFileName := fw.Name()
-	return &outputFileName, nil
-}
-
-// buildZtocReader creates the tar gz file for tar entries.
-// It returns ztoc and io.SectionReader of the file.
+// buildZtocReader creates the tar gz file for tar entries. It returns ztoc and io.SectionReader of the file.
 func BuildZtocReader(ents []testutil.TarEntry, compressionLevel int, spanSize int64, opts ...testutil.BuildTarOption) (*Ztoc, *io.SectionReader, error) {
-	// build tar gz file
 	tarReader := testutil.BuildTarGz(ents, compressionLevel, opts...)
 
-	// build ztoc
 	tarFile, err := os.CreateTemp("", "tmp.*")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create temp file: %v", err)
@@ -170,52 +47,4 @@ func BuildZtocReader(ents []testutil.TarEntry, compressionLevel int, spanSize in
 		return nil, nil, fmt.Errorf("failed to build sample ztoc: %v", err)
 	}
 	return ztoc, sr, nil
-}
-
-func GenerateTempTestingDir(dirMaker TempDirMaker) (string, error) {
-	tempDir := dirMaker.TempDir()
-	err := createRandFile(tempDir+"/smallfile", 1, 100)
-	if err != nil {
-		return "", fmt.Errorf("failed to create small random file: %w", err)
-	}
-	err = createRandFile(tempDir+"/mediumfile", 10000, 128000)
-	if err != nil {
-		return "", fmt.Errorf("failed to create medium random file: %w", err)
-	}
-	err = createRandFile(tempDir+"/largefile", 350000, 500000)
-	if err != nil {
-		return "", fmt.Errorf("failed to create large random file: %w", err)
-	}
-	err = createRandFile(tempDir+"/jumbofile", 3000000, 5000000)
-	if err != nil {
-		return "", fmt.Errorf("failed to create jumbo random file: %w", err)
-	}
-
-	return tempDir, nil
-}
-
-func createRandFile(name string, minBytes int, maxBytes int) error {
-	f, err := os.Create(name)
-	if err != nil {
-		return fmt.Errorf("failed to create file: %w", err)
-	}
-	defer f.Close()
-
-	const charset = "abcdefghijklmnopqrstuvwxyz" +
-		"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" + " "
-	const randSeed = 1658503010463818386
-
-	rand.Seed(randSeed)
-	randByteNum := rand.Intn(maxBytes-minBytes) + minBytes
-	randBytes := make([]byte, randByteNum)
-	for i := range randBytes {
-		randBytes[i] = charset[rand.Intn(len(charset))]
-	}
-
-	_, err = f.WriteString(string(randBytes))
-	if err != nil {
-		return fmt.Errorf("failed to write string: %w", err)
-	}
-	f.Sync()
-	return nil
 }


### PR DESCRIPTION
Combined duplicate temp targz generation funcs + helpers within ztoc/testutils.go. into util/tar.go . Util/tar.go has 2 functions (BuildTar + BuildTarGz), which both return tar(gz) io.Reader. Since some integration tests require targz file paths to be returned a WriteTarToTempFile function has been added to create a targz file from an io.Reader.

Signed-off-by: Yasin Turan <turyasin@amazon.com>

*Issue #, if available:*

Fixes: #355 

*Description of changes:*


*Testing performed:*

make test && make integration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
