### PR TITLE
Add `soci --version` to get the CLI version

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -119,7 +119,7 @@ func main() {
 		log.L.WithError(err).Fatal("failed to prepare logger")
 	}
 	if *printVersion {
-		fmt.Println("soci-snapshotter-grpc", version.Version, version.Revision)
+		fmt.Println("soci-snapshotter-grpc version", version.Version, version.Revision)
 		return
 	}
 	logrus.SetLevel(lvl)

--- a/cmd/soci/main.go
+++ b/cmd/soci/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/image"
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/index"
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/ztoc"
+	"github.com/awslabs/soci-snapshotter/version"
 	"github.com/containerd/containerd/cmd/ctr/commands/run"
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/namespaces"
@@ -76,6 +77,8 @@ func main() {
 			Usage: "enable debug output",
 		},
 	}
+
+	app.Version = fmt.Sprintf("%s %s", version.Version, version.Revision)
 
 	app.Commands = []cli.Command{
 		image.Command,


### PR DESCRIPTION
**Issue #, if available:**
Closes https://github.com/awslabs/soci-snapshotter/issues/477

**Description of changes:**
This change adds a `soci --version` flag to match `soci-snapshotter-grpc --version`.

Since urfave has a specific output format, soci-snapshotter-grpc was updated to match it. The new version format is:

$BINARY_NAME version $TAG $COMMIT

**Testing performed:**
```
$ ./out/soci --version
soci version 303d3db 303d3dbc7ea16376d77ba5279426b9139a147e0b
$ ./out/soci-snapshotter-grpc --version
soci-snapshotter-grpc version 303d3db 303d3dbc7ea16376d77ba5279426b9139a147e0b
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
