### PR TITLE
Add `rebuild-db` command to rebuild artifacts db

### DIFF
--- a/cmd/soci/commands/rebuild_db.go
+++ b/cmd/soci/commands/rebuild_db.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"path/filepath"
+
+	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/urfave/cli"
+	"oras.land/oras-go/v2/content/oci"
+)
+
+var RebuildDBCommand = cli.Command{
+	Name:  "rebuild-db",
+	Usage: `rebuild the artifacts database. You should use this command after "rpull" so that indices/ztocs can be discovered by commands like "soci index list".`,
+	Action: func(cliContext *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(cliContext)
+		if err != nil {
+			return err
+		}
+		defer cancel()
+		containerdContentStore := client.ContentStore()
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath())
+		if err != nil {
+			return err
+		}
+		blobStore, err := oci.New(config.SociContentStorePath)
+		if err != nil {
+			return err
+		}
+		blobStorePath := filepath.Join(config.SociContentStorePath, "blobs")
+		return artifactsDb.SyncWithLocalStore(ctx, blobStore, blobStorePath, containerdContentStore)
+	},
+}

--- a/cmd/soci/main.go
+++ b/cmd/soci/main.go
@@ -90,6 +90,7 @@ func main() {
 		commands.CreateCommand,
 		commands.PushCommand,
 		run.Command,
+		commands.RebuildDBCommand,
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/integration/rebuild-db_test.go
+++ b/integration/rebuild-db_test.go
@@ -1,0 +1,97 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/soci"
+)
+
+func TestRebuildArtifactsDB(t *testing.T) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+	rebootContainerd(t, sh, "", "")
+	img := rabbitmqImage
+	copyImage(sh, dockerhub(img), regConfig.mirror(img))
+	indexDigest := buildIndex(sh, regConfig.mirror(img), withMinLayerSize(0))
+	indexBytes := sh.O("cat", filepath.Join(blobStorePath, trimSha256Prefix(indexDigest)))
+	var sociIndex soci.Index
+	err := soci.DecodeIndex(bytes.NewBuffer(indexBytes), &sociIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sh.X("soci", "push", "--user", regConfig.creds(), regConfig.mirror(img).ref)
+
+	rebuildDb := []string{"soci", "rebuild-db"}
+
+	verifyArtifacts := func(expectedIndexCount, expectedZtocCount int) error {
+		indexOutput := sh.O("soci", "index", "list")
+		ztocOutput := sh.O("soci", "ztoc", "list")
+		indexCount := len(bytes.Split(indexOutput, []byte("\n"))) - 2
+		ztocCount := len(bytes.Split(ztocOutput, []byte("\n"))) - 2
+		if indexCount != expectedIndexCount {
+			return fmt.Errorf("expected %v indices; got %v", expectedIndexCount, indexCount)
+		}
+		if ztocCount != expectedZtocCount {
+			return fmt.Errorf(" expected %v ztoc; got %v", expectedZtocCount, ztocCount)
+		}
+		return nil
+	}
+
+	testCases := []struct {
+		name               string
+		cmd                []string
+		afterContent       bool
+		expectedIndexCount int
+		exptectedZtocCount int
+	}{
+		{
+			name:               "Rpull and rebuild",
+			cmd:                []string{"soci", "image", "rpull", "--user", regConfig.creds(), regConfig.mirror(img).ref},
+			afterContent:       true,
+			expectedIndexCount: 1,
+			exptectedZtocCount: len(sociIndex.Blobs),
+		},
+		{
+			name:               "Remove artifacts from content store and rebuild",
+			cmd:                []string{"rm", "-rf", blobStorePath},
+			expectedIndexCount: 0,
+			exptectedZtocCount: 0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rebootContainerd(t, sh, "", "")
+			if !tc.afterContent {
+				copyImage(sh, dockerhub(img), regConfig.mirror(img))
+				buildIndex(sh, regConfig.mirror(img), withMinLayerSize(0))
+			}
+			sh.X(tc.cmd...)
+			sh.X(rebuildDb...)
+			err := verifyArtifacts(tc.expectedIndexCount, tc.exptectedZtocCount)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+}

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -139,7 +139,7 @@ func UnmarshalIndex(b []byte, index *Index) error {
 	return err
 }
 
-// fromManifest converts and OCI 1.0 Manifest to a SOCI Index
+// fromManifest converts an OCI 1.0 Manifest to a SOCI Index
 func fromManifest(manifest ocispec.Manifest, index *Index) {
 	index.MediaType = manifest.MediaType
 	index.ArtifactType = SociIndexArtifactType

--- a/util/dockershell/exec/cmd.go
+++ b/util/dockershell/exec/cmd.go
@@ -86,7 +86,7 @@ type Cmd struct {
 	// Path is the path of the command to run.
 	Path string
 
-	// Args holds the command line arguents.
+	// Args holds the command line arguments.
 	Args []string
 
 	// Env holds the environment variables for the command.


### PR DESCRIPTION
**Issue #, if available:**

Fixes: #30 

**Description of changes:**

Added `rebuild-db` command to CLI to rebuild/sync artifacts db with local content store. 

TODO: 
 * [x] add integration tests
 * [x] determine if getting platform for an index is feasible

**Testing performed:**

`make check && make test && make integration`

```shell
$ sudo ./soci image rpull --platform linux/amd64  dkr.ecr.us-west-2.amazonaws.com/rabbitmq:latest
fetching sha256:f5f012e4... application/vnd.docker.distribution.manifest.v2+json
fetching sha256:7cb0caa8... application/vnd.docker.container.image.v1+json 

$ sudo ./soci index list
DIGEST    SIZE    IMAGE REF    PLATFORM    MEDIA TYPE    CREATED

$ sudo ./soci ztoc list
DIGEST    SIZE    LAYER DIGEST

$ sudo ./soci rebuild-db

$ sudo ./soci index list
DIGEST                                                                     SIZE    IMAGE REF                                                       PLATFORM    MEDIA TYPE                                    CREATED
sha256:a6494e77b9d51f160e9c74a282b1779421f980f3dd3d130402c2222aa8f38e40    1570    .dkr.ecr.us-west-2.amazonaws.com/rabbitmq:latest    linux/amd64     application/vnd.oci.image.manifest.v1+json    9s ago

$ sudo ./soci ztoc list
DIGEST                                                                     SIZE       LAYER DIGEST
sha256:0d83470e087681a426a7219adf9c9e02b96583df6e3e045e9277c815b92392b9    1090344    sha256:328b9d3248edeb3ae6e7f9c347bcdb5632c122be218e6ecd89543cca9c8f1997
sha256:1a6457d173b415902ee571f068009fe288e5e12d8ce5fd80a0288ba8b0c2f4eb    1152224    sha256:df6635ed1257a768a4cf0fba31ebc5c8a6a03ae7d5b9b079bfd9df9eb89e0f81
sha256:1ae8016952be5b522dbc5a695ad3044dc52ef9af9fb1840c8c6442b694ecb579    1235272    sha256:e50ba1435db6125cd01ba5740e1899412c8dfa2f8ce8526ea32574742d3a0f41 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
