### PR TITLE
Remove docker resolver from artifactFetcher

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -394,7 +394,7 @@ func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels 
 	if err != nil {
 		return fmt.Errorf("cannot create remote store: %w", err)
 	}
-	fetcher, err := newArtifactFetcher(refspec, fs.orasStore, remoteStore, newResolver())
+	fetcher, err := newArtifactFetcher(refspec, fs.orasStore, remoteStore)
 	if err != nil {
 		return fmt.Errorf("cannot create fetcher: %w", err)
 	}


### PR DESCRIPTION
**Issue #, if available:**
Part of https://github.com/awslabs/soci-snapshotter/issues/581

**Description of changes:**
The `artifactFetcher` had two different mechanisms for connecting to a remote registry. A docker `remotes.Resolver` (from containerd) to resolve a ref to a descriptor, and a `content.Storage` (from oras-go) for pulling SOCI artifacts.

The underlying implementation of `content.Storage` is a `remote.Repository` which has it's own implementation of resolving a ref to a descriptor. We couldn't use it because `content.Storage` doesn't expose it.

This change takes a new interface type that combines `content.Storage` and `content.Resolver`, both of which are already implemented by `remote.Registry` so that we don't need the docker resolver at all.

Oras-go offers a `registry.Repository` interface that is also implemented by `remote.Repository`, but it has a lot of additional functionality that we don't need.

This change is covered by [TestLazyPull](https://github.com/awslabs/soci-snapshotter/blob/ef8f21ca6996c81b8277a61c133601d86911ae65/integration/pull_test.go#L240). Since we explicitly pass a digest, we have a ref with no size which triggers the resolve code path.


**Testing performed:**
`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
