### PR TITLE
Implement background fetch metrics

### DIFF
--- a/fs/backgroundfetcher/background_fetcher_test.go
+++ b/fs/backgroundfetcher/background_fetcher_test.go
@@ -50,7 +50,7 @@ func (c *countingPauser) pause(time.Duration) {
 
 func TestBackgroundFetcherPause(t *testing.T) {
 	p := &countingPauser{}
-	bf, err := NewBackgroundFetcher(WithSilencePeriod(0), withPauser(p))
+	bf, err := NewBackgroundFetcher(WithSilencePeriod(0), withPauser(p), WithEmitMetricPeriod(time.Second))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestBackgroundFetcherRun(t *testing.T) {
 		},
 		{
 			name:     "background fetcher fetches all data for multiple span managers",
-			waitTime: 1 * time.Second,
+			waitTime: 3 * time.Second,
 			entries: [][]testutil.TarEntry{
 				{
 					testutil.File("test1", string(testutil.RandomByteData(10000000))),
@@ -116,7 +116,7 @@ func TestBackgroundFetcherRun(t *testing.T) {
 				infos = append(infos, testInfo{sm, cache, ztoc})
 			}
 
-			bf, err := NewBackgroundFetcher(WithFetchPeriod(0))
+			bf, err := NewBackgroundFetcher(WithFetchPeriod(0), WithEmitMetricPeriod(time.Second))
 			if err != nil {
 				t.Fatalf("unable to construct background fetcher: %v", err)
 			}

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -126,4 +126,8 @@ type BackgroundFetchConfig struct {
 	// i.e., the maximum number of span managers that can be queued
 	// in the background fetcher.
 	MaxQueueSize int `toml:"max_queue_size"`
+
+	// EmitMetricPeriodSec is the amount of interval (in second) at which the background
+	// fetcher emits metrics
+	EmitMetricPeriodSec int64 `toml:"emit_metric_period_sec"`
 }

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -69,6 +69,7 @@ const (
 	NodeReaddir       = "node_readdir"
 	InitMetadataStore = "init_metadata_store"
 	SynchronousRead   = "synchronous_read"
+	BackgroundFetch   = "background_fetch"
 
 	SynchronousReadCount              = "synchronous_read_count"
 	SynchronousReadRegistryFetchCount = "synchronous_read_remote_registry_fetch_count" // TODO revisit (wrong place)
@@ -91,6 +92,15 @@ const (
 	// Number of times the snapshotter falls back to use a normal overlay mount instead of mounting the layer as a FUSE mount.
 	// Note that a layer not having a ztoc is NOT classified as an error, even though `fs.Mount` returns an error in that case.
 	FuseMountFailureCount = "fuse_mount_failure_count"
+
+	// Number of errors of span fetch by background fetcher
+	BackgroundSpanFetchFailureCount = "background_span_fetch_failure_count"
+
+	// Number of spans fetched by background fetcher
+	BackgroundSpanFetchCount = "background_span_fetch_count"
+
+	// Number of items in the work queue of background fetcher
+	BackgroundFetchWorkQueueSize = "background_fetch_work_queue_size"
 )
 
 var (

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -217,16 +217,6 @@ fuse_metrics_emit_wait_duration_sec = 10
 	sh, done := newShellWithRegistry(t, newRegistryConfig())
 	defer done()
 
-	checkMetricExists := func(output, metric string) bool {
-		lines := strings.Split(output, "\n")
-		for _, line := range lines {
-			if strings.Contains(line, metric) {
-				return true
-			}
-		}
-		return false
-	}
-
 	testCases := []struct {
 		name  string
 		image string
@@ -259,6 +249,55 @@ fuse_metrics_emit_wait_duration_sec = 10
 			time.Sleep(10 * time.Second)
 			curlOutput = string(sh.O("curl", tcpMetricsAddress+metricsPath))
 			for _, m := range layer.FuseOpsList {
+				if !checkMetricExists(curlOutput, m) {
+					t.Fatalf("missing expected metric: %s", m)
+				}
+			}
+		})
+	}
+
+}
+
+func TestBackgroundFetchMetrics(t *testing.T) {
+	const backgroundFetchConfig = `
+[background_fetch]
+silence_period_msec = 1000
+fetch_period_msec = 100
+emit_metric_period_sec = 2
+	`
+
+	bgFetchMetricsToCheck := []string{
+		commonmetrics.BackgroundFetchWorkQueueSize,
+		commonmetrics.BackgroundSpanFetchCount,
+	}
+
+	sh, done := newShellWithRegistry(t, newRegistryConfig())
+	defer done()
+
+	testCases := []struct {
+		name  string
+		image string
+	}{
+		{
+			name:  "drupal image",
+			image: drupalImage,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false, tcpMetricsConfig, backgroundFetchConfig))
+
+			imgInfo := dockerhub(tc.image)
+			sh.X("ctr", "i", "pull", imgInfo.ref)
+			indexDigest := buildIndex(sh, imgInfo)
+
+			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
+			sh.XLog("ctr", "run", "--rm", "-d", "--snapshotter=soci", imgInfo.ref, "test", "echo", "hi")
+
+			time.Sleep(5 * time.Second)
+			curlOutput := string(sh.O("curl", tcpMetricsAddress+metricsPath))
+			for _, m := range bgFetchMetricsToCheck {
 				if !checkMetricExists(curlOutput, m) {
 					t.Fatalf("missing expected metric: %s", m)
 				}
@@ -360,4 +399,14 @@ func checkFuseOperationFailureMetrics(t *testing.T, output string, metricToCheck
 		t.Fatalf("incorrect fuse operation failure metrics. metric: %s, total operation failure count: %d, expect fuse operation failure: %t",
 			metricToCheck, metricCountSum, expectOpFailure)
 	}
+}
+
+func checkMetricExists(output, metric string) bool {
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, metric) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
*Issue #, if available:* #237

*Description of changes:*
Added these 4 background fetch metrics:
``background_span_fetch_count`` Number of spans fetched by bg-fetcher
``background_span_fetch_failure_count`` Number of errors during span fetch by bg-fetcher
``operation_duration_background_fetch`` Time in milliseconds to complete background fetch for a layer
``background_fetch_work_queue_size`` Number of items in the work queue of the bg fetcher. Emitted every ``emitMetricPeriod`` seconds (defaulting to 10 sec)

*Testing performed:*
`` curl localhost:6060/metrics | grep background``
Example output:
```
soci_fs_image_operation_count_key{image="",operation_type="background_fetch_work_queue_size"} 18
soci_fs_operation_count{layer="sha256:08b2c94789a92745987c560c2b49f78ebb8b771682c98d378c46b8735fdae9f2",operation_type="background_span_fetch_count"} 3
soci_fs_operation_count{layer="sha256:21933556955c0a0da9c739edbb8e3abc0ec60627975d74448c9bdc035b98a462",operation_type="background_span_fetch_count"} 8
soci_fs_operation_duration_milliseconds_sum{layer="sha256:08b2c94789a92745987c560c2b49f78ebb8b771682c98d378c46b8735fdae9f2",operation_type="background_fetch"} 9000.550487
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
