### PR TITLE
Add comments identifying sensitive logging risks

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -84,6 +84,8 @@ const (
 	defaultMetricsNetwork      = "tcp"
 )
 
+// logLevel of Debug or Trace may emit sensitive information
+// e.g. file contents, file names and paths, network addresses and ports
 var (
 	address      = flag.String("address", defaultAddress, "address for the snapshotter's GRPC server")
 	configPath   = flag.String("config", defaultConfigPath, "path to the configuration file")
@@ -133,7 +135,7 @@ func main() {
 	)
 	defer cancel()
 	// Streams log of standard lib (go-fuse uses this) into debug log
-	// Snapshotter should use "github.com/containerd/containerd/log" otherwize
+	// Snapshotter should use "github.com/containerd/containerd/log" otherwise
 	// logs are always printed as "debug" mode.
 	golog.SetOutput(log.G(ctx).WriterLevel(logrus.DebugLevel))
 	log.G(ctx).WithFields(logrus.Fields{

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -101,7 +101,8 @@ type FuseConfig struct {
 	NegativeTimeout int64 `toml:"negative_timeout"`
 
 	// LogFuseOperations enables logging of operations on FUSE FS. This is to be used
-	// for debugging purposes only.
+	// for debugging purposes only. This option may emit sensitive information,
+	// e.g. filenames and paths within an image
 	LogFuseOperations bool `toml:"log_fuse_operations"`
 }
 

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -190,6 +190,8 @@ func incFuseOpFailureMetric(operationName string, layer digest.Digest) {
 	commonmetrics.IncOperationCount(metric, layer)
 }
 
+// logFSOperations may cause sensitive information to be emitted to logs
+// e.g. filenames and paths within an image
 func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseInode uint32, opaque OverlayOpaqueType, logFSOperations bool, opCounter *FuseOperationCounter) (fusefs.InodeEmbedder, error) {
 	rootID := r.Metadata().RootID()
 	rootAttr, err := r.Metadata().GetAttr(rootID)


### PR DESCRIPTION
**Issue #, if available:**
Partially addresses #416 

**Description of changes:**
Add comments noting options that may result in sensitive / private / secret information being emitted to logs, particularly related to fuse fs operation logging. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
