### PR TITLE
Fail integration tests immediately on fatal soci error

### DIFF
--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -648,7 +648,6 @@ func rebootContainerd(t *testing.T, sh *shell.Shell, customContainerdConfig, cus
 	removeDirContents(sh, snapshotterRoot)
 
 	// run containerd and snapshotter
-	var m *testutil.RemoteSnapshotMonitor
 	containerdCmds := shell.C("containerd", "--log-level", containerdLogLevel)
 	if customContainerdConfig != "" {
 		containerdCmds = addConfig(t, sh, customContainerdConfig, containerdCmds...)
@@ -663,7 +662,9 @@ func rebootContainerd(t *testing.T, sh *shell.Shell, customContainerdConfig, cus
 	if err != nil {
 		t.Fatalf("failed to create pipe: %v", err)
 	}
-	m = testutil.NewRemoteSnapshotMonitor(testutil.NewTestingReporter(t), outR, errR)
+	reporter := testutil.NewTestingReporter(t)
+	testutil.FatalMonitor(reporter, outR, errR)
+	var m *testutil.RemoteSnapshotMonitor = testutil.NewRemoteSnapshotMonitor(reporter, outR, errR)
 
 	// make sure containerd and soci-snapshotter-grpc are up-and-running
 	sh.Retry(100, "ctr", "snapshots", "--snapshotter", "soci",


### PR DESCRIPTION
**Issue #, if available:**
Fixes #371 

**Description of changes:**
This PR adds a second io.Reader scanner to the soci output logs during integration tests, focused on spotting fatal errors. When a fatal error is found, the test is aborted immediately instead of allowing further downstream retries to continue.

**Testing performed:**
Ran a modified integration test to produce an invalid config.toml, confirmed test bails as soon as soci-snapshotter-grpc logs the config invalidity as a fatal error. Previous behavior (100 retries to make connection from ctr to running soci-snapshotter-grpc) is gone.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
