### PR TITLE
Implement network retry integration tests

### DIFF
--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -666,8 +666,7 @@ func rebootContainerd(t *testing.T, sh *shell.Shell, customContainerdConfig, cus
 	reporter := testutil.NewTestingReporter(t)
 	var m *testutil.LogMonitor = testutil.NewLogMonitor(reporter, outR, errR)
 
-	err = testutil.LogConfirmStartup(m)
-	if err != nil {
+	if err = testutil.LogConfirmStartup(m); err != nil {
 		t.Fatalf("snapshotter startup failed: %v", err)
 	}
 

--- a/util/testutil/shell.go
+++ b/util/testutil/shell.go
@@ -97,8 +97,8 @@ type LogMonitor struct {
 func NewLogMonitor(r shell.Reporter, stdout, stderr io.Reader) *LogMonitor {
 	m := &LogMonitor{}
 	m.monitorFuncs = make(map[string]func(string))
-	go m.ScanLog(io.TeeReader(stdout, r.Stdout()))
-	go m.ScanLog(io.TeeReader(stderr, r.Stderr()))
+	go m.scanLog(io.TeeReader(stdout, r.Stdout()))
+	go m.scanLog(io.TeeReader(stderr, r.Stderr()))
 	return m
 }
 
@@ -120,8 +120,8 @@ func (m *LogMonitor) Remove(name string) error {
 	return fmt.Errorf("attempted to remove nonexistent log monitor: %s", name)
 }
 
-// ScanLog calls each registered log monitor function for each new line of the Reader
-func (m *LogMonitor) ScanLog(inputR io.Reader) {
+// scanLog calls each registered log monitor function for each new line of the Reader
+func (m *LogMonitor) scanLog(inputR io.Reader) {
 	scanner := bufio.NewScanner(inputR)
 	for scanner.Scan() {
 		rawL := scanner.Text()


### PR DESCRIPTION
**Issue #, if available:**
Resolves #358 

**Description of changes:**
Added a new set of integration tests that interact with containers with different retry settings while disabling/enabling network access to the registry.

**Testing performed:**
Running with multiple variations of test configurations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
