### PR TITLE
Ignore ErrAlreadyExists when storing index

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -44,7 +44,6 @@ package fs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os/exec"
 	"sync"
@@ -74,7 +73,6 @@ import (
 	"github.com/sirupsen/logrus"
 	orascontent "oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/oci"
-	"oras.land/oras-go/v2/errdef"
 )
 
 const (
@@ -327,7 +325,7 @@ func (c *sociContext) Init(fsCtx context.Context, ctx context.Context, imageRef,
 		log.G(ctx).WithField("digest", indexDesc.Digest.String()).Infof("fetching SOCI artifacts using index descriptor")
 
 		index, err := FetchSociArtifacts(ctx, refspec, indexDesc, store, remoteStore)
-		if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		if err != nil {
 			retErr = fmt.Errorf("error trying to fetch SOCI artifacts: %w", err)
 			return
 		}

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -61,7 +61,8 @@ func TestRunMultipleContainers(t *testing.T) {
 					testFunc:       testWebServiceContainer,
 				},
 			},
-		}, {
+		},
+		{
 			name: "Run multiple containers from different images",
 			containers: []containerImageAndTestFunc{
 				{
@@ -70,6 +71,19 @@ func TestRunMultipleContainers(t *testing.T) {
 				},
 				{
 					containerImage: drupalImage,
+					testFunc:       testWebServiceContainer,
+				},
+			},
+		},
+		{
+			name: "Run multiple containers from different images with shared layers",
+			containers: []containerImageAndTestFunc{
+				{
+					containerImage: nginxAlpineImage,
+					testFunc:       testWebServiceContainer,
+				},
+				{
+					containerImage: nginxAlpineImage2,
 					testFunc:       testWebServiceContainer,
 				},
 			},

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -83,6 +83,10 @@ const (
 	ubuntuImage   = "ubuntu:23.04"
 	drupalImage   = "drupal:10.0.2"
 	rabbitmqImage = "rabbitmq:3.11.7"
+	// These 2 images enable us to test cases where 2 different images
+	// have shared layers (thus shared ztocs if built with the same parameters).
+	nginxAlpineImage  = "nginx:1.22-alpine3.17"
+	nginxAlpineImage2 = "nginx:1.23-alpine3.17"
 )
 
 const proxySnapshotterConfig = `


### PR DESCRIPTION
**Issue #, if available:**

The `ErrAlreadyExists` should be handled internally by `FetchSociArtifacts` instead of returning to the caller, in which case the caller might ignore the error but the returned soci index is `nil`, causing `nil` dereference. 

**Description of changes:**

Handle `ErrAlreadyExists` in `FetchSociArtifacts` by ignoring it and still returning the index.

**Testing performed:**

make test && make integration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
