### PR TITLE
Update duration types to int64

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -61,8 +61,8 @@ type Config struct {
 	DisableVerification            bool   `toml:"disable_verification"`
 	MaxConcurrency                 int64  `toml:"max_concurrency"`
 	NoPrometheus                   bool   `toml:"no_prometheus"`
-	MountTimeoutSec                int    `toml:"mount_timeout_sec"`
-	FuseMetricsEmitWaitDurationSec int    `toml:"fuse_metrics_emit_wait_duration_sec"`
+	MountTimeoutSec                int64  `toml:"mount_timeout_sec"`
+	FuseMetricsEmitWaitDurationSec int64  `toml:"fuse_metrics_emit_wait_duration_sec"`
 
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob"`
@@ -81,8 +81,8 @@ type BlobConfig struct {
 	FetchTimeoutSec      int64 `toml:"fetching_timeout_sec"`
 	ForceSingleRangeMode bool  `toml:"force_single_range_mode"`
 	MaxRetries           int   `toml:"max_retries"`
-	MinWaitMsec          int   `toml:"min_wait_msec"`
-	MaxWaitMsec          int   `toml:"max_wait_msec"`
+	MinWaitMsec          int64 `toml:"min_wait_msec"`
+	MaxWaitMsec          int64 `toml:"max_wait_msec"`
 
 	// MaxSpanVerificationRetries defines the number of additional times fetch
 	// will be invoked in case of span verification failure.

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -170,17 +170,17 @@ var (
 var register sync.Once
 
 // sinceInMilliseconds gets the time since the specified start in milliseconds.
-// The division by 1e6 is made to have the milliseconds value as floating point number, since the native method
-// .Milliseconds() returns an integer value and you can lost a precision for sub-millisecond values.
+// The division is made to have the milliseconds value as floating point number, since the native method
+// .Milliseconds() returns an integer value and you can lose precision for sub-millisecond values.
 func sinceInMilliseconds(start time.Time) float64 {
-	return float64(time.Since(start).Nanoseconds()) / 1e6
+	return float64(time.Since(start).Nanoseconds()) / float64(time.Millisecond/time.Nanosecond)
 }
 
 // sinceInMicroseconds gets the time since the specified start in microseconds.
-// The division by 1e3 is made to have the microseconds value as floating point number, since the native method
-// .Microseconds() returns an integer value and you can lost a precision for sub-microsecond values.
+// The division is made to have the microseconds value as floating point number, since the native method
+// .Microseconds() returns an integer value and you can lose precision for sub-microsecond values.
 func sinceInMicroseconds(start time.Time) float64 {
-	return float64(time.Since(start).Nanoseconds()) / 1e3
+	return float64(time.Since(start).Nanoseconds()) / float64(time.Microsecond/time.Nanosecond)
 }
 
 // Register registers metrics. This is always called only once.

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -70,13 +70,13 @@ import (
 )
 
 const (
-	defaultValidIntervalSec = 60
-	defaultFetchTimeoutSec  = 300
+	defaultValidIntervalSec int64 = 60
+	defaultFetchTimeoutSec  int64 = 300
 
 	// defaults based on a target total retry time of at least 5s. 30*((2^8)-1)>5000
-	defaultMaxRetries  = 8
-	defaultMinWaitMsec = 30
-	defaultMaxWaitMsec = 300000
+	defaultMaxRetries        = 8
+	defaultMinWaitMsec int64 = 30
+	defaultMaxWaitMsec int64 = 300000
 )
 
 func NewResolver(cfg config.BlobConfig, handlers map[string]Handler) *Resolver {

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -558,7 +558,7 @@ func generateRegistrySelfSignedCert(registryHost string) (crt, key []byte, _ err
 		SerialNumber:          serialNumber,
 		Subject:               pkix.Name{CommonName: registryHost},
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		NotAfter:              time.Now().AddDate(1, 0, 0), // one year
 		KeyUsage:              x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		DNSNames:              []string{registryHost},

--- a/service/resolver/registry.go
+++ b/service/resolver/registry.go
@@ -41,7 +41,7 @@ import (
 	rhttp "github.com/hashicorp/go-retryablehttp"
 )
 
-const defaultRequestTimeoutSec = 30
+const defaultRequestTimeoutSec int64 = 30
 
 // Config is config for resolving registries.
 type Config struct {
@@ -63,7 +63,7 @@ type MirrorConfig struct {
 	// RequestTimeoutSec is timeout seconds of each request to the registry.
 	// RequestTimeoutSec == 0 indicates the default timeout (defaultRequestTimeoutSec).
 	// RequestTimeoutSec < 0 indicates no timeout.
-	RequestTimeoutSec int `toml:"request_timeout_sec"`
+	RequestTimeoutSec int64 `toml:"request_timeout_sec"`
 }
 
 type Credential func(string, reference.Spec) (string, string, error)
@@ -80,7 +80,7 @@ func RegistryHostsFromConfig(cfg Config, credsFuncs ...Credential) source.Regist
 			tr := client.StandardClient()
 			if h.RequestTimeoutSec >= 0 {
 				if h.RequestTimeoutSec == 0 {
-					tr.Timeout = defaultRequestTimeoutSec * time.Second
+					tr.Timeout = time.Duration(defaultRequestTimeoutSec) * time.Second
 				} else {
 					tr.Timeout = time.Duration(h.RequestTimeoutSec) * time.Second
 				}


### PR DESCRIPTION
*Issue #, if available:*
#443 

*Description of changes:*
Change members, variables, and consts that store time durations to type `int64`. Add necessary explicit type conversions.

Also remove a few magic numbers from time type conversions in favor of constants from the `time` package.

Also make an existing `plus one year` calculation more accurate.

*Testing performed:*
`make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.