### PR TITLE
Fix bg fetcher pause long wait

### DIFF
--- a/fs/backgroundfetcher/background_fetcher.go
+++ b/fs/backgroundfetcher/background_fetcher.go
@@ -100,7 +100,7 @@ func NewBackgroundFetcher(opts ...Option) (*BackgroundFetcher, error) {
 	bf.rateLimiter = rate.NewLimiter(rate.Every(bf.fetchPeriod), 1)
 	bf.workQueue = make(chan Resolver, bf.maxQueueSize)
 	bf.closeChan = make(chan struct{})
-	bf.pauseChan = make(chan struct{})
+	bf.pauseChan = make(chan struct{}, bf.maxQueueSize)
 
 	if bf.bfPauser == nil {
 		bf.bfPauser = defaultPauser{}
@@ -120,7 +120,7 @@ func (bf *BackgroundFetcher) Close() error {
 	return nil
 }
 
-// Sends a signal to pause the background fetcher for silencePeriod on the next iteration.
+// Pause sends a signal to pause the background fetcher for silencePeriod on the next iteration.
 func (bf *BackgroundFetcher) Pause() {
 	bf.pauseChan <- struct{}{}
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Multiple calls to `bg.Pause` from multiple images will cause a long wait because the channel is unbuffered.

This add a buf size to the pause channel so there is not blocking.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
