### PR TITLE
Add ztoc v0.9 tests

### DIFF
--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -93,7 +93,7 @@ var infoCommand = cli.Command{
 
 		multiSpanFiles := 0
 		zinfo := Info{
-			Version:   ztoc.Version,
+			Version:   string(ztoc.Version),
 			BuildTool: ztoc.BuildToolIdentifier,
 			Size:      entry.Size,
 			SpanSize:  gzInfo.SpanSize(),

--- a/integration/ztoc_test.go
+++ b/integration/ztoc_test.go
@@ -401,7 +401,7 @@ func ztocExistChecker(t *testing.T, listOutputLines []string, img testImageIndex
 }
 
 func verifyInfoOutput(zinfo Info, ztoc *ztoc.Ztoc) error {
-	if zinfo.Version != ztoc.Version {
+	if zinfo.Version != string(ztoc.Version) {
 		return fmt.Errorf("different versions: expected %s got %s", ztoc.Version, zinfo.Version)
 	}
 	if zinfo.BuildTool != ztoc.BuildToolIdentifier {

--- a/ztoc/ztoc.go
+++ b/ztoc/ztoc.go
@@ -28,6 +28,12 @@ import (
 	"github.com/awslabs/soci-snapshotter/compression"
 )
 
+type Version string
+
+const (
+	Version09 Version = "0.9"
+)
+
 // Ztoc is a table of contents for compressed data which consists 2 parts:
 //
 // (1). toc (`TOC`): a table of contents containing file metadata and its
@@ -35,7 +41,7 @@ import (
 // (2). zinfo (`CompressionInfo`): a collection of "checkpoints" of the
 // state of the compression engine at various points in the layer.
 type Ztoc struct {
-	Version                 string
+	Version                 Version
 	BuildToolIdentifier     string
 	CompressedArchiveSize   compression.Offset
 	UncompressedArchiveSize compression.Offset

--- a/ztoc/ztoc_builder.go
+++ b/ztoc/ztoc_builder.go
@@ -99,7 +99,7 @@ func (b *Builder) BuildZtoc(filename string, span int64, options ...BuildOption)
 	}
 
 	return &Ztoc{
-		Version:                 "0.9",
+		Version:                 Version09,
 		TOC:                     toc,
 		CompressedArchiveSize:   fs,
 		UncompressedArchiveSize: uncompressedArchiveSize,

--- a/ztoc/ztoc_marshaler.go
+++ b/ztoc/ztoc_marshaler.go
@@ -68,7 +68,7 @@ func flatbufToZtoc(flatbuffer []byte) (z *Ztoc, err error) {
 
 	ztoc := new(Ztoc)
 	ztocFlatbuf := ztoc_flatbuffers.GetRootAsZtoc(flatbuffer, 0)
-	ztoc.Version = string(ztocFlatbuf.Version())
+	ztoc.Version = Version(ztocFlatbuf.Version())
 	ztoc.BuildToolIdentifier = string(ztocFlatbuf.BuildToolIdentifier())
 	ztoc.CompressedArchiveSize = compression.Offset(ztocFlatbuf.CompressedArchiveSize())
 	ztoc.UncompressedArchiveSize = compression.Offset(ztocFlatbuf.UncompressedArchiveSize())
@@ -133,7 +133,7 @@ func ztocToFlatbuffer(ztoc *Ztoc) (fb []byte, err error) {
 	}()
 
 	builder := flatbuffers.NewBuilder(0)
-	version := builder.CreateString(ztoc.Version)
+	version := builder.CreateString(string(ztoc.Version))
 	buildToolIdentifier := builder.CreateString(ztoc.BuildToolIdentifier)
 
 	metadataOffsetList := make([]flatbuffers.UOffsetT, len(ztoc.TOC.Metadata))

--- a/ztoc/ztoc_test.go
+++ b/ztoc/ztoc_test.go
@@ -615,7 +615,7 @@ func TestZtocSerialization(t *testing.T) {
 func TestWriteZtoc(t *testing.T) {
 	testCases := []struct {
 		name                    string
-		version                 string
+		version                 Version
 		checkpoints             []byte
 		metadata                []FileMetadata
 		compressedArchiveSize   compression.Offset
@@ -626,15 +626,15 @@ func TestWriteZtoc(t *testing.T) {
 		expSize                 int64
 	}{
 		{
-			name:                    "success write succeeds - same digest and size",
-			version:                 "0.1",
+			name:                    "success write succeeds - same digest and size " + string(Version09),
+			version:                 Version09,
 			checkpoints:             make([]byte, 1<<16),
 			metadata:                make([]FileMetadata, 2),
 			compressedArchiveSize:   2000000,
 			uncompressedArchiveSize: 2500000,
 			maxSpanID:               3,
 			buildTool:               "AWS SOCI CLI",
-			expDigest:               "sha256:9c8effca78ecc82fad49a4d591dd81615555b05eaaae605a621c927ecf6fc1e7",
+			expDigest:               "sha256:eba28fdf50b1b57543f57dd051b2468c1d4f57b64d2006c75aa4de1d03e6c7ec",
 			expSize:                 65928,
 		},
 	}


### PR DESCRIPTION

**Issue #, if available:**
Related to https://github.com/awslabs/soci-snapshotter/pull/465

**Description of changes:**
We currently have a test that ztoc v0.1 is consistently generated, but we don't have an equivalent test for v0.9 which is what we are currently producing. This also gives us more confidence that the changes in https://github.com/awslabs/soci-snapshotter/pull/465 aren't breaking anything.

**Testing performed:**
`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
