### PR TITLE
Remove atomic.Int32 usage to support go 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 21
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.18.0'
+          go-version: '1.18.10'
       - run: wget https://github.com/google/flatbuffers/releases/download/v22.9.29/Linux.flatc.binary.g++-10.zip
       - run: unzip Linux.flatc.binary.g++-10.zip
       - run: ./scripts/install-check-tools.sh
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.18.0'
+          go-version: '1.18.10'
       - run: make
       - run: make test
   integration:
@@ -42,5 +42,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.18.0'
+          go-version: '1.18.10'
       - run: make integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG CONTAINERD_VERSION=v1.6.4
 ARG RUNC_VERSION=v1.1.1
 ARG NERDCTL_VERSION=0.19.0
 
-FROM golang:1.19-buster AS golang-base
+FROM golang:1.18.10-buster AS golang-base
 
 FROM golang-base AS containerd-snapshotter-base
 ARG CONTAINERD_VERSION


### PR DESCRIPTION
Signed-off-by: Jin Dong <jindon@amazon.com>

*Issue #, if available:* fix #367

*Description of changes:*

`*atomic.Int32` -> `*int32`.
`atomic.Int32.Add(1)` -> `atomic.AddInt32(opCount, 1)`.
`atomic.Int32.Load()` -> `atomic.LoadInt32(opCount)`.

*Testing performed:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
