### PR TITLE
Emit fuse operation counts as a log

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -129,9 +129,10 @@ func main() {
 	})
 
 	var (
-		ctx    = log.WithLogger(context.Background(), log.L)
-		config snapshotterConfig
+		ctx, cancel = context.WithCancel(log.WithLogger(context.Background(), log.L))
+		config      snapshotterConfig
 	)
+	defer cancel()
 	// Streams log of standard lib (go-fuse uses this) into debug log
 	// Snapshotter should use "github.com/containerd/containerd/log" otherwize
 	// logs are always printed as "debug" mode.

--- a/service/service.go
+++ b/service/service.go
@@ -101,7 +101,7 @@ func NewSociSnapshotterService(ctx context.Context, root string, config *Config,
 		sourceFromCRILabels(hosts),      // provides source info based on CRI labels
 		source.FromDefaultLabels(hosts), // provides source info based on default labels
 	)), socifs.WithOverlayOpaqueType(opq))
-	fs, err := socifs.NewFilesystem(fsRoot(root), config.Config, fsOpts...)
+	fs, err := socifs.NewFilesystem(ctx, fsRoot(root), config.Config, fsOpts...)
 	if err != nil {
 		log.G(ctx).WithError(err).Fatalf("failed to configure filesystem")
 	}


### PR DESCRIPTION

Signed-off-by: Kern Walster <walster@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*
Before this change, we emitted fuse operation counts as prometheus metrics with a label indicating which image is referred to by the metric. This works well when the cardinaltiy of images is low, however it can be quite expensive when the cardinality is high.

This change emits the data as both a metric and a log. This allows low cardinality systems to use rollup to record both aggregate (e.g. P90) metrics and image specific metrics, while allowing high cardinality system to remove the layer label to get aggregate metrics and cheaper logs for image specific information.


*Testing performed:*
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
