### PR TITLE
Fix incorrect retry max wait time

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -90,7 +90,7 @@ func NewResolver(cfg config.BlobConfig, handlers map[string]Handler) *Resolver {
 		cfg.MinWaitMsec = socihttp.DefaultMinWaitMsec
 	}
 	if cfg.MaxWaitMsec == 0 {
-		cfg.MaxWaitMsec = socihttp.DefaultMaxRetries
+		cfg.MaxWaitMsec = socihttp.DefaultMaxWaitMsec
 	}
 
 	return &Resolver{


### PR DESCRIPTION
The retry max wait time was set incorrectly to the default max retry count which is 8(ms) instead of the actual default max wait time of 300000 ms.

This would cause no retries to happen when fetching spans or when [resolving blobs](https://github.com/awslabs/soci-snapshotter/blob/main/fs/remote/resolver.go#L304).

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
