### PR TITLE
Replace ctr i pull/push with nerdctl -q

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -127,7 +127,7 @@ func TestOverlayFallbackMetric(t *testing.T) {
 
 			imgInfo := dockerhub(tc.image)
 
-			sh.X("ctr", "i", "pull", imgInfo.ref)
+			sh.X("nerdctl", "pull", "-q", imgInfo.ref)
 			indexDigest := tc.indexDigestFn(sh, imgInfo)
 
 			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
@@ -196,7 +196,7 @@ log_fuse_operations = true
 			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false, tcpMetricsConfig, logFuseOperationConfig))
 
 			imgInfo := dockerhub(tc.image)
-			sh.X("ctr", "i", "pull", imgInfo.ref)
+			sh.X("nerdctl", "pull", "-q", imgInfo.ref)
 			indexDigest := tc.indexDigestFn(t, sh, imgInfo)
 
 			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
@@ -232,7 +232,7 @@ fuse_metrics_emit_wait_duration_sec = 10
 			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false, tcpMetricsConfig, snapshotterConfig))
 
 			imgInfo := dockerhub(tc.image)
-			sh.X("ctr", "i", "pull", imgInfo.ref)
+			sh.X("nerdctl", "pull", "-q", imgInfo.ref)
 			indexDigest := buildIndex(sh, imgInfo)
 
 			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
@@ -289,7 +289,7 @@ emit_metric_period_sec = 2
 			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false, tcpMetricsConfig, backgroundFetchConfig))
 
 			imgInfo := dockerhub(tc.image)
-			sh.X("ctr", "i", "pull", imgInfo.ref)
+			sh.X("nerdctl", "pull", "-q", imgInfo.ref)
 			indexDigest := buildIndex(sh, imgInfo)
 
 			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -164,7 +164,7 @@ func TestLazyPullWithSparseIndex(t *testing.T) {
 	fromNormalSnapshotter := func(image string) tarPipeExporter {
 		return func(t *testing.T, tarExportArgs ...string) {
 			rebootContainerd(t, sh, "", "")
-			sh.X("ctr", "i", "pull", "--user", regConfig.creds(), image)
+			sh.X("nerdctl", "pull", "-q", image)
 			sh.Pipe(nil, shell.C("ctr", "run", "--rm", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
 		}
 	}
@@ -259,7 +259,7 @@ func TestLazyPull(t *testing.T) {
 	fromNormalSnapshotter := func(image string) tarPipeExporter {
 		return func(t *testing.T, tarExportArgs ...string) {
 			rebootContainerd(t, sh, "", "")
-			sh.X("ctr", "i", "pull", "--user", regConfig.creds(), image)
+			sh.X("nerdctl", "pull", "-q", image)
 			sh.Pipe(nil, shell.C("ctr", "run", "--rm", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
 		}
 	}
@@ -338,7 +338,7 @@ func TestLazyPullNoIndexDigest(t *testing.T) {
 	fromNormalSnapshotter := func(image string) tarPipeExporter {
 		return func(t *testing.T, tarExportArgs ...string) {
 			rebootContainerd(t, sh, "", "")
-			sh.X("ctr", "i", "pull", "--user", regConfig.creds(), image)
+			sh.X("nerdctl", "pull", "-q", image)
 			sh.Pipe(nil, shell.C("ctr", "run", "--rm", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
 		}
 	}
@@ -405,7 +405,7 @@ func TestPullWithAribtraryBlobInvalidZtocFormat(t *testing.T) {
 	fromNormalSnapshotter := func(image string) tarPipeExporter {
 		return func(t *testing.T, tarExportArgs ...string) {
 			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
-			sh.X("ctr", "i", "pull", "--user", regConfig.creds(), image)
+			sh.X("nerdctl", "pull", "-q", image)
 			sh.Pipe(nil, shell.C("ctr", "run", "--rm", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
 		}
 	}
@@ -519,7 +519,7 @@ disable = true
 	fromNormalSnapshotter := func(image string) tarPipeExporter {
 		return func(t *testing.T, tarExportArgs ...string) {
 			rebootContainerd(t, sh, "", "")
-			sh.X("ctr", "i", "pull", "--user", regConfig.creds(), image)
+			sh.X("nerdctl", "pull", "-q", image)
 			sh.Pipe(nil, shell.C("ctr", "run", "--rm", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
 		}
 	}
@@ -679,7 +679,7 @@ insecure = true
 	//       we added "check_always = true" to the configuration in the above.
 	//       We use this behaviour for testing mirroring & refleshing functionality.
 	rebootContainerd(t, sh, "", "")
-	sh.X("ctr", "i", "pull", "--user", regConfig.creds(), regConfig.mirror(imageName).ref)
+	sh.X("nerdctl", "pull", "-q", regConfig.mirror(imageName).ref)
 	sh.X("soci", "create", regConfig.mirror(imageName).ref)
 	sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(imageName).ref)
 	registryHostIP, registryAltHostIP := getIP(t, sh, regConfig.host), getIP(t, sh, regAltConfig.host)

--- a/integration/testutil_soci.go
+++ b/integration/testutil_soci.go
@@ -93,7 +93,7 @@ func buildIndex(sh *shell.Shell, src imageInfo, opt ...indexBuildOption) string 
 	for _, o := range opt {
 		o(&indexBuildConfig)
 	}
-	opts := encodeImageInfo(src)
+	opts := encodeImageInfoNerdctl(src)
 
 	createCommand := []string{"soci", "create", src.ref}
 	createArgs := []string{
@@ -106,7 +106,7 @@ func buildIndex(sh *shell.Shell, src imageInfo, opt ...indexBuildOption) string 
 	}
 
 	indexDigest := sh.
-		X(append([]string{"ctr", "i", "pull", "--platform", platforms.Format(src.platform)}, opts[0]...)...).
+		X(append([]string{"nerdctl", "pull", "-q", "--platform", platforms.Format(src.platform)}, opts[0]...)...).
 		X(append(createCommand, createArgs...)...).
 		O("soci", "index", "list",
 			"-q", "--ref", src.ref,


### PR DESCRIPTION
*Issue #, if available:*
Closes #403 

*Description of changes:*
Replace `ctr i pull`/`push` with `nerdctl -q` to quieten log output during image operations.

*Testing performed:*
Ran integration test suite successfully.
Also ran one test, LazyPullWithSparseIndex, with and without this change, to compare output verbosity:
```
% wc out.before
  1372   8285 248098 out.before

% wc out.after
  1166   7415 215406 out.after
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
