### PR TITLE
Skip indexing layers with unrecognized compression

### DIFF
--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -121,6 +121,8 @@ func TestOptimizeConsistentSociArtifact(t *testing.T) {
 				X("cp", "-r", blobStorePath, "copy") // move the contents of soci dir to another folder
 
 			// optimize for the second time
+			sh.
+				X("rm", "-rf", blobStorePath)
 			buildIndex(sh, regConfig.mirror(tt.containerImage), withMinLayerSize(0))
 
 			currContent := sh.O("ls", blobStorePath)
@@ -135,7 +137,7 @@ func TestOptimizeConsistentSociArtifact(t *testing.T) {
 					// skipping artifacts.db, since this is bbolt file and we have no control over its internals
 					continue
 				}
-				out, _ := sh.OLog("cmp", filepath.Join("soci", fn), filepath.Join("copy", "soci", fn))
+				out, _ := sh.OLog("cmp", filepath.Join(blobStorePath, fn), filepath.Join("copy", "sha256", fn))
 				if string(out) != "" {
 					t.Fatalf("the artifact is different: %v", string(out))
 				}
@@ -243,7 +245,7 @@ func TestLazyPull(t *testing.T) {
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
 
-	optimizedImageName1 := alpineImage
+	optimizedImageName1 := rabbitmqImage
 	optimizedImageName2 := nginxImage
 	nonOptimizedImageName := ubuntuImage
 
@@ -504,7 +506,7 @@ disable = true
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
 
-	optimizedImageName1 := alpineImage
+	optimizedImageName1 := rabbitmqImage
 	optimizedImageName2 := nginxImage
 	nonOptimizedImageName := ubuntuImage
 
@@ -672,7 +674,7 @@ insecure = true
 		X("update-ca-certificates").
 		Retry(100, "nerdctl", "login", "-u", regConfig.user, "-p", regConfig.pass, regConfig.host)
 
-	imageName := alpineImage
+	imageName := rabbitmqImage
 	// Mirror images
 	rebootContainerd(t, sh, getContainerdConfigToml(t, false, containerdMirrorConfig), getSnapshotterConfigToml(t, false, snapshotterMirrorConfig))
 	copyImage(sh, dockerhub(imageName), regConfig.mirror(imageName))

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/awslabs/soci-snapshotter/ztoc"
@@ -35,7 +36,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"golang.org/x/sync/errgroup"
 	orascontent "oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 )
@@ -296,28 +296,57 @@ func (b *IndexBuilder) Build(ctx context.Context, img images.Image) (*IndexWithM
 		return nil, err
 	}
 
+	// attempt to build a ztoc for each layer
 	sociLayersDesc := make([]*ocispec.Descriptor, len(manifest.Layers))
-	eg, ctx := errgroup.WithContext(ctx)
-	for i, l := range manifest.Layers {
-		i, l := i, l
-		eg.Go(func() error {
-			desc, err := b.buildSociLayer(ctx, l)
-			if err != nil {
-				return fmt.Errorf("could not build zTOC for layer %s: %w", l.Digest.String(), err)
-			}
-			sociLayersDesc[i] = desc
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return nil, err
+	errChan := make(chan error)
+	go func() {
+		var wg sync.WaitGroup
+		for i, l := range manifest.Layers {
+			wg.Add(1)
+			go func(i int, l ocispec.Descriptor) {
+				defer wg.Done()
+				desc, err := b.buildSociLayer(ctx, l)
+				if err != nil {
+					if err != errUnsupportedLayerFormat {
+						errChan <- err
+					}
+					return
+				}
+				if desc != nil {
+					// index layers must be in some deterministic order
+					// actual layer order used for historic consistency
+					sociLayersDesc[i] = desc
+				}
+			}(i, l)
+		}
+		wg.Wait()
+		close(errChan)
+	}()
+
+	errs := make([]error, 0, len(manifest.Layers))
+
+	for err := range errChan {
+		errs = append(errs, err)
 	}
 
-	ztocsDesc := make([]ocispec.Descriptor, 0, len(manifest.Layers))
+	if len(errs) > 0 {
+		errWrap := errors.New("errors encountered while building soci layers")
+		for _, err := range errs {
+			errWrap = fmt.Errorf("%w; %v", errWrap, err)
+		}
+
+		return nil, errWrap
+	}
+
+	ztocsDesc := make([]ocispec.Descriptor, 0, len(sociLayersDesc))
 	for _, desc := range sociLayersDesc {
 		if desc != nil {
 			ztocsDesc = append(ztocsDesc, *desc)
 		}
+	}
+
+	if len(ztocsDesc) == 0 {
+		return nil, errors.New("no ztocs created, all layers either skipped or produced errors")
 	}
 
 	annotations := map[string]string{
@@ -346,8 +375,8 @@ func (b *IndexBuilder) buildSociLayer(ctx context.Context, desc ocispec.Descript
 		return nil, errNotLayerType
 	}
 	// check if we need to skip building the zTOC
-	if skipBuildingZtoc(desc, b.config) {
-		fmt.Printf("layer %s -> ztoc skipped\n", desc.Digest)
+	if skip, reason := skipBuildingZtoc(desc, b.config); skip {
+		fmt.Printf("ztoc skipped - layer %s (%s) %s\n", desc.Digest, desc.MediaType, reason)
 		return nil, nil
 	}
 
@@ -365,8 +394,9 @@ func (b *IndexBuilder) buildSociLayer(ctx context.Context, desc ocispec.Descript
 	}
 
 	if !b.ztocBuilder.CheckCompressionAlgorithm(compressionAlgo) {
-		return nil, fmt.Errorf("layer %s (%s) is compressed in an unsupported format. expect: [tar, gzip, unknown] but got %q: %w",
-			desc.Digest, desc.MediaType, compressionAlgo, errUnsupportedLayerFormat)
+		fmt.Printf("ztoc skipped - layer %s (%s) is compressed in an unsupported format. expect: [tar, gzip, unknown] but got %q\n",
+			desc.Digest, desc.MediaType, compressionAlgo)
+		return nil, errUnsupportedLayerFormat
 	}
 
 	ra, err := b.contentStore.ReaderAt(ctx, desc)
@@ -450,12 +480,15 @@ func NewIndexFromReader(reader io.Reader) (*Index, error) {
 	return index, nil
 }
 
-func skipBuildingZtoc(desc ocispec.Descriptor, cfg *buildConfig) bool {
+func skipBuildingZtoc(desc ocispec.Descriptor, cfg *buildConfig) (bool, string) {
 	if cfg == nil {
-		return false
+		return false, ""
 	}
 	// avoid the file access if the layer size is below threshold
-	return desc.Size < cfg.minLayerSize
+	if desc.Size < cfg.minLayerSize {
+		return true, fmt.Sprintf("size %d is less than min-layer-size %d", desc.Size, cfg.minLayerSize)
+	}
+	return false, ""
 }
 
 // GetImageManifestDescriptor gets the descriptor of image manifest

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -77,7 +77,7 @@ func TestSkipBuildingZtoc(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			if skipBuildingZtoc(tc.desc, &tc.buildConfig) != tc.skip {
+			if skip, _ := skipBuildingZtoc(tc.desc, &tc.buildConfig); skip != tc.skip {
 				t.Fatalf("%v: the value returned does not equal actual value %v", tc.name, tc.skip)
 			}
 		})


### PR DESCRIPTION
**Issue #, if available:**
Closes #591

**Description of changes:**
Replace fatal error on non-gzip compression type with simply skipping the layer.
Emit fatal error if all layers are skipped, including for pre-existing skip conditions which currently is mostly min-layer-size.

**Testing performed:**
Significant troubleshooting and some updates to existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
