### PR TITLE
[DOC]Update getting-started-doc

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ required to run soci-snapshotter; to confirm please check with `sudo ctr version
 - **[ctr](https://github.com/containerd/containerd/blob/main/docs/getting-started.md)** -
 required for this doc to interact with containerd/registry.
 - **fuse** - used for mounting without root access (`sudo yum install fuse` or
-other Linux package manager like `apt-get`, dpending on your Linux distro).
+other Linux package manager like `apt-get`, depending on your Linux distro).
 
 ## Install soci-snapshotter
 
@@ -54,8 +54,8 @@ directory (`/usr/local/bin`):
 > You can find other download link in the release page that matches your machine.
 
 ```shell
-wget -O https://github.com/awslabs/soci-snapshotter/releases/download/v0.1.0/soci-snapshotter-0.1.0-linux-amd64.tar.gz
-sudo tar -C /usr/local/bin -xvf soci-snapshotter-0.1.0-linux-amd64.tar.gz soci soci-snapshotter-grpc
+wget https://github.com/awslabs/soci-snapshotter/releases/download/v0.1.0/soci-snapshotter-0.1.0-linux-amd64.tar.gz
+sudo tar -C /usr/local/bin -xvf soci-snapshotter-0.1.0-linux-amd64.tar.gz ./soci ./soci-snapshotter-grpc
 ```
 
 Now you should be able to use the `soci` CLI (and `soci-snapshotter-grpc` containerd plugin shortly):
@@ -97,14 +97,14 @@ sudo ctr i tag docker.io/library/rabbitmq:latest $REGISTRY/rabbitmq:latest
 sudo ctr i push --user $REGISTRY_USER:$REGISTRY_PASSWORD --platform linux/amd64 $REGISTRY/rabbitmq:latest
 ```
 
-After this step, please check your registry to confirm the image is pushed to it.
+After this step, please check your registry to confirm the image is present.
 You can go to your registry console or use your registry's CLI (e.g. for ECR, you
 can use `aws ecr describe-images --repository-name rabbitmq --region $AWS_REGION`).
 
 ## Create and push SOCI index
 
 Instead of converting the image format, soci-snapshotter uses the SOCI index
-associated with an image to implement its lazy loading. For more detail
+associated with an image to implement its lazy loading. For more details
 please see [README](../README.md#no-image-conversion).
 
 ### Create SOCI index
@@ -141,7 +141,7 @@ From the above output, we can see that SOCI creates ztocs for 3 layers and skips
 
 ### (Optional) Inspect SOCI index and ztoc
 
-We can inspect one of these ztoc's from the output of previous command (replace
+We can inspect one of these ztocs from the output of previous command (replace
 the digest with one in your command output). This command will print the ztoc,
 which contains all of the information that SOCI needs to find a given file in the layer:
 
@@ -207,8 +207,7 @@ sudo ctr plugin ls id==soci
 
 ### Start soci-snapshotter
 
-First we need to start the snapshotter grpc service binary (`soci-snapshotter-grpc`).
-Here we start the binary in background and simply redirect logs to an arbitrary file:
+First we need to start the snapshotter grpc service by running the `soci-snapshotter-grpc` binary in background and simply redirecting logs to an arbitrary file:
 
 ```shell
 sudo soci-snapshotter-grpc &> ~/soci-snapshotter-logs &
@@ -223,7 +222,7 @@ sudo soci-snapshotter-grpc 2> ~/soci-snapshotter-errors 1> ~/soci-snapshotter-lo
 ### Lazily pull image
 
 Once the snapshotter is running we can call the `rpull` command from SOCI CLI.
-This command reads the manfiest from the registry and mounts FUSE filesystems
+This command reads the manifest from the registry and mounts FUSE filesystems
 for each layer.
 
 > The optional flag `--soci-index-digest` needs to be the digest of the SOCI index manifest.


### PR DESCRIPTION
**Issue #, if available:**
When following the getting-started guide, the install commands errored with 
```
~ wget -O https://github.com/awslabs/soci-snapshotter/releases/download/v0.1.0/soci-snapshotter-0.1.0-linux-amd64.tar.gz
wget: missing URL
Usage: wget [OPTION]... [URL]...

Try `wget --help' for more options.
``` 
Since `-O` in the command means `-O,  --output-document=FILE    write documents to FILE` and we didn't specify the file name here. I think we should just remove it. 
```
~ wget https://github.com/awslabs/soci-snapshotter/releases/download/v0.1.0/soci-snapshotter-0.1.0-linux-amd64.tar.gz
--2023-04-24 15:36:50--  https://github.com/awslabs/soci-snapshotter/releases/download/v0.1.0/soci-snapshotter-0.1.0-linux-amd64.tar.gz
Resolving github.com (github.com)... 140.82.113.3
Connecting to github.com (github.com)|140.82.113.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
```
Another error at tar command once the tarball is downloaded.
```
➜  ~ sudo tar -C /usr/local/bin -xvf soci-snapshotter-0.1.0-linux-amd64.tar.gz soci soci-snapshotter-grpc
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.com.apple.macl'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.com.apple.lastuseddate#PS'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.com.apple.lastuseddate#PS'
tar: soci: Not found in archive
tar: soci-snapshotter-grpc: Not found in archive
tar: Exiting with failure status due to previous errors
```
Preview the tarball, found those binaries have different pattern. 
```
➜  ~ tar tvf soci-snapshotter-0.1.0-linux-amd64.tar.gz
-rw-r--r-- walster/staff   276 2023-03-07 21:57 ./._NOTICE.md
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.com.apple.macl'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.com.apple.lastuseddate#PS'
-rw-r--r-- walster/staff  5204 2023-03-07 21:57 ./NOTICE.md
-rw-r--r-- walster/staff   176 2023-03-07 21:57 ./._THIRD_PARTY_LICENSES
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.com.apple.lastuseddate#PS'
-rw-r--r-- walster/staff 140745 2023-03-07 21:57 ./THIRD_PARTY_LICENSES
-rwxr-xr-x walster/staff 26325352 2023-03-07 21:57 ./soci
-rwxr-xr-x walster/staff 43655984 2023-03-07 21:57 ./soci-snapshotter-grpc
```
Update the binary patterns(added `./` in front of the binaries) and it worked. 
```
➜  ~ sudo tar -C /usr/local/bin -xzvf soci-snapshotter-0.1.0-linux-amd64.tar.gz ./soci ./soci-snapshotter-grpc
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.com.apple.macl'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.com.apple.lastuseddate#PS'
tar: Ignoring unknown extended header keyword `LIBARCHIVE.xattr.com.apple.lastuseddate#PS'
./soci
./soci-snapshotter-grpc
```


**Description of changes:**
1. Fix download and install commands of the soci tarball
2. Fix typos 
3. Rephrase some statements(pick bones out of egg and it's pretty personal oponioned.  Let me know if it makes sense, or I can change it back)

**Testing performed:**
Tested the updated download and install commands locally

 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
Signed-off-by: Tony Fang <nhfang@amazon.com>