### PR TITLE
Update pull mode doc

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -271,5 +271,5 @@ use the `--net-host` binary flag.  Then we pass in the two main arguments, our
 image registry and the id of the container:
 
 ```shell
-sudo ctr run --user $REGISTRY_USER:$REGISTRY_PASSWORD --snapshotter soci --net-host $REGISTRY/rabbitmq:latest sociExample
+sudo ctr run --snapshotter soci --net-host $REGISTRY/rabbitmq:latest sociExample
 ```


### PR DESCRIPTION
**Issue #, if available:** fix #488

Items in the issue:

Item1: already fixed.
Item2: added that if a image won't be lazily loaded, the entire image pull will fall back to normal pull (like overlayfs).
Item3: mentioned that "no zTOC for a specific layer" is a normal case and when it happens.

**Description of changes:**

Update the `pull-modes` doc to specify what will happen during `rpull`. 

Also fixed an issue in the getting-started doc where an unexpected `--user` arg is passed to `ctr run`. `ctr run` doesn't require registry auth and the `--user` flag is to pass user-id to the container.

**Testing performed:**

Go through the doc and check the log.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
