### PR TITLE
Add a zinfo creation func in ztoc

### DIFF
--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -86,7 +86,7 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		gzInfo, err := compression.NewZinfo(compression.Gzip, ztoc.Checkpoints)
+		gzInfo, err := ztoc.Zinfo()
 		if err != nil {
 			return err
 		}

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -65,7 +65,7 @@ type spanInfo struct {
 // New creates a SpanManager with given ztoc and content reader, and builds all
 // spans based on the ztoc.
 func New(ztoc *ztoc.Ztoc, r *io.SectionReader, cache cache.BlobCache, retries int, cacheOpt ...cache.Option) *SpanManager {
-	index, err := compression.NewZinfo(compression.Gzip, ztoc.Checkpoints)
+	index, err := ztoc.Zinfo()
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
**Issue #, if available:** related to #463

**Description of changes:**

Add a helper func to ztoc that creates zinfo based on info in the ztoc.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
