### PR TITLE
Use docker auth config for `soci push` without `--user`

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/awslabs/soci-snapshotter v0.0.0-local
 	github.com/containerd/containerd v1.7.0
 	github.com/coreos/go-systemd/v22 v22.5.0
+	github.com/docker/cli v23.0.4+incompatible
 	github.com/docker/go-metrics v0.0.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
@@ -38,7 +39,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/cli v23.0.4+incompatible // indirect
 	github.com/docker/docker v20.10.24+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -171,6 +171,8 @@ This will push all of the SOCI related artifacts (index manifest, ztoc):
 sudo soci push --user $REGISTRY_USER:$REGISTRY_PASSWORD $REGISTRY/rabbitmq:latest
 ```
 
+Credentials here can be omitted if `docker login` has stored credentials for this registry.
+
 ## Run container with soci-snapshotter
 
 ### Configure containerd


### PR DESCRIPTION
**Issue #, if available:**
Closes #572 

**Description of changes:**
When `soci push` is used without `--user`, try to read credentials from docker config file, or cred stores/helpers configured there

Also per feedback during review, I moved a lot of code outside of the per-platform loop.

**Testing performed:**
Pushed to ECR using creds stored in `~/.docker/config.json` `auths` section. Pushed to ECR using creds retrieved from a custom creds helper. Confirmed push fails with wrong or missing creds not supplied at the command line.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
