### PR TITLE
Add uncompressed archive size check to ztoc tests

### DIFF
--- a/ztoc/toc_builder.go
+++ b/ztoc/toc_builder.go
@@ -184,9 +184,7 @@ type positionTrackerReader struct {
 
 func (p *positionTrackerReader) Read(b []byte) (int, error) {
 	n, err := p.r.Read(b)
-	if err == nil {
-		p.pos += compression.Offset(n)
-	}
+	p.pos += compression.Offset(n)
 	return n, err
 }
 


### PR DESCRIPTION
**Issue #, if available:**
closes https://github.com/awslabs/soci-snapshotter/issues/584

**Description of changes:**
Adds an uncompressed archive size verification to the ztoc build tests. 

This also fixes a bug in the position tracker where it wouldn't record the number of bytes read on `io.EOF` and thus could truncate the file.

**Testing performed:**
`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
