### PR TITLE
Using "context" instead of "error" key when using withError 

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -127,6 +127,7 @@ func main() {
 	logrus.SetFormatter(&logrus.JSONFormatter{
 		TimestampFormat: log.RFC3339NanoFixed,
 	})
+	logrus.ErrorKey = "context"
 
 	var (
 		ctx    = log.WithLogger(context.Background(), log.L)


### PR DESCRIPTION
Using `context` instead of `error` key when logging operations that are not representative of actual errors. This should eliminate extraneous error keys within logs generated from `rpull`

Signed-off-by: Yasin Turan <turyasin@amazon.com>

Eg Log:

```
{"context":"exec: \"fusermount\": executable file not found in $PATH","key":"default/1/extract-198840019-FSRo sha256:d543b8cad89e3428ac8852a13cb2dbfaf55b1e10fd95a9753e51faf393d60e81","level":"info","mountpoint":"/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs","msg":"fusermount not installed; trying direct mount","parent":"","time":"2023-02-08T18:22:39.001486489Z"}
{"context":"skipping mounting layer sha256:5063b4e8e15250a2ed6aaa980e813b2d9145f67a57f1ca884078498fdf36d44b as FUSE mount: no ztoc for layer","key":"default/2/extract-155573583-fJQ7 sha256:91deb04bc1d7ee311492676790144a0d4ca41ce306e3bca19bb04e416ef3cf62","level":"warning","msg":"failed to prepare remote snapshot","parent":"sha256:d543b8cad89e3428ac8852a13cb2dbfaf55b1e10fd95a9753e51faf393d60e81","remote-snapshot-prepared":"false","time":"2023-02-08T18:22:39.158989711Z"}

```

*Issue #, if available:*

Fixes: #361 


*Testing performed:*

`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
