### PR TITLE
Fix timeouts

### DIFF
--- a/service/resolver/registry.go
+++ b/service/resolver/registry.go
@@ -41,7 +41,7 @@ import (
 	rhttp "github.com/hashicorp/go-retryablehttp"
 )
 
-const defaultRequestTimeoutSec int64 = 30
+const defaultRequestTimeoutSec int64 = 1
 
 // Config is config for resolving registries.
 type Config struct {
@@ -77,14 +77,14 @@ func RegistryHostsFromConfig(cfg Config, credsFuncs ...Credential) source.Regist
 		}) {
 			client := rhttp.NewClient()
 			client.Logger = nil // disable logging every request
-			tr := client.StandardClient()
 			if h.RequestTimeoutSec >= 0 {
 				if h.RequestTimeoutSec == 0 {
-					tr.Timeout = time.Duration(defaultRequestTimeoutSec) * time.Second
+					client.HTTPClient.Timeout = time.Duration(defaultRequestTimeoutSec) * time.Second
 				} else {
-					tr.Timeout = time.Duration(h.RequestTimeoutSec) * time.Second
+					client.HTTPClient.Timeout = time.Duration(h.RequestTimeoutSec) * time.Second
 				}
 			} // h.RequestTimeoutSec < 0 means "no timeout"
+			tr := client.StandardClient()
 			config := docker.RegistryHost{
 				Client:       tr,
 				Host:         h.Host,


### PR DESCRIPTION

**Issue #, if available:**
Part of https://github.com/awslabs/soci-snapshotter/issues/517

**Description of changes:**
When we set up an http client to interact with a registry, we use go-retryablehttp's rhttp.Client. However, we actually want a standard library http.Client which is a struct, not an interface, so we use rhttp.Client.StandardClient() which gives us back a real http.Client wrapped around the rhttp.Client.

We then set the timeout on this returned client.

The final wrapped struct looks like this (ignoring irrelevant fields):

```
http.Client {
     Timeout: timeout (default 30s)
     Transport: rhttp.Transport {
          Client: rhttp.Client {
               HTTPClient: http.Client {
                    Transport: {
                         *DialTimeout: 30s
                    }
               }
          }
     }
}
```

* there's actually a few more structs, but they're not relevant here.

What appears to be happening is that the outer http.Client times out and cancels the request context, but since the inner client doesn't have a timeout, it doesn't break on a canceled context and keeps the request alive until the DialTimeout is after 30s. Once the timeout does occur, the rhttp.Client makes a decision on whether to retry the request, which it opts not to because the request context was canceled.

This change sets the timeout on the inner client and reduces the timeout to 1s so we don't go way over our intended retry timelines


**Testing performed:**
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
