### PR TITLE
Fix timeout in `httpFetcher`

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -234,15 +234,16 @@ func newHTTPFetcher(ctx context.Context, fc *fetcherConfig) (*httpFetcher, error
 		// Prepare transport with authorization functionality
 		tr := host.Client.Transport
 
+		timeout := host.Client.Timeout
 		if rt, ok := tr.(*rhttp.RoundTripper); ok {
 			rt.Client.RetryMax = fc.maxRetries
 			rt.Client.RetryWaitMin = fc.minWait
 			rt.Client.RetryWaitMax = fc.maxWait
 			rt.Client.Backoff = backoffStrategy
 			rt.Client.CheckRetry = retryStrategy
+			timeout = rt.Client.HTTPClient.Timeout
 		}
 
-		timeout := host.Client.Timeout
 		if host.Authorizer != nil {
 			tr = &transport{
 				inner: tr,


### PR DESCRIPTION
**Issue #, if available:**
Part of https://github.com/awslabs/soci-snapshotter/issues/517

**Description of changes:**
A previous commit switched from setting the timeout on the outer `http.Client` of `rhttp.Client` to the inner `http.Client`. `httpFetcher` uses the timeout directly when resolving redirects because it directly uses the `RoundTripper`. This fixes that timeout to read it from the inner client instead of the outer client.

I don't think the redirect resolver/`httpFetcher` work as expected either because they try to use the `rhttp.RoundTripper` directly to do exactly 1 roundtrip without redirects, but internally this ends up calling `http.Client.Do` which will follow redirects. I will create an issue for this.

**Testing performed:**
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
