### PR TITLE
Added flag to configure behavior when pushing to remote that has existing soci indices

### DIFF
--- a/cmd/soci/commands/internal/index.go
+++ b/cmd/soci/commands/internal/index.go
@@ -1,0 +1,48 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import "github.com/urfave/cli"
+
+const (
+	ExistingIndexFlagName = "existing-index"
+	Warn                  = "warn"
+	Skip                  = "skip"
+	Allow                 = "allow"
+)
+
+var SupportedExistingIndexOptions = []string{Warn, Skip, Allow}
+
+var ExistingIndexFlag = cli.StringFlag{
+	Name:  ExistingIndexFlagName,
+	Value: Warn,
+	Usage: `Configure how to handle existing SOCI artifacts in remote when pushing indices
+			warn  - print warning message to stdout but push index anyway
+			skip  - skip pushing the index
+			allow - push the index regardless
+	`,
+}
+
+// SupportedArg checks if a value is present within a given slice
+func SupportedArg[K comparable](v K, list []K) bool {
+	for _, o := range list {
+		if v == o {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -105,11 +105,8 @@ please see [README](../README.md#no-image-conversion).
 
 Let's create a SOCI index, which later will be pushed to your registry:
 
-> The `--legacy-registry` flag specifies to create SOCI index as image manifest
-> instead of artifact.
-
 ```shell
-sudo soci create --legacy-registry $REGISTRY/rabbitmq:latest
+sudo soci create $REGISTRY/rabbitmq:latest
 
 # output
 layer sha256:57315aaee690b22265ebb83b5443587443398a7cd99dd2a43985c28868d34053 -> ztoc skipped

--- a/fs/client.go
+++ b/fs/client.go
@@ -65,7 +65,7 @@ func NewOCIArtifactClient(inner Inner) *OCIArtifactClient {
 }
 
 func (c *OCIArtifactClient) SelectReferrer(ctx context.Context, desc ocispec.Descriptor, fn IndexSelectionPolicy) (ocispec.Descriptor, error) {
-	descs, err := c.allReferrers(ctx, desc)
+	descs, err := c.AllReferrers(ctx, desc)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("unable to fetch referrers: %w", err)
 	}
@@ -75,7 +75,7 @@ func (c *OCIArtifactClient) SelectReferrer(ctx context.Context, desc ocispec.Des
 	return fn(descs)
 }
 
-func (c *OCIArtifactClient) allReferrers(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+func (c *OCIArtifactClient) AllReferrers(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 	descs := []ocispec.Descriptor{}
 	err := c.Referrers(ctx, desc, soci.SociIndexArtifactType, func(referrers []ocispec.Descriptor) error {
 		descs = append(descs, referrers...)

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -331,7 +331,7 @@ func TestLazyPullNoIndexDigest(t *testing.T) {
 	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
 	copyImage(sh, dockerhub(optimizedImageName), regConfig.mirror(optimizedImageName))
 	copyImage(sh, dockerhub(nonOptimizedImageName), regConfig.mirror(nonOptimizedImageName))
-	buildIndex(sh, regConfig.mirror(optimizedImageName), withMinLayerSize(0), withOCIArtifactRegistrySupport)
+	buildIndex(sh, regConfig.mirror(optimizedImageName), withMinLayerSize(0))
 	sh.X("soci", "push", "--user", regConfig.creds(), regConfig.mirror(optimizedImageName).ref)
 
 	// Test if contents are pulled

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -17,10 +17,12 @@
 package integration
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/awslabs/soci-snapshotter/soci"
+
 	"github.com/containerd/containerd/platforms"
 )
 
@@ -54,12 +56,13 @@ func TestSociArtifactsPushAndPull(t *testing.T) {
 
 			imageName := ubuntuImage
 			copyImage(sh, dockerhub(imageName, withPlatform(platform)), regConfig.mirror(imageName, withPlatform(platform)))
-			indexDigest := buildIndex(sh, regConfig.mirror(imageName, withPlatform(platform)), withMinLayerSize(0), withOCIArtifactRegistrySupport)
+			indexDigest := buildIndex(sh, regConfig.mirror(imageName, withPlatform(platform)), withMinLayerSize(0))
 			artifactsStoreContentDigest := getSociLocalStoreContentDigest(sh)
+
 			sh.X("soci", "push", "--user", regConfig.creds(), "--platform", tt.Platform, regConfig.mirror(imageName).ref)
 			sh.X("rm", "-rf", "/var/lib/soci-snapshotter-grpc/content/blobs/sha256")
-
 			sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, "--platform", tt.Platform, regConfig.mirror(imageName).ref)
+
 			artifactsStoreContentDigestAfterRPull := getSociLocalStoreContentDigest(sh)
 
 			if artifactsStoreContentDigest != artifactsStoreContentDigestAfterRPull {
@@ -108,11 +111,10 @@ func TestPushAlwaysMostRecentlyCreatedIndex(t *testing.T) {
 			copyImage(sh, dockerhub(tc.image), regConfig.mirror(tc.image))
 
 			for _, opt := range tc.opts {
-				index := buildIndex(sh, regConfig.mirror(tc.image), withMinLayerSize(opt.minLayerSize), withSpanSize(opt.spanSize), withOCIArtifactRegistrySupport)
+				index := buildIndex(sh, regConfig.mirror(tc.image), withMinLayerSize(opt.minLayerSize), withSpanSize(opt.spanSize))
 				index = strings.Split(index, "\n")[0]
-				out := sh.O("soci", "push", "--user", regConfig.creds(), regConfig.mirror(tc.image).ref, "-q")
+				out := sh.O("soci", "push", "--existing-index", "allow", "--user", regConfig.creds(), regConfig.mirror(tc.image).ref, "-q")
 				pushedIndex := strings.Trim(string(out), "\n")
-
 				if index != pushedIndex {
 					t.Fatalf("incorrect index pushed to remote registry; expected %s, got %s", index, pushedIndex)
 				}
@@ -191,6 +193,126 @@ func TestLegacyOCI(t *testing.T) {
 				t.Fatalf("failed to rpull: %v", err)
 			}
 			checkFuseMounts(t, sh, len(sociIndex.Blobs))
+		})
+	}
+}
+
+func TestPushWithExistingIndices(t *testing.T) {
+	t.Parallel()
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
+
+	images := []string{nginxImage, rabbitmqImage, drupalImage, ubuntuImage}
+	const (
+		singleFoundMessage   = "soci index found in remote repository with digest:"
+		multipleFoundMessage = "multiple soci indices found in remote repository:"
+		skipMessageTail      = "skipping pushing artifacts for image manifest:"
+		warnMessageHead      = "[WARN]"
+		warnMessageTail      = "pushing index anyway"
+	)
+	imageToIndexDigest := make(map[string]string)
+	imageToManifestDigest := make(map[string]string)
+	for _, img := range images {
+		mirrorImg := regConfig.mirror(img)
+		copyImage(sh, dockerhub(img), mirrorImg)
+		indexDigest := buildIndex(sh, mirrorImg)
+		manifestDigest, err := getManifestDigest(sh, mirrorImg.ref, mirrorImg.platform)
+		if err != nil {
+			t.Fatal(err)
+		}
+		imageToIndexDigest[img] = indexDigest
+		imageToManifestDigest[mirrorImg.ref] = manifestDigest
+
+		sh.X("soci", "push", "--user", regConfig.creds(), mirrorImg.ref)
+		if img == ubuntuImage {
+			buildIndex(sh, mirrorImg, withSpanSize(1280))
+			sh.X("soci", "push", "--user", regConfig.creds(), mirrorImg.ref)
+		}
+
+	}
+
+	tests := []struct {
+		name               string
+		imgInfo            imageInfo
+		imgName            string
+		cmd                []string
+		hasOutput          bool
+		outputContains     string
+		expectedIndexCount int
+	}{
+		{
+			name:               "Warn with existing index",
+			imgInfo:            regConfig.mirror(nginxImage),
+			imgName:            "nginx",
+			cmd:                []string{"soci", "push", "--user", regConfig.creds(), "--existing-index", "warn"},
+			hasOutput:          true,
+			outputContains:     fmt.Sprintf("%s %s %s: %s", warnMessageHead, singleFoundMessage, imageToIndexDigest[nginxImage], warnMessageTail),
+			expectedIndexCount: 2,
+		},
+		{
+			name:               "Skip with existing index",
+			imgInfo:            regConfig.mirror(rabbitmqImage),
+			imgName:            "rabbitmq",
+			cmd:                []string{"soci", "push", "--user", regConfig.creds(), "--existing-index", "skip"},
+			hasOutput:          true,
+			outputContains:     fmt.Sprintf("%s %s: %s %s", singleFoundMessage, imageToIndexDigest[rabbitmqImage], skipMessageTail, imageToManifestDigest[regConfig.mirror(rabbitmqImage).ref]),
+			expectedIndexCount: 1,
+		},
+
+		{
+			name:               "Allow with existing index",
+			imgInfo:            regConfig.mirror(drupalImage),
+			imgName:            "drupal",
+			cmd:                []string{"soci", "push", "--user", regConfig.creds(), "--existing-index", "allow"},
+			expectedIndexCount: 2,
+		},
+		{
+			name:               "Warn with multiple existing indices",
+			imgInfo:            regConfig.mirror(ubuntuImage),
+			imgName:            "ubuntu",
+			cmd:                []string{"soci", "push", "--user", regConfig.creds(), "--existing-index", "warn"},
+			hasOutput:          true,
+			outputContains:     fmt.Sprintf("%s %s %s", warnMessageHead, multipleFoundMessage, warnMessageTail),
+			expectedIndexCount: 3,
+		},
+	}
+	verifyOutput := func(given, expected string) error {
+		if !strings.Contains(given, expected) {
+			return fmt.Errorf("output: %s does not contain substring %s", given, expected)
+		}
+		return nil
+	}
+	verifyIndexCount := func(imgName, digest string, expected int) error {
+		index, err := getReferrers(sh, regConfig, imgName, digest)
+		if err != nil {
+			return err
+		}
+		if len(index.Manifests) != expected {
+			return fmt.Errorf("unexpected index count in remote: expected: %v; got: %v", expected, len(index.Manifests))
+		}
+		return nil
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+			digest := imageToManifestDigest[tc.imgInfo.ref]
+			buildIndex(sh, tc.imgInfo, withSpanSize(1<<19))
+			tc.cmd = append(tc.cmd, tc.imgInfo.ref)
+			output, err := sh.OLog(tc.cmd...)
+			if err != nil {
+				t.Fatalf("unexpected error for test case: %v", err)
+			}
+			if tc.hasOutput {
+				if err = verifyOutput(string(output), tc.outputContains); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err = verifyIndexCount(tc.imgName, strings.TrimSpace(digest), tc.expectedIndexCount); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 }

--- a/integration/testutil_soci.go
+++ b/integration/testutil_soci.go
@@ -33,6 +33,7 @@
 package integration
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -168,9 +169,12 @@ func validateSociIndex(sh *shell.Shell, sociIndex soci.Index, imgManifestDigest 
 	return nil
 }
 
+// getSociLocalStoreContentDigest will generate a digest based on the contents of the soci content store
+// Files that are smaller than 10 bytes wil not be included when generating the digest
 func getSociLocalStoreContentDigest(sh *shell.Shell) digest.Digest {
-	content := sh.O("ls", blobStorePath)
-	return digest.FromBytes(content)
+	content := new(bytes.Buffer)
+	sh.Pipe(nil, []string{"find", blobStorePath, "-maxdepth", "1", "-type", "f", "-size", "+10c"}).Pipe(content, []string{"sort"})
+	return digest.FromBytes(content.Bytes())
 }
 
 func sociIndexFromDigest(sh *shell.Shell, indexDigest string) (index soci.Index, err error) {

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -175,18 +175,21 @@ func marshalIndexAs10Manifest(i *Index) ([]byte, error) {
 }
 
 // GetIndexDescriptorCollection returns all `IndexDescriptorInfo` of the given image and platforms.
-func GetIndexDescriptorCollection(ctx context.Context, cs content.Store, artifactsDb *ArtifactsDb, img images.Image, ps []ocispec.Platform) ([]IndexDescriptorInfo, error) {
-	descriptors := []IndexDescriptorInfo{}
-	var entries []ArtifactEntry
+func GetIndexDescriptorCollection(ctx context.Context, cs content.Store, artifactsDb *ArtifactsDb, img images.Image, ps []ocispec.Platform) ([]IndexDescriptorInfo, *ocispec.Descriptor, error) {
+	var (
+		descriptors []IndexDescriptorInfo
+		entries     []ArtifactEntry
+		indexDesc   *ocispec.Descriptor
+		err         error
+	)
 	for _, platform := range ps {
-		indexDesc, err := GetImageManifestDescriptor(ctx, cs, img.Target, platforms.OnlyStrict(platform))
+		indexDesc, err = GetImageManifestDescriptor(ctx, cs, img.Target, platforms.OnlyStrict(platform))
 		if err != nil {
-			return descriptors, err
+			return nil, nil, err
 		}
-
 		e, err := artifactsDb.getIndexArtifactEntries(indexDesc.Digest.String())
 		if err != nil {
-			return descriptors, err
+			return nil, nil, err
 		}
 		entries = append(entries, e...)
 	}
@@ -207,7 +210,7 @@ func GetIndexDescriptorCollection(ctx context.Context, cs content.Store, artifac
 		})
 	}
 
-	return descriptors, nil
+	return descriptors, indexDesc, nil
 }
 
 type buildConfig struct {


### PR DESCRIPTION
**Issue #, if available:**

Fixes: #168 

**Description of changes:**

Added `--existing-index` [`skip`,`warn`,`allow`] flag to `soci push` that enables different behavior when soci indices are found within a remote repository before pushing.


Before pushing a Referrers API call is made to the remote registry to check for existing SOCI indices. If they are found SOCI will either `skip` the current image manifest, `warn` but still push the artifact for the image manifest or continue with pushing the artifacts with no warning (`allow`).

Remove mentions of `--legacy-registry` from Getting Started guide since 'soci create' creates OCI 1.0 image manifests by default now

**Testing performed:**
`make test && make integration`

Example: 

```
$ soci push --existing-index warn 140217179670.dkr.ecr.us-west-2.amazonaws.com/rabbitmq:latest

checking if a soci index already exists in remote repository...
[WARN] multiple soci indices found in remote repository: pushing index anyway
pushing soci index with digest: sha256:353428fe89b0de95d01bb8e78e69eb75e5722c30f94857959409fdebc1f832b6
skipped artifact with digest: sha256:353428fe89b0de95d01bb8e78e69eb75e5722c30f94857959409fdebc1f832b6

$ soci push --existing-index skip  140217179670.dkr.ecr.us-west-2.amazonaws.com/rabbitmq:latest

checking if a soci index already exists in remote repository...
multiple soci indices found in remote repository; skipping pushing artifacts for image manifest: sha256:a90724968ebde29569f08365d9641465c9f771993b562e6a0ad5dc91f541bb01

$ soci push --existing-index allow  140217179670.dkr.ecr.us-west-2.amazonaws.com/rabbitmq:latest

pushing soci index with digest: sha256:353428fe89b0de95d01bb8e78e69eb75e5722c30f94857959409fdebc1f832b6
skipped artifact with digest: sha256:353428fe89b0de95d01bb8e78e69eb75e5722c30f94857959409fdebc1f832b6

// With quiet flag (warn and abort will still be printed)

$ soci push --existing-index skip  140217179670.dkr.ecr.us-west-2.amazonaws.com/rabbitmq:latest -q

$ soci push --existing-index warn  140217179670.dkr.ecr.us-west-2.amazonaws.com/rabbitmq:latest -q

[WARN] multiple soci indices found in remote repository: pushing index anyway
sha256:353428fe89b0de95d01bb8e78e69eb75e5722c30f94857959409fdebc1f832b6

$ soci push --existing-index allow 140217179670.dkr.ecr.us-west-2.amazonaws.com/rabbitmq:latest -q

sha256:353428fe89b0de95d01bb8e78e69eb75e5722c30f94857959409fdebc1f832b6


```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
