### PR TITLE
Return from scanFatalLog after finding a matching line

### DIFF
--- a/util/testutil/shell.go
+++ b/util/testutil/shell.go
@@ -175,9 +175,11 @@ func scanFatalLog(inputR io.Reader, errs chan error) {
 		if err := json.Unmarshal([]byte(rawL), &logline); err == nil {
 			if logline.Level == "fatal" {
 				errs <- errors.New("aborting test: fatal snapshotter log entry encountered")
+				return
 			}
 			if strings.Contains(logline.Msg, "background") {
 				errs <- nil
+				return
 			}
 		}
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This PR changes the scanFatalLog function to return once it has found a fatal or successful launch log entry. This is intended to resolve test flakiness related to having two scanners running at once later in the test process.

**Testing performed:**
Ran test suite.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
