### PR TITLE
Build registries in integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,3 +41,7 @@ RUN curl -sSL --output /tmp/runc https://github.com/opencontainers/runc/releases
 RUN curl -sSL --output /tmp/nerdctl.tgz https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${TARGETARCH:-amd64}.tar.gz && \
     tar zxvf /tmp/nerdctl.tgz -C /usr/local/bin/ && \
     rm -f /tmp/nerdctl.tgz
+
+FROM registry:2 AS registry2
+
+FROM ghcr.io/oci-playground/registry:v3.0.0-alpha.1 AS registry3alpha1

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -79,8 +79,10 @@ func TestMain(m *testing.M) {
 // setup can be used to initialize things before integration tests start (as of now it only builds the services used by the integration tests so they can be referenced)
 func setup() ([]func() error, error) {
 	var (
-		serviceName = "testing"
-		targetStage = "containerd-snapshotter-base"
+		serviceName          = "testing"
+		targetStage          = "containerd-snapshotter-base"
+		registry2Stage       = "registry2"
+		registry3alpha1Stage = "registry3alpha1"
 	)
 	pRoot, err := testutil.GetProjectRoot()
 	if err != nil {
@@ -92,9 +94,11 @@ func setup() ([]func() error, error) {
 	}
 
 	composeYaml, err := testutil.ApplyTextTemplate(composeBuildTemplate, dockerComposeYaml{
-		ServiceName:     serviceName,
-		ImageContextDir: pRoot,
-		TargetStage:     targetStage,
+		ServiceName:          serviceName,
+		ImageContextDir:      pRoot,
+		TargetStage:          targetStage,
+		Registry2Stage:       registry2Stage,
+		Registry3Alpha1Stage: registry3alpha1Stage,
 	})
 	if err != nil {
 		return nil, err

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -71,8 +71,8 @@ const (
 	containerdBlobStorePath      = "/var/lib/containerd/io.containerd.content.v1.content/blobs/sha256"
 	// Registry images to use in the test infrastructure. These are not intended to be used
 	// as images in the test itself, but just when we're setting up docker compose.
-	oci11RegistryImage = "ghcr.io/oci-playground/registry:v3.0.0-alpha.1"
-	oci10RegistryImage = "docker.io/library/registry:2"
+	oci11RegistryImage = "ghcr:soci_test"
+	oci10RegistryImage = "registry2:soci_test"
 )
 
 // These are images that we use in our integration tests
@@ -126,7 +126,7 @@ const composeDefaultTemplate = `
 version: "3.7"
 services:
   testing:
-   image: soci_integ_test 
+   image: soci_base:soci_test
    privileged: true
    init: true
    entrypoint: [ "sleep", "infinity" ]
@@ -143,7 +143,7 @@ const composeRegistryTemplate = `
 version: "3.7"
 services:
  {{.ServiceName}}:
-  image: soci_integ_test
+  image: soci_base:soci_test
   privileged: true
   init: true
   entrypoint: [ "sleep", "infinity" ]
@@ -173,7 +173,7 @@ const composeRegistryAltTemplate = `
 version: "3.7"
 services:
   {{.ServiceName}}:
-    image: soci_integ_test
+    image: soci_base:soci_test
     privileged: true
     init: true
     entrypoint: [ "sleep", "infinity" ]
@@ -186,7 +186,7 @@ services:
     volumes:
     - /dev/fuse:/dev/fuse
   registry:
-    image: ghcr.io/oci-playground/registry:v3.0.0-alpha.1
+    image: ghcr:soci_test
     container_name: {{.RegistryHost}}
     environment:
     - REGISTRY_AUTH=htpasswd
@@ -198,7 +198,7 @@ services:
     volumes:
     - {{.AuthDir}}:/auth:ro
   registry-alt:
-    image: registry:2
+    image: registry2:soci_test
     container_name: {{.RegistryAltHost}}
 `
 
@@ -206,27 +206,35 @@ const composeBuildTemplate = `
 version: "3.7"
 services:
  {{.ServiceName}}:
-  image: soci_integ_test
+  image: soci_base:soci_test
   build:
    context: {{.ImageContextDir}}
    target: {{.TargetStage}}
    args:
     - SNAPSHOTTER_BUILD_FLAGS="-race"
  registry:
-  image: ghcr.io/oci-playground/registry:v3.0.0-alpha.1
+  image: ghcr:soci_test
+  build:
+   context: {{.ImageContextDir}}
+   target: {{.Registry3Alpha1Stage}}
  registry-alt:
-  image: registry:2
+  image: registry2:soci_test
+  build:
+   context: {{.ImageContextDir}}
+   target: {{.Registry2Stage}}
 `
 
 type dockerComposeYaml struct {
-	ServiceName      string
-	ImageContextDir  string
-	TargetStage      string
-	RegistryHost     string
-	RegistryImageRef string
-	RegistryAltHost  string
-	AuthDir          string
-	NetworkConfig    string
+	ServiceName          string
+	ImageContextDir      string
+	TargetStage          string
+	Registry2Stage       string
+	Registry3Alpha1Stage string
+	RegistryHost         string
+	RegistryImageRef     string
+	RegistryAltHost      string
+	AuthDir              string
+	NetworkConfig        string
 }
 
 // getContainerdConfigToml creates a containerd config yaml, by appending all


### PR DESCRIPTION
This change allows us to build the registries used by our integration tests (dockers registry and GHCR). This enables us to add a custom test tag to the registry images to avoid any conflict with user owned images/containers (eg: during our integration tear down where we remove the registry images).

*Issue #, if available:*

Fixes: #400 

*Description of changes:*

*Testing performed:*
 

The demo below reflects a situation in which a user may have instances of both the dockerhub registry as well as GHCR running on their machine. When integration tests are run registry images are built and tagged with `soci_test`. After tests have run all test images are successfully removed, while having no affect on the users registry images. 

```
$ docker image ls                                                                                                                                                                          

REPOSITORY                        TAG              IMAGE ID       CREATED        SIZE
registry                          2                0d153fadf70b   5 days ago     24.2MB
ghcr.io/oci-playground/registry   v3.0.0-alpha.1   bf427d5377cc   3 months ago   26.5MB

$ docker ps 

CONTAINER ID   IMAGE          COMMAND                  CREATED          STATUS          PORTS      NAMES
a71a812d073e   0d153fadf70b   "/entrypoint.sh /etc…"   10 minutes ago   Up 10 minutes   5000/tcp   user_registry
f2ef685c8d01   bf427d5377cc   "registry serve /etc…"   36 minutes ago   Up 36 minutes   5000/tcp   user_ghcr

$ GO_TEST_FLAGS="-run SnapshotterStartup -count=1" make integration

$ docker image ls                                                                                                                                                                           
REPOSITORY                        TAG              IMAGE ID       CREATED          SIZE
soci_base                         soci_test        20cf2f873332   16 minutes ago   1.23GB
ghcr                              soci_test        1dfc9ba7ec10   3 months ago     26.5MB
registry                          soci_test        ebbf605cfe93   5 days ago       24.2MB
registry                          2                0d153fadf70b   5 days ago       24.2MB
ghcr.io/oci-playground/registry   v3.0.0-alpha.1   bf427d5377cc   3 months ago     26.5MB


$ ...
--- PASS: TestSnapshotterStartup (1.55s)
PASS
ok  	github.com/awslabs/soci-snapshotter/integration	14.744s

$ docker image ls                                                                                                                                                                           
REPOSITORY                        TAG              IMAGE ID       CREATED        SIZE
registry                          2                0d153fadf70b   5 days ago     24.2MB
ghcr.io/oci-playground/registry   v3.0.0-alpha.1   bf427d5377cc   3 months ago   26.5MB


```


`make test && make integration`



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
