### PR TITLE
Change ztoc to toc in metadata

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -328,7 +328,7 @@ func getMetadataStore(rootDir string, config snapshotterConfig) (metadata.Store,
 		if err != nil {
 			return nil, err
 		}
-		return func(sr *io.SectionReader, toc *ztoc.Ztoc, opts ...metadata.Option) (metadata.Reader, error) {
+		return func(sr *io.SectionReader, toc ztoc.TOC, opts ...metadata.Option) (metadata.Reader, error) {
 			return metadata.NewReader(db, sr, toc, opts...)
 		}, nil
 	default:

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -322,7 +322,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 			commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.InitMetadataStore, desc.Digest, start)
 		},
 	}
-	meta, err := r.metadataStore(sr, ztoc, append(metadataOpts, metadata.WithTelemetry(&telemetry))...)
+	meta, err := r.metadataStore(sr, ztoc.TOC, append(metadataOpts, metadata.WithTelemetry(&telemetry))...)
 	if err != nil {
 		return nil, err
 	}

--- a/fs/layer/util_test.go
+++ b/fs/layer/util_test.go
@@ -164,7 +164,7 @@ func makeNodeReader(t *testing.T, contents []byte, spanSize int64, factory metad
 	if err != nil {
 		t.Fatalf("failed to build ztoc: %v", err)
 	}
-	mr, err := factory(sr, ztoc)
+	mr, err := factory(sr, ztoc.TOC)
 	if err != nil {
 		t.Fatalf("failed to create reader: %v", err)
 	}
@@ -325,7 +325,7 @@ func testExistenceWithOpaque(t *testing.T, factory metadata.Store, opaque Overla
 					t.Fatalf("failed to build sample ztoc: %v", err)
 				}
 
-				mr, err := factory(sr, ztoc)
+				mr, err := factory(sr, ztoc.TOC)
 				if err != nil {
 					t.Fatalf("failed to create reader: %v", err)
 				}

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -151,7 +151,7 @@ func makeFile(t *testing.T, contents []byte, factory metadata.Store, spanSize in
 		t.Fatalf("failed to build sample ztoc: %v", err)
 	}
 
-	mr, err := factory(sr, ztoc)
+	mr, err := factory(sr, ztoc.TOC)
 	if err != nil {
 		t.Fatalf("failed to create reader: %v", err)
 	}
@@ -193,7 +193,7 @@ func testFailReader(t *testing.T, factory metadata.Store) {
 			}
 
 			// build a metadata reader
-			mr, err := factory(sr, ztoc)
+			mr, err := factory(sr, ztoc.TOC)
 			if err != nil {
 				t.Fatalf("failed to prepare metadata reader")
 			}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -75,7 +75,7 @@ type Attr struct {
 }
 
 // Store reads the provided blob and creates a metadata reader.
-type Store func(sr *io.SectionReader, ztoc *ztoc.Ztoc, opts ...Option) (Reader, error)
+type Store func(sr *io.SectionReader, toc ztoc.TOC, opts ...Option) (Reader, error)
 
 // Reader provides access to file metadata of a blob.
 type Reader interface {

--- a/metadata/reader_test.go
+++ b/metadata/reader_test.go
@@ -45,7 +45,7 @@ func TestMetadataReader(t *testing.T) {
 	testReader(t, newTestableReader)
 }
 
-func newTestableReader(sr *io.SectionReader, ztoc *ztoc.Ztoc, opts ...Option) (testableReader, error) {
+func newTestableReader(sr *io.SectionReader, toc ztoc.TOC, opts ...Option) (testableReader, error) {
 	f, err := os.CreateTemp("", "readertestdb")
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func newTestableReader(sr *io.SectionReader, ztoc *ztoc.Ztoc, opts ...Option) (t
 	if err != nil {
 		return nil, err
 	}
-	r, err := NewReader(db, sr, ztoc, opts...)
+	r, err := NewReader(db, sr, toc, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/metadata/testutil.go
+++ b/metadata/testutil.go
@@ -26,7 +26,7 @@ import (
 
 // NewTempDbStore returns a Reader by creating a temp bolt db, which will
 // be removed when `Reader.Close()` is called.
-func NewTempDbStore(sr *io.SectionReader, ztoc *ztoc.Ztoc, opts ...Option) (Reader, error) {
+func NewTempDbStore(sr *io.SectionReader, toc ztoc.TOC, opts ...Option) (Reader, error) {
 	f, err := os.CreateTemp("", "readertestdb")
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func NewTempDbStore(sr *io.SectionReader, ztoc *ztoc.Ztoc, opts ...Option) (Read
 	if err != nil {
 		return nil, err
 	}
-	r, err := NewReader(db, sr, ztoc, opts...)
+	r, err := NewReader(db, sr, toc, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/metadata/util_test.go
+++ b/metadata/util_test.go
@@ -58,7 +58,7 @@ var srcCompressions = map[string]int{
 	"gzip-huffmanonly":        gzip.HuffmanOnly,
 }
 
-type readerFactory func(sr *io.SectionReader, ztoc *ztoc.Ztoc, opts ...Option) (r testableReader, err error)
+type readerFactory func(sr *io.SectionReader, toc ztoc.TOC, opts ...Option) (r testableReader, err error)
 
 type testableReader interface {
 	Reader
@@ -189,7 +189,7 @@ func testReader(t *testing.T, factory readerFactory) {
 					telemetry, checkCalled := newCalledTelemetry()
 
 					// create a metadata reader
-					r, err := factory(sr, ztoc, WithTelemetry(telemetry))
+					r, err := factory(sr, ztoc.TOC, WithTelemetry(telemetry))
 					if err != nil {
 						t.Fatalf("failed to create new reader: %v", err)
 					}


### PR DESCRIPTION
**Issue #, if available:** fix #503

**Description of changes:**

change `./metadata` pkg to depend on `ztoc.TOC` instead of `ztoc.Ztoc`.

**Testing performed:**

make check && make test && make integration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
