### PR TITLE
Remove annotations from subject descriptor

### DIFF
--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -362,10 +362,9 @@ func (b *IndexBuilder) Build(ctx context.Context, img images.Image) (*IndexWithM
 	}
 
 	refers := &ocispec.Descriptor{
-		MediaType:   imgManifestDesc.MediaType,
-		Digest:      imgManifestDesc.Digest,
-		Size:        imgManifestDesc.Size,
-		Annotations: imgManifestDesc.Annotations,
+		MediaType: imgManifestDesc.MediaType,
+		Digest:    imgManifestDesc.Digest,
+		Size:      imgManifestDesc.Size,
 	}
 	var indexOpts []IndexOption
 	if b.config.artifactRegistry {


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
We don't have a good reason to be copying image annotations into the SOCI index' subject descriptor. This removes the field to reduce clutter.

**Testing performed:**
`make check && make test && make integration`

Looking at an index
Before:
```
  "subject": {
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "digest": "sha256:04a05c2fbcc5324b9b639de67e3bd03c31634baeb5ed5eddaf6b011fccb42ca2",
    "size": 1477,
    "annotations": {
      "io.containerd.image.name": "docker.io/library/test:latest",
      "org.opencontainers.image.created": "2023-03-21T17:22:06Z",
      "org.opencontainers.image.ref.name": "latest"
    }
  },
```

after:
```
"subject": {
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "digest": "sha256:04a05c2fbcc5324b9b639de67e3bd03c31634baeb5ed5eddaf6b011fccb42ca2",
    "size": 1477
  },
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
