### PR TITLE
Disable unused containerd plugins in integ tests

### DIFF
--- a/integration/config/etc/containerd/config.toml
+++ b/integration/config/etc/containerd/config.toml
@@ -1,6 +1,16 @@
 # explicitly use v2 config format
 version = 2
 
+disabled_plugins = [
+	"io.containerd.snapshotter.v1.aufs",
+	"io.containerd.snapshotter.v1.btrfs",
+	"io.containerd.snapshotter.v1.devmapper",
+	"io.containerd.snapshotter.v1.zfs",
+	"io.containerd.tracing.processor.v1.otlp",
+	"io.containerd.internal.v1.tracing",
+	"io.containerd.grpc.v1.cri",
+]
+
 # Use soci snapshotter
 [proxy_plugins]
   [proxy_plugins.soci]

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -94,6 +94,16 @@ const proxySnapshotterConfig = `
 const containerdConfigTemplate = `
 version = 2
 
+disabled_plugins = [
+	"io.containerd.snapshotter.v1.aufs",
+	"io.containerd.snapshotter.v1.btrfs",
+	"io.containerd.snapshotter.v1.devmapper",
+	"io.containerd.snapshotter.v1.zfs",
+	"io.containerd.tracing.processor.v1.otlp",
+	"io.containerd.internal.v1.tracing",
+	"io.containerd.grpc.v1.cri",
+]
+
 [plugins."io.containerd.snapshotter.v1.soci"]
 root_path = "/var/lib/soci-snapshotter-grpc/"
 disable_verification = {{.DisableVerification}}
@@ -521,7 +531,7 @@ func newSnapshotterBaseShell(t *testing.T) (*shell.Shell, func() error) {
 	}
 	sh := shell.New(de, testutil.NewTestingReporter(t))
 	if !isTestingBuiltinSnapshotter() {
-		if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, []byte(proxySnapshotterConfig), 0600); err != nil {
+		if err := testutil.WriteFileContents(sh, defaultContainerdConfigPath, []byte(getContainerdConfigToml(t, false)), 0600); err != nil {
 			t.Fatalf("failed to write containerd config %v: %v", defaultContainerdConfigPath, err)
 		}
 	}


### PR DESCRIPTION
*Issue #, if available:*
Closes #377 

*Description of changes:*
This change disables several containerd plugins that we're not using so they don't clutter the integ test logs with setup failures.

There are a lot more containerd logs, but here are the relevant ones to this change:

Before:
```
time="2023-02-15T17:16:28Z" level=warning msg="containerd config version `1` has been deprecated and will be removed in containerd v2.0, please switch to version `2`, see https://github.com/containerd/containerd/blob/main/docs/PLUGINS.md#version-header"
time="2023-02-15T17:16:28.173825328Z" level=info msg="starting containerd" revision=299b677800044531671d336af5f0976fd2e6ac70 version=v1.6.17
time="2023-02-15T17:16:28.189613676Z" level=info msg="loading plugin \"io.containerd.content.v1.content\"..." type=io.containerd.content.v1
time="2023-02-15T17:16:28.189682682Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.aufs\"..." type=io.containerd.snapshotter.v1
time="2023-02-15T17:16:28.189781232Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.aufs\"..." error="aufs is not supported (modprobe aufs failed: exec: \"modprobe\": executable file not found in $PATH \"\"): skip plugin" type=io.containerd.snapshotter.v1
time="2023-02-15T17:16:28.189833756Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." type=io.containerd.snapshotter.v1
time="2023-02-15T17:16:28.189973342Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.btrfs\"..." error="path /var/lib/containerd/io.containerd.snapshotter.v1.btrfs (tmpfs) must be a btrfs filesystem to be used with the btrfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
time="2023-02-15T17:16:28.189988318Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.devmapper\"..." type=io.containerd.snapshotter.v1
time="2023-02-15T17:16:28.189999106Z" level=warning msg="failed to load plugin io.containerd.snapshotter.v1.devmapper" error="devmapper not configured"
time="2023-02-15T17:16:28.190010276Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.native\"..." type=io.containerd.snapshotter.v1
time="2023-02-15T17:16:28.190034499Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.overlayfs\"..." type=io.containerd.snapshotter.v1
time="2023-02-15T17:16:28.190136853Z" level=info msg="loading plugin \"io.containerd.snapshotter.v1.zfs\"..." type=io.containerd.snapshotter.v1
time="2023-02-15T17:16:28.190260705Z" level=info msg="skip loading plugin \"io.containerd.snapshotter.v1.zfs\"..." error="path /var/lib/containerd/io.containerd.snapshotter.v1.zfs must be a zfs filesystem to be used with the zfs snapshotter: skip plugin" type=io.containerd.snapshotter.v1
```

After:
```
{"level":"info","msg":"starting containerd","revision":"299b677800044531671d336af5f0976fd2e6ac70","time":"2023-02-15T00:39:39.174449547Z","version":"v1.6.17"}
{"level":"info","msg":"loading plugin \"io.containerd.content.v1.content\"...","time":"2023-02-15T00:39:39.186902483Z","type":"io.containerd.content.v1"}
{"level":"info","msg":"loading plugin \"io.containerd.snapshotter.v1.native\"...","time":"2023-02-15T00:39:39.186991924Z","type":"io.containerd.snapshotter.v1"}
{"level":"info","msg":"loading plugin \"io.containerd.snapshotter.v1.overlayfs\"...","time":"2023-02-15T00:39:39.187024919Z","type":"io.containerd.snapshotter.v1"}
```

*Testing performed:*
`make check && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
