### PR TITLE
Refactor span manager to improve comment and reusability

### DIFF
--- a/fs/reader/testutil.go
+++ b/fs/reader/testutil.go
@@ -125,7 +125,7 @@ func testFileReadAt(t *testing.T, factory metadata.Store) {
 							// read the file
 							respData := make([]byte, size)
 							n, err := f.ReadAt(respData, offset)
-							if err != nil {
+							if err != nil && err != io.EOF {
 								t.Fatalf("failed to read off=%d, size=%d, filesize=%d: %v", offset, size, filesize, err)
 							}
 							respData = respData[:n]
@@ -237,7 +237,7 @@ func testFailReader(t *testing.T, factory metadata.Store) {
 			// tests for reading file
 			p := make([]byte, len(sampleData1))
 			n, err := fr.ReadAt(p, 0)
-			if err != nil || n != len(sampleData1) || !bytes.Equal([]byte(sampleData1), p) {
+			if (err != nil && err != io.EOF) || n != len(sampleData1) || !bytes.Equal([]byte(sampleData1), p) {
 				t.Errorf("failed to read data but wanted to succeed: %v", err)
 			}
 		})

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -385,7 +385,7 @@ func (m *SpanManager) resolveSpanFromCache(s *span, offsetStart, size compressio
 func (m *SpanManager) fetchAndCacheSpan(spanID compression.SpanID) ([]byte, error) {
 	// fetch compressed span
 	compressedBuf, err := m.fetchSpanWithRetries(spanID)
-	if err != nil && err != io.EOF {
+	if err != nil {
 		return nil, err
 	}
 
@@ -430,7 +430,9 @@ func (m *SpanManager) fetchSpanWithRetries(spanID compression.SpanID) ([]byte, e
 	)
 	for i := 0; i < m.maxSpanVerificationFailureRetries+1; i++ {
 		n, err = m.r.ReadAt(compressedBuf, int64(offset))
-		if err != nil {
+		// if the n = len(p) bytes returned by ReadAt are at the end of the input source,
+		// ReadAt may return either err == EOF or err == nil: https://pkg.go.dev/io#ReaderAt
+		if err != nil && err != io.EOF {
 			return []byte{}, err
 		}
 

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -391,7 +391,7 @@ type retryableReaderAt struct {
 
 func (r *retryableReaderAt) ReadAt(buf []byte, off int64) (int, error) {
 	n, err := r.inner.ReadAt(buf, off)
-	if err != nil || n != len(buf) {
+	if (err != nil && err != io.EOF) || n != len(buf) {
 		return n, err
 	}
 	if r.errCount < r.maxErrors {

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -238,7 +238,7 @@ func TestStateTransition(t *testing.T) {
 					t.Fatalf("failed transitioning to Fetched state")
 				}
 			} else {
-				_, err := m.GetSpanContent(tc.spanID, 0, s.endUncompOffset-s.startUncompOffset, s.endUncompOffset-s.startUncompOffset)
+				_, err := m.GetSpanContent(tc.spanID, 0, s.endUncompOffset-s.startUncompOffset)
 				if err != nil {
 					t.Fatalf("failed getting the span for on-demand fetch: %v", err)
 				}

--- a/ztoc/toc_builder.go
+++ b/ztoc/toc_builder.go
@@ -192,6 +192,9 @@ type positionTrackerReader struct {
 
 func (p *positionTrackerReader) Read(b []byte) (int, error) {
 	n, err := p.r.ReadAt(b, int64(p.pos))
+	if err == io.EOF {
+		err = nil
+	}
 	if err == nil {
 		p.pos += compression.Offset(n)
 	}

--- a/ztoc/ztoc.go
+++ b/ztoc/ztoc.go
@@ -155,7 +155,7 @@ func ExtractFile(r *io.SectionReader, config *FileExtractConfig) ([]byte, error)
 				rangeStart--
 			}
 			n, err := r.ReadAt(buf[rangeStart-start:rangeEnd-start], int64(rangeStart)) // need to convert rangeStart to int64 to use in ReadAt
-			if err != nil {
+			if err != nil && err != io.EOF {
 				return err
 			}
 


### PR DESCRIPTION
*Issue #, if available:*

Part of #231, this PR makes refactor-only changes to span manager, so the follow up PR for #231 will be smaller.

*Description of changes:*

1. Remove `fetchSpan` and reuse `fetchWithRetries` (there're just too many "fetch span" related funcs: `FetchSingleSpan`, `fetchWithRetries`, `fetchSpan`, `fetchAndCacheSpan`, etc).
2. Remove `size` arg in `GetSpanContent` (it already has `offsetStart, offsetEnd`, size is redundant).
3. Let `fetchSpanWithRetries` calculate span size and return the buffer. (so every caller doesn't need to calculate span size and make a buffer and pass buffer to `fetchSpanWithRetries`, which is duplicated)
4. Doc/comment improvement.

(in a separate commit https://github.com/awslabs/soci-snapshotter/pull/444/commits/b4022ce41036db1711e8431e89632d6b3aa8ae89)

1. add `err != io.EOF` check to `ReadAt` calls (https://github.com/awslabs/soci-snapshotter/pull/444#discussion_r1114554669)

*Testing performed:*

make check && make test && make integration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
