### PR TITLE
Use nerdctl 1.3.0 to utilize push -q

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@
 #   limitations under the License.
 
 ARG CONTAINERD_VERSION=1.6.17
-ARG RUNC_VERSION=1.1.4
-ARG NERDCTL_VERSION=1.2.0
+ARG RUNC_VERSION=1.1.5
+ARG NERDCTL_VERSION=1.3.0
 
 FROM golang:1.18.10-buster AS golang-base
 

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -344,7 +344,7 @@ func copyImage(sh *shell.Shell, src, dst imageInfo) {
 	sh.
 		X(append([]string{"nerdctl", "pull", "-q", "--platform", platforms.Format(src.platform)}, opts[0]...)...).
 		X("ctr", "i", "tag", src.ref, dst.ref).
-		X(append([]string{"nerdctl", "push", "--platform", platforms.Format(src.platform)}, opts[1]...)...)
+		X(append([]string{"nerdctl", "push", "-q", "--platform", platforms.Format(src.platform)}, opts[1]...)...)
 }
 
 type registryConfig struct {


### PR DESCRIPTION
**Issue #, if available:**

I created a PR in nerdctl that adds `-q` to `nerdctl push` which is released as part of nerdctl 1.3.0.

Add this to soci which should reduces around 2000 lines of integration test output.

**Description of changes:**

Bump up nerdctl to 1.3.0, add `-q` to `nerdctl push`.

**Testing performed:**

make test && make integration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
