### PR TITLE
Skip k8s deps in bump-deps.sh

### DIFF
--- a/scripts/bump-deps.sh
+++ b/scripts/bump-deps.sh
@@ -21,11 +21,16 @@ SOCI_SNAPSHOTTER_PROJECT_ROOT="${CUR_DIR}/.."
 
 pushd ${SOCI_SNAPSHOTTER_PROJECT_ROOT}
 
-go get -u $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all)
+# skip k8s deps since they use the latest go version/features that may not be in the go version soci uses
+go get -u $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
+    grep -v "k8s.io")
 make vendor
 
 pushd ./cmd
-go get -u $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | grep -v "github.com/awslabs/soci-snapshotter")
+# skip k8s deps and soci-snapshotter itself
+go get -u $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
+    grep -v "github.com/awslabs/soci-snapshotter" | \
+    grep -v "k8s.io")
 popd
 make vendor
 


### PR DESCRIPTION
**Issue #, if available:** fix #582

**Description of changes:**

Skip k8s deps in bump-deps.sh

**Testing performed:**

Tested in my fork, generated PR skipped k8s deps: https://github.com/djdongjin/soci-snapshotter/pull/2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
