### PR TITLE
Move layer::waiter to layer_test

### DIFF
--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -533,54 +533,6 @@ type layerRef struct {
 	done func()
 }
 
-func newWaiter() *waiter {
-	return &waiter{
-		completionCond: sync.NewCond(&sync.Mutex{}),
-	}
-}
-
-type waiter struct {
-	isDone         bool
-	isDoneMu       sync.Mutex
-	completionCond *sync.Cond
-}
-
-func (w *waiter) done() {
-	w.isDoneMu.Lock()
-	w.isDone = true
-	w.isDoneMu.Unlock()
-	w.completionCond.Broadcast()
-}
-
-func (w *waiter) wait(timeout time.Duration) error {
-	wait := func() <-chan struct{} {
-		ch := make(chan struct{})
-		go func() {
-			w.isDoneMu.Lock()
-			isDone := w.isDone
-			w.isDoneMu.Unlock()
-
-			w.completionCond.L.Lock()
-			if !isDone {
-				w.completionCond.Wait()
-			}
-			w.completionCond.L.Unlock()
-			ch <- struct{}{}
-		}()
-		return ch
-	}
-	select {
-	case <-time.After(timeout):
-		w.isDoneMu.Lock()
-		w.isDone = true
-		w.isDoneMu.Unlock()
-		w.completionCond.Broadcast()
-		return fmt.Errorf("timeout(%v)", timeout)
-	case <-wait():
-		return nil
-	}
-}
-
 type readerAtFunc func([]byte, int64) (int, error)
 
 func (f readerAtFunc) ReadAt(p []byte, offset int64) (int, error) { return f(p, offset) }

--- a/fs/layer/layer_test.go
+++ b/fs/layer/layer_test.go
@@ -39,6 +39,8 @@
 package layer
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -73,5 +75,53 @@ func TestWaiter(t *testing.T) {
 
 	if doneTime.Sub(startTime) < waitTime {
 		t.Errorf("wait time is too short: %v; want %v", doneTime.Sub(startTime), waitTime)
+	}
+}
+
+func newWaiter() *waiter {
+	return &waiter{
+		completionCond: sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+type waiter struct {
+	isDone         bool
+	isDoneMu       sync.Mutex
+	completionCond *sync.Cond
+}
+
+func (w *waiter) done() {
+	w.isDoneMu.Lock()
+	w.isDone = true
+	w.isDoneMu.Unlock()
+	w.completionCond.Broadcast()
+}
+
+func (w *waiter) wait(timeout time.Duration) error {
+	wait := func() <-chan struct{} {
+		ch := make(chan struct{})
+		go func() {
+			w.isDoneMu.Lock()
+			isDone := w.isDone
+			w.isDoneMu.Unlock()
+
+			w.completionCond.L.Lock()
+			if !isDone {
+				w.completionCond.Wait()
+			}
+			w.completionCond.L.Unlock()
+			ch <- struct{}{}
+		}()
+		return ch
+	}
+	select {
+	case <-time.After(timeout):
+		w.isDoneMu.Lock()
+		w.isDone = true
+		w.isDoneMu.Unlock()
+		w.completionCond.Broadcast()
+		return fmt.Errorf("timeout(%v)", timeout)
+	case <-wait():
+		return nil
 	}
 }


### PR DESCRIPTION
fs/layer/layer.go contains a struct that creates a waiter that is useful for testing, and is currently only used in testing.  This PR moves the struct and logic from fs/layer/layer.go to fs/layer/layer_test.go.  

This was previously included in a different PR (https://github.com/awslabs/soci-snapshotter/pull/341), which we plan to close as it also adds testing tags which we have decided against.

*Testing performed:*
```make && make check && make test```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
