### PR TITLE
Add version to soci-snapshotter-grpc logs

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -136,6 +136,10 @@ func main() {
 	// Snapshotter should use "github.com/containerd/containerd/log" otherwize
 	// logs are always printed as "debug" mode.
 	golog.SetOutput(log.G(ctx).WriterLevel(logrus.DebugLevel))
+	log.G(ctx).WithFields(logrus.Fields{
+		"version":  version.Version,
+		"revision": version.Revision,
+	}).Info("starting soci-snapshotter-grpc")
 
 	// Get configuration from specified file
 	tree, err := toml.LoadFile(*configPath)


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/soci-snapshotter/issues/489

**Description of changes:**
Adds a simple log statement with the version information in the beginning of the log

```
{"level":"info","msg":"soci-snapshotter-grpc version db04a28 db04a28547f6a79f68dec2bffda0cb47e8463aa3","time":"2023-03-10T15:50:46.192050630Z"}
```

compare to:

```
sudo ./soci-snapshotter-grpc  --version
soci-snapshotter-grpc version db04a28 db04a28547f6a79f68dec2bffda0cb47e8463aa3
```

**Testing performed:**
Manual testing (writing log to standard out) and make && make check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
