### PR TITLE
Add blob size checks

### DIFF
--- a/compression/gzip_zinfo.go
+++ b/compression/gzip_zinfo.go
@@ -33,11 +33,11 @@ type GzipZinfo struct {
 }
 
 // NewGzipZinfo creates a new instance of `GzipZinfo` from cZinfo byte blob on zTOC.
-func NewGzipZinfo(checkpoints []byte) (*GzipZinfo, error) {
-	if len(checkpoints) == 0 {
+func NewGzipZinfo(zinfoBytes []byte) (*GzipZinfo, error) {
+	if len(zinfoBytes) == 0 {
 		return nil, fmt.Errorf("empty checkpoints")
 	}
-	cZinfo := C.blob_to_zinfo(unsafe.Pointer(&checkpoints[0]), C.off_t(len(checkpoints)))
+	cZinfo := C.blob_to_zinfo(unsafe.Pointer(&zinfoBytes[0]), C.off_t(len(zinfoBytes)))
 	if cZinfo == nil {
 		return nil, fmt.Errorf("cannot convert blob to gzip_zinfo")
 	}


### PR DESCRIPTION

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
This change adds validations that a zinfo blob's claimed size matches the actual byte buffer size.

It also updates gzip zinfo tests to validate some more edge cases.

*Testing performed:*
`make check && make test && make integration`

Manually tested a pre-existing index that uses the v1 gzip zinfo format to verify that it's still rpull-able.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
