### PR TITLE
Futureproof runtime minimum layer size test

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -352,7 +352,7 @@ func (o *snapshotter) skipRemoteSnapshotPrepare(ctx context.Context, labels map[
 					return true
 				}
 			} else {
-				log.G(ctx).WithError(err).Error("config min_layer_size cannot be converted to int")
+				log.G(ctx).WithError(err).Errorf("config min_layer_size cannot be converted to int: %s", strVal)
 			}
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*
Closes #373

*Description of changes:*
Update the integration test for the runtime minimum layer size configuration so that it calculates the median layer size and uses that as the minimum. This makes the test a little more robust and a lot more futureproof.

*Testing performed:*
Ran the test, then again with manual changes to the median index and the layer sizes, confirmed expected results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.