### PR TITLE
Eliminate null errors in resolver

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -152,7 +152,12 @@ func (r *Resolver) resolveFetcher(ctx context.Context, hosts source.RegistryHost
 		return &remoteFetcher{r}, size, nil
 	}
 
-	log.G(ctx).WithError(handlersErr).WithField("ref", refspec.String()).WithField("digest", desc.Digest).Debugf("using default handler")
+	logger := log.G(ctx)
+	if handlersErr != nil {
+		logger = logger.WithError(handlersErr)
+	}
+	logger.WithField("ref", refspec.String()).WithField("digest", desc.Digest).Debugf("using default handler")
+
 	hf, err := newHTTPFetcher(ctx, fc)
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
*Issue #, if available:*
Closes #375 

*Description of changes:*
Make WithError conditional on the presence of an error in resolveFetcher

*Testing performed:*
Ran integration test suite. Confirmed approximately 80 fewer instances of `"error":null`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
