### PR TITLE
Create OCI 1.0 Image Manifests for SOCI Indices by default.

### DIFF
--- a/cmd/soci/commands/internal/spec.go
+++ b/cmd/soci/commands/internal/spec.go
@@ -19,13 +19,14 @@ package internal
 import "github.com/urfave/cli"
 
 const (
-	LegacyRegistryFlagName = "legacy-registry"
+	ManifestTypeFlagName = "manifest-type"
+	ImageManifestType    = "image"
+	ArtifactManifestType = "artifact"
 )
 
-var LegacyRegistryFlag = cli.BoolFlag{
-	Name: LegacyRegistryFlagName,
-	Usage: `Whether to create the SOCI index for a legacy registry. OCI 1.1 added support for associating artifacts such as soci indices with images.
-     There is a mechanism to emulate this behavior with OCI 1.0 registries by pretending that the SOCI index
-     is itself an image. This option should only be use if the SOCI index will be pushed to a
-     registry which does not support OCI 1.1 features.`,
+var ManifestTypeFlag = cli.StringFlag{
+	Name:  ManifestTypeFlagName,
+	Value: ImageManifestType,
+	Usage: `Generate either an OCI 1.1 artifact manifest or OCI 1.0 image manifest for the SOCI index. 
+        (You should use 'artifact' only if you intend on interacting with a registry that supports OCI 1.1 artifacts)`,
 }

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -86,7 +86,7 @@ func TestMetrics(t *testing.T) {
 }
 
 func TestOverlayFallbackMetric(t *testing.T) {
-	sh, done := newShellWithRegistry(t, newRegistryConfig())
+	sh, done := newSnapshotterBaseShell(t)
 	defer done()
 
 	testCases := []struct {
@@ -146,7 +146,7 @@ func TestFuseOperationFailureMetrics(t *testing.T) {
 log_fuse_operations = true
 `
 
-	sh, done := newShellWithRegistry(t, newRegistryConfig())
+	sh, done := newSnapshotterBaseShell(t)
 	defer done()
 
 	manipulateZtocMetadata := func(zt *ztoc.Ztoc) {
@@ -214,7 +214,7 @@ func TestFuseOperationCountMetrics(t *testing.T) {
 fuse_metrics_emit_wait_duration_sec = 10
 	`
 
-	sh, done := newShellWithRegistry(t, newRegistryConfig())
+	sh, done := newSnapshotterBaseShell(t)
 	defer done()
 
 	testCases := []struct {
@@ -271,7 +271,7 @@ emit_metric_period_sec = 2
 		commonmetrics.BackgroundSpanFetchCount,
 	}
 
-	sh, done := newShellWithRegistry(t, newRegistryConfig())
+	sh, done := newSnapshotterBaseShell(t)
 	defer done()
 
 	testCases := []struct {
@@ -351,11 +351,11 @@ func buildIndexByManipulatingZtocData(sh *shell.Shell, indexDigest string, manip
 	}
 
 	newIndex := soci.Index{
-		MediaType:    soci.OCIArtifactManifestMediaType,
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: soci.SociIndexArtifactType,
 		Blobs:        ztocDescs,
 		Subject: &ocispec.Descriptor{
-			MediaType: soci.OCIArtifactManifestMediaType,
+			MediaType: ocispec.MediaTypeArtifactManifest,
 			Digest:    index.Subject.Digest,
 			Size:      index.Subject.Size,
 		},

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -331,7 +331,7 @@ func TestLazyPullNoIndexDigest(t *testing.T) {
 	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
 	copyImage(sh, dockerhub(optimizedImageName), regConfig.mirror(optimizedImageName))
 	copyImage(sh, dockerhub(nonOptimizedImageName), regConfig.mirror(nonOptimizedImageName))
-	buildIndex(sh, regConfig.mirror(optimizedImageName), withMinLayerSize(0))
+	buildIndex(sh, regConfig.mirror(optimizedImageName), withMinLayerSize(0), withOCIArtifactRegistrySupport)
 	sh.X("soci", "push", "--user", regConfig.creds(), regConfig.mirror(optimizedImageName).ref)
 
 	// Test if contents are pulled
@@ -443,11 +443,11 @@ func TestPullWithAribtraryBlobInvalidZtocFormat(t *testing.T) {
 		}
 
 		index := soci.Index{
-			MediaType:    soci.OCIArtifactManifestMediaType,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			ArtifactType: soci.SociIndexArtifactType,
 			Blobs:        ztocDescs,
 			Subject: &ocispec.Descriptor{
-				MediaType: soci.OCIArtifactManifestMediaType,
+				MediaType: ocispec.MediaTypeArtifactManifest,
 				Digest:    digest.Digest(imgDigest),
 				Size:      int64(len(imgBytes)),
 			},

--- a/integration/testutil_soci.go
+++ b/integration/testutil_soci.go
@@ -54,9 +54,9 @@ const (
 // indexBuildConfig represents the values of the CLI flags that should be used
 // when creating an index with `buildIndex`
 type indexBuildConfig struct {
-	spanSize              int64
-	minLayerSize          int64
-	supportLegacyRegistry bool
+	spanSize                int64
+	minLayerSize            int64
+	supportArtifactRegistry bool
 }
 
 // indexBuildOption is a functional argument to update `indexBuildConfig`
@@ -77,8 +77,9 @@ func withMinLayerSize(minLayerSize int64) indexBuildOption {
 	}
 }
 
-func withLegacyRegistrySupport(ibc *indexBuildConfig) {
-	ibc.supportLegacyRegistry = true
+// withOCIArtifactRegistrySupport sets the SOCI index to built as an artifact manifest
+func withOCIArtifactRegistrySupport(ibc *indexBuildConfig) {
+	ibc.supportArtifactRegistry = true
 }
 
 // defaultIndexBuildConfig is the default parameters when creating and index with `buildIndex`
@@ -104,8 +105,8 @@ func buildIndex(sh *shell.Shell, src imageInfo, opt ...indexBuildOption) string 
 		"--span-size", fmt.Sprintf("%d", indexBuildConfig.spanSize),
 		"--platform", platforms.Format(src.platform),
 	}
-	if indexBuildConfig.supportLegacyRegistry {
-		createArgs = append(createArgs, "--legacy-registry")
+	if indexBuildConfig.supportArtifactRegistry {
+		createArgs = append(createArgs, "--manifest-type", "artifact")
 	}
 
 	indexDigest := sh.
@@ -118,10 +119,9 @@ func buildIndex(sh *shell.Shell, src imageInfo, opt ...indexBuildOption) string 
 }
 
 func validateSociIndex(sh *shell.Shell, sociIndex soci.Index, imgManifestDigest string, includedLayers map[string]struct{}) error {
-	if sociIndex.MediaType != ocispec.MediaTypeArtifactManifest {
-		return fmt.Errorf("unexpected index media type; expected = %v, got = %v", ocispec.MediaTypeArtifactManifest, sociIndex.MediaType)
+	if sociIndex.MediaType != ocispec.MediaTypeArtifactManifest && sociIndex.MediaType != ocispec.MediaTypeImageManifest {
+		return fmt.Errorf("unexpected index media type; expected types: [%v, %v], got: %v", ocispec.MediaTypeArtifactManifest, ocispec.MediaTypeImageManifest, sociIndex.MediaType)
 	}
-
 	if sociIndex.ArtifactType != soci.SociIndexArtifactType {
 		return fmt.Errorf("unexpected index artifact type; expected = %v, got = %v", soci.SociIndexArtifactType, sociIndex.ArtifactType)
 	}

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -238,7 +238,7 @@ func (db *ArtifactsDb) RemoveArtifactEntryByImageDigest(digest string) error {
 // Determines whether a bucket represents an index, as opposed to a zTOC
 func indexBucket(b *bolt.Bucket) bool {
 	mt := string(b.Get(bucketKeyMediaType))
-	return mt == OCIArtifactManifestMediaType || mt == ocispec.MediaTypeImageManifest
+	return mt == ocispec.MediaTypeArtifactManifest || mt == ocispec.MediaTypeImageManifest
 }
 
 // Determines whether a bucket's image digest is the same as digest

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -97,7 +97,7 @@ func TestBuildSociIndexNotLayer(t *testing.T) {
 		},
 		{
 			name:      "soci index manifest",
-			mediaType: OCIArtifactManifestMediaType,
+			mediaType: ocispec.MediaTypeArtifactManifest,
 			err:       errNotLayerType,
 		},
 		{
@@ -251,7 +251,7 @@ func TestNewIndex(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			index := NewIndex(tc.blobs, &tc.subject, tc.annotations, false)
+			index := NewIndex(tc.blobs, &tc.subject, tc.annotations, WithIndexAsArtifact)
 
 			if diff := cmp.Diff(index.Blobs, tc.blobs); diff != "" {
 				t.Fatalf("unexpected blobs; diff = %v", diff)
@@ -261,8 +261,8 @@ func TestNewIndex(t *testing.T) {
 				t.Fatalf("unexpected artifact type; expected = %s, got = %s", SociIndexArtifactType, index.ArtifactType)
 			}
 
-			if index.MediaType != OCIArtifactManifestMediaType {
-				t.Fatalf("unexpected media type; expected = %v, got = %v", OCIArtifactManifestMediaType, index.MediaType)
+			if index.MediaType != ocispec.MediaTypeArtifactManifest {
+				t.Fatalf("unexpected media type; expected = %v, got = %v", ocispec.MediaTypeArtifactManifest, index.MediaType)
 			}
 
 			if diff := cmp.Diff(index.Subject, &tc.subject); diff != "" {
@@ -299,7 +299,7 @@ func TestDecodeIndex(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			index := NewIndex(tc.blobs, &tc.subject, tc.annotations, false)
+			index := NewIndex(tc.blobs, &tc.subject, tc.annotations, WithIndexAsArtifact)
 			jsonBytes, err := json.Marshal(index)
 			if err != nil {
 				t.Fatalf("cannot convert index to json byte data: %v", err)
@@ -340,12 +340,12 @@ func TestMarshalIndex(t *testing.T) {
 	}{
 		{
 			name:  "successfully roundtrip as Artifact Manifest",
-			index: NewIndex(blobs, &subject, annotations, false),
+			index: NewIndex(blobs, &subject, annotations, WithIndexAsArtifact),
 			ty:    ocispec.Artifact{},
 		},
 		{
 			name:  "successfully roundtrip as Image Manifest",
-			index: NewIndex(blobs, &subject, annotations, true),
+			index: NewIndex(blobs, &subject, annotations),
 			ty:    ocispec.Manifest{},
 		},
 	}


### PR DESCRIPTION
 This change inverts the current behavior of 'soci create' to create OCI 1.0 image manifests for the SOCI index by default. A `--manifest-type` flag has been added to specify the type of manifest to create for SOCI indices (currently either 'artifact' or 'image'). If the flag is not used 'soci create' will default to image manifest.

*Issue #, if available:*

Fixes: #434 

Example:

```
$ soci create --help
NAME:
   soci create - create SOCI index
USAGE:
   soci create [command options] [flags] <image_ref>
OPTIONS:
   ....
   --manifest-type value       Generate either an OCI 1.1 artifact manifest or OCI 1.0 image manifest for the SOCI index.
        (You should use 'artifact' only if you intend on interacting with a registry that support OCI 1.1 artifacts) (default: "image")
   ...


$ soci create -p linux/amd64  docker.io/library/redis:latest
layer sha256:db7c27bf355290eeb889d2e2986ba34352eba3adba6ae44eaef63d5e7dd69898 -> ztoc skipped
layer sha256:51afc2cce3dfa745f19f601b33820e4a960311cd81b0a6a816b1de8e5ae6d7d7 -> ztoc skipped
layer sha256:ac509f65c3e925781d771dc15fd63c2bd795abdc461f29bd9a3acd0a19f65d3f -> ztoc skipped
layer sha256:ab1a1215d5f9ec95bf6981023be29642373dcdd6218d602d1f049d5e5ee3ee29 -> ztoc skipped
layer sha256:817f7e347ebd5d210d4a5923c221e92275d665ced36e12185bc26747e977e47d -> ztoc skipped
layer sha256:bb263680fed18eecdc67f885094df6f589bafc19004839d7fdf141df236a61aa -> ztoc sha256:3bb9b6f663024dc85e7acffe60dff225d3ff32d9ebfef4784760ce4a6214b36b

$ soci index list
DIGEST                                                                     SIZE    IMAGE REF                         PLATFORM       MEDIA TYPE                                    CREATED
sha256:daca991c9c605eb10e1eaa0f4ee608f7ede3b4b3a12ce26317c7e96d92224972    854     docker.io/library/redis:latest    linux/amd64    application/vnd.oci.image.manifest.v1+json    5s ago

$ soci index info sha256:daca991c9c605eb10e1eaa0f4ee608f7ede3b4b3a12ce26317c7e96d92224972 | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.amazon.soci.index.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/octet-stream",
      "digest": "sha256:3bb9b6f663024dc85e7acffe60dff225d3ff32d9ebfef4784760ce4a6214b36b",
      "size": 1495528,
      "annotations": {
        "com.amazon.soci.image-layer-digest": "sha256:bb263680fed18eecdc67f885094df6f589bafc19004839d7fdf141df236a61aa",
        "com.amazon.soci.image-layer-mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip"
      }
    }
  ],
  "subject": {
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "digest": "sha256:87583c95fd2253658fdd12e765addbd2126879af86a90b34efc09457486b21b1",
    "size": 1573
  },
  "annotations": {
    "com.amazon.soci.build-tool-identifier": "AWS SOCI CLI v0.1"
  }
}
```



*Testing performed:*

`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

