### PR TITLE
Create framework to support multiple log monitors

### DIFF
--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -289,10 +289,12 @@ func TestLazyPull(t *testing.T) {
 			test: func(t *testing.T, tarExportArgs ...string) {
 				image := regConfig.mirror(optimizedImageName1).ref
 				m := rebootContainerd(t, sh, "", "")
+				rsm, done := testutil.NewRemoteSnapshotMonitor(m)
+				defer done()
 				buildIndex(sh, regConfig.mirror(optimizedImageName1), withMinLayerSize(0))
 				sh.X("ctr", "i", "rm", optimizedImageName1)
 				export(sh, image, tarExportArgs)
-				m.CheckAllRemoteSnapshots(t)
+				rsm.CheckAllRemoteSnapshots(t)
 			},
 		},
 		{
@@ -301,12 +303,14 @@ func TestLazyPull(t *testing.T) {
 			test: func(t *testing.T, tarExportArgs ...string) {
 				image := regConfig.mirror(optimizedImageName1).ref
 				m := rebootContainerd(t, sh, "", "")
+				rsm, done := testutil.NewRemoteSnapshotMonitor(m)
+				defer done()
 				buildIndex(sh, regConfig.mirror(optimizedImageName2), withMinLayerSize(0))
 				sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest2, regConfig.mirror(optimizedImageName2).ref)
 				buildIndex(sh, regConfig.mirror(optimizedImageName1), withMinLayerSize(0))
 				sh.X("ctr", "i", "rm", optimizedImageName1)
 				export(sh, image, tarExportArgs)
-				m.CheckAllRemoteSnapshots(t)
+				rsm.CheckAllRemoteSnapshots(t)
 			},
 		},
 	}
@@ -375,9 +379,11 @@ func TestLazyPullNoIndexDigest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := rebootContainerd(t, sh, "", "")
+			rsm, done := testutil.NewRemoteSnapshotMonitor(m)
+			defer done()
 			testSameTarContents(t, sh, tt.want, tt.test)
 			if tt.checkAllRemoteSnapshots {
-				m.CheckAllRemoteSnapshots(t)
+				rsm.CheckAllRemoteSnapshots(t)
 			}
 		})
 	}
@@ -549,10 +555,12 @@ disable = true
 			test: func(t *testing.T, tarExportArgs ...string) {
 				image := regConfig.mirror(optimizedImageName1).ref
 				m := rebootContainerd(t, sh, "", "")
+				rsm, done := testutil.NewRemoteSnapshotMonitor(m)
+				defer done()
 				buildIndex(sh, regConfig.mirror(optimizedImageName1), withMinLayerSize(0))
 				sh.X("ctr", "i", "rm", optimizedImageName1)
 				export(sh, image, tarExportArgs)
-				m.CheckAllRemoteSnapshots(t)
+				rsm.CheckAllRemoteSnapshots(t)
 			},
 		},
 		{
@@ -561,12 +569,14 @@ disable = true
 			test: func(t *testing.T, tarExportArgs ...string) {
 				image := regConfig.mirror(optimizedImageName1).ref
 				m := rebootContainerd(t, sh, "", "")
+				rsm, done := testutil.NewRemoteSnapshotMonitor(m)
+				defer done()
 				buildIndex(sh, regConfig.mirror(optimizedImageName2), withMinLayerSize(0))
 				sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest2, regConfig.mirror(optimizedImageName2).ref)
 				buildIndex(sh, regConfig.mirror(optimizedImageName1), withMinLayerSize(0))
 				sh.X("ctr", "i", "rm", optimizedImageName1)
 				export(sh, image, tarExportArgs)
-				m.CheckAllRemoteSnapshots(t)
+				rsm.CheckAllRemoteSnapshots(t)
 			},
 		},
 	}

--- a/util/testutil/util.go
+++ b/util/testutil/util.go
@@ -91,7 +91,7 @@ func GetProjectRoot() (string, error) {
 		}
 	}
 	if _, err := os.Stat(filepath.Join(pRoot, "Dockerfile")); err != nil {
-		return "", fmt.Errorf("Dockerfile not found under project root")
+		return "", fmt.Errorf("no Dockerfile was found under project root")
 	}
 	return pRoot, nil
 }


### PR DESCRIPTION
**Issue #, if available:**
Resolves #520
Also needed for next steps on #499 

**Description of changes:**
Adds a new LogMonitor struct that manages multiple functions to scan stdout/stderr coming from a process. Currently only used for soci-snapshotter-grpc, but likely to be used for containerd later as well.
RemoteSnapshotMonitor and FatalMonitor are now modified (and the latter renamed) to register a function with LogMonitor rather than doing their own scanning directly. This should ensure that every log line (generated after the registration) reaches both of them, rather than one occasionally consuming logs meant for the other. It will also support the need for #499 to monitor logs for network retry, failure, and success.

**Testing performed:**
`make integration` and some manual tweaking of parameters to force failures

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
