### PR TITLE
Make HTTP timeouts and retries configurable

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -21,7 +21,7 @@ import (
 	"os"
 
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
-	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/urfave/cli"

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 
 	"github.com/opencontainers/go-digest"

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/fs"
-	"github.com/awslabs/soci-snapshotter/fs/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/reference"

--- a/cmd/soci/commands/rebuild_db.go
+++ b/cmd/soci/commands/rebuild_db.go
@@ -19,7 +19,7 @@ package commands
 import (
 	"path/filepath"
 
-	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/urfave/cli"

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/ztoc"
 	"github.com/containerd/containerd/cmd/ctr/commands"

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/ztoc"
 	"github.com/awslabs/soci-snapshotter/ztoc/compression"

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -1,0 +1,96 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
+*/
+
+package config
+
+// Config (root) defaults
+const (
+	defaultMetricsNetwork = "tcp"
+)
+
+// ServiceConfig defaults
+const (
+	defaultImageServiceAddress = "/run/containerd/containerd.sock"
+)
+
+// FSConfig defaults
+const (
+	defaultFuseTimeoutSec = 1
+
+	// defaultBgSilencePeriodMsec specifies the amount of time the background fetcher will wait once a new layer comes in
+	// before (re)starting fetches.
+	defaultBgSilencePeriodMsec = 30_000
+
+	// defaultBgFetchPeriodMsec specifies how often the fetch will occur.
+	// The background fetcher will fetch a single span every `defaultFetchPeriod`.
+	defaultBgFetchPeriodMsec = 500
+
+	// defaultBgMaxQueueSize specifies the maximum size of the bg-fetcher work queue i.e., the maximum number
+	// of span managers that can be queued. In case of overflow, the `Add` call
+	// will block until a span manager is removed from the workqueue.
+	defaultBgMaxQueueSize = 100
+
+	// defaultBgMetricEmitPeriodSec is the default amount of interval at which the background fetcher emits metrics
+	defaultBgMetricEmitPeriodSec = 10
+
+	// defaultMountTimeoutSec is the amount of time Mount will time out if a layer can't be resolved.
+	defaultMountTimeoutSec = 30
+
+	// defaultFuseMetricsEmitWaitDurationSec is the amount of time the snapshotter will wait before emitting the metrics for FUSE operation.
+	defaultFuseMetricsEmitWaitDurationSec = 60
+
+	defaultValidIntervalSec = 60
+
+	defaultFetchTimeoutSec = 300
+
+	// defaultDialTimeoutMsec is the default number of milliseconds before timeout while connecting to a remote endpoint. See `TimeoutConfig.DialTimeout`.
+	defaultDialTimeoutMsec = 3_000
+	// defaultResponseHeaderTimeoutMsec is the default number of milliseconds before timeout while waiting for response header from a remote endpoint. See `TimeoutConfig.ResponseHeaderTimeout`.
+	defaultResponseHeaderTimeoutMsec = 3_000
+	// defaultRequestTimeoutMsec is the default number of milliseconds that the entire request can take before timeout. See `TimeoutConfig.RequestTimeout`.
+	defaultRequestTimeoutMsec = 30_000
+
+	// defaults based on a target total retry time of at least 5s. 30*((2^8)-1)>5000
+
+	// defaultMaxRetries is the default number of retries that a retryable request will make. See `RetryConfig.MaxRetries`.
+	defaultMaxRetries = 8
+	// defaultMinWaitMsec is the default minimum number of milliseconds between attempts. See `RetryConfig.MinWait`.
+	defaultMinWaitMsec = 30
+	// defaultMaxWaitMsec is the default maximum number of milliseconds between attempts. See `RetryConfig.MaxWait`.
+	defaultMaxWaitMsec = 300_000
+)

--- a/config/resolver.go
+++ b/config/resolver.go
@@ -1,0 +1,62 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
+*/
+
+package config
+
+// ResolverConfig is config for resolving registries.
+type ResolverConfig struct {
+	Host map[string]HostConfig `toml:"host"`
+}
+
+type HostConfig struct {
+	Mirrors []MirrorConfig `toml:"mirrors"`
+}
+
+type MirrorConfig struct {
+
+	// Host is the hostname of the host.
+	Host string `toml:"host"`
+
+	// Insecure is true means use http scheme instead of https.
+	Insecure bool `toml:"insecure"`
+
+	// RequestTimeoutSec is timeout seconds of each request to the registry.
+	// RequestTimeoutSec == 0 indicates the default timeout (defaultRequestTimeoutSec).
+	// RequestTimeoutSec < 0 indicates no timeout.
+	RequestTimeoutSec int64 `toml:"request_timeout_sec"`
+}

--- a/config/root.go
+++ b/config/root.go
@@ -1,0 +1,66 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
+*/
+
+package config
+
+const (
+	// Default path to OCI-compliant CAS
+	SociContentStorePath = "/var/lib/soci-snapshotter-grpc/content/"
+
+	// Default path to snapshotter root dir
+	SociSnapshotterRootPath = "/var/lib/soci-snapshotter-grpc/"
+)
+
+type Config struct {
+	ServiceConfig
+
+	// MetricsAddress is address for the metrics API
+	MetricsAddress string `toml:"metrics_address"`
+
+	// MetricsNetwork is the type of network for the metrics API (e.g. tcp or unix)
+	MetricsNetwork string `toml:"metrics_network"`
+
+	// NoPrometheus is a flag to disable the emission of the metrics
+	NoPrometheus bool `toml:"no_prometheus"`
+
+	// DebugAddress is a Unix domain socket address where the snapshotter exposes /debug/ endpoints.
+	DebugAddress string `toml:"debug_address"`
+
+	// MetadataStore is the type of the metadata store to use.
+	MetadataStore string `toml:"metadata_store" default:"db"`
+}

--- a/config/service.go
+++ b/config/service.go
@@ -78,3 +78,9 @@ type SnapshotterConfig struct {
 	//       ctr (e.g. `ctr snapshot rm`).
 	AllowInvalidMountsOnRestart bool `toml:"allow_invalid_mounts_on_restart"`
 }
+
+func parseServiceConfig(cfg *Config) {
+	if cfg.CRIKeychainConfig.ImageServicePath == "" {
+		cfg.CRIKeychainConfig.ImageServicePath = defaultImageServiceAddress
+	}
+}

--- a/config/service.go
+++ b/config/service.go
@@ -30,15 +30,10 @@
    limitations under the License.
 */
 
-package service
+package config
 
-import (
-	"github.com/awslabs/soci-snapshotter/fs/config"
-	"github.com/awslabs/soci-snapshotter/service/resolver"
-)
-
-type Config struct {
-	config.Config
+type ServiceConfig struct {
+	FSConfig
 
 	// KubeconfigKeychainConfig is config for kubeconfig-based keychain.
 	KubeconfigKeychainConfig `toml:"kubeconfig_keychain"`
@@ -71,9 +66,6 @@ type CRIKeychainConfig struct {
 	// ImageServicePath is the path to the unix socket of backing CRI Image Service (e.g. containerd CRI plugin)
 	ImageServicePath string `toml:"image_service_path"`
 }
-
-// ResolverConfig is config for resolving registries.
-type ResolverConfig resolver.Config
 
 // SnapshotterConfig is snapshotter-related config.
 type SnapshotterConfig struct {

--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/service/keychain/dockerconfig"
 	"github.com/awslabs/soci-snapshotter/soci"
 	socihttp "github.com/awslabs/soci-snapshotter/util/http"
@@ -67,14 +68,14 @@ func newArtifactFetcher(refspec reference.Spec, localStore content.Storage, remo
 	}, nil
 }
 
-func newRemoteStore(refspec reference.Spec) (*remote.Repository, error) {
+func newRemoteStore(refspec reference.Spec, httpConfig config.RetryableHTTPClientConfig) (*remote.Repository, error) {
 	repo, err := remote.NewRepository(refspec.Locator)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create repository %s: %w", refspec.Locator, err)
 	}
 
 	authClient := auth.Client{
-		Client: socihttp.NewRetryableClient(socihttp.NewRetryableClientConfig()),
+		Client: socihttp.NewRetryableClient(httpConfig),
 		Cache:  auth.DefaultCache,
 		Credential: func(_ context.Context, host string) (auth.Credential, error) {
 			username, secret, err := dockerconfig.DockerCreds(host)

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -50,8 +50,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/awslabs/soci-snapshotter/config"
 	bf "github.com/awslabs/soci-snapshotter/fs/backgroundfetcher"
-	"github.com/awslabs/soci-snapshotter/fs/config"
 	"github.com/awslabs/soci-snapshotter/fs/layer"
 	commonmetrics "github.com/awslabs/soci-snapshotter/fs/metrics/common"
 	layermetrics "github.com/awslabs/soci-snapshotter/fs/metrics/layer"
@@ -142,7 +142,7 @@ func WithOverlayOpaqueType(overlayOpaqueType layer.OverlayOpaqueType) Option {
 	}
 }
 
-func NewFilesystem(ctx context.Context, root string, cfg config.Config, opts ...Option) (_ snapshot.FileSystem, err error) {
+func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts ...Option) (_ snapshot.FileSystem, err error) {
 	var fsOpts options
 	for _, o := range opts {
 		o(&fsOpts)

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -49,7 +49,7 @@ import (
 	"time"
 
 	"github.com/awslabs/soci-snapshotter/cache"
-	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/config"
 
 	backgroundfetcher "github.com/awslabs/soci-snapshotter/fs/backgroundfetcher"
 	commonmetrics "github.com/awslabs/soci-snapshotter/fs/metrics/common"
@@ -125,7 +125,7 @@ type Resolver struct {
 	blobCache         *lrucache.Cache
 	blobCacheMu       sync.Mutex
 	resolveLock       *namedmutex.NamedMutex
-	config            config.Config
+	config            config.FSConfig
 	metadataStore     metadata.Store
 	artifactStore     content.Storage
 	overlayOpaqueType OverlayOpaqueType
@@ -133,7 +133,7 @@ type Resolver struct {
 }
 
 // NewResolver returns a new layer resolver.
-func NewResolver(root string, cfg config.Config, resolveHandlers map[string]remote.Handler,
+func NewResolver(root string, cfg config.FSConfig, resolveHandlers map[string]remote.Handler,
 	metadataStore metadata.Store, artifactStore content.Storage, overlayOpaqueType OverlayOpaqueType, bgFetcher *backgroundfetcher.BackgroundFetcher) (*Resolver, error) {
 	resolveResultEntry := cfg.ResolveResultEntry
 	if resolveResultEntry == 0 {
@@ -180,7 +180,7 @@ func NewResolver(root string, cfg config.Config, resolveHandlers map[string]remo
 	}, nil
 }
 
-func newCache(root string, cacheType string, cfg config.Config) (cache.BlobCache, error) {
+func newCache(root string, cacheType string, cfg config.FSConfig) (cache.BlobCache, error) {
 	if cacheType == memoryCacheType {
 		return cache.NewMemoryCache(), nil
 	}

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -74,25 +74,6 @@ const (
 )
 
 func NewResolver(cfg config.BlobConfig, handlers map[string]Handler) *Resolver {
-	if cfg.ValidInterval == 0 { // zero means "use default interval"
-		cfg.ValidInterval = defaultValidIntervalSec
-	}
-	if cfg.CheckAlways {
-		cfg.ValidInterval = 0
-	}
-	if cfg.FetchTimeoutSec == 0 {
-		cfg.FetchTimeoutSec = defaultFetchTimeoutSec
-	}
-	if cfg.MaxRetries == 0 {
-		cfg.MaxRetries = socihttp.DefaultMaxRetries
-	}
-	if cfg.MinWaitMsec == 0 {
-		cfg.MinWaitMsec = socihttp.DefaultMinWaitMsec
-	}
-	if cfg.MaxWaitMsec == 0 {
-		cfg.MaxWaitMsec = socihttp.DefaultMaxWaitMsec
-	}
-
 	return &Resolver{
 		blobConfig: cfg,
 		handlers:   handlers,

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -54,7 +54,7 @@ import (
 	"time"
 
 	"github.com/awslabs/soci-snapshotter/cache"
-	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/config"
 	commonmetrics "github.com/awslabs/soci-snapshotter/fs/metrics/common"
 	"github.com/awslabs/soci-snapshotter/fs/source"
 	socihttp "github.com/awslabs/soci-snapshotter/util/http"

--- a/service/plugin/plugin.go
+++ b/service/plugin/plugin.go
@@ -40,6 +40,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/service"
 	"github.com/awslabs/soci-snapshotter/service/keychain/cri"
 	"github.com/awslabs/soci-snapshotter/service/keychain/dockerconfig"
@@ -58,7 +59,7 @@ import (
 
 // Config represents configuration for the soci snapshotter plugin.
 type Config struct {
-	service.Config
+	config.ServiceConfig
 
 	// RootPath is the directory for the plugin
 	RootPath string `toml:"root_path"`
@@ -92,17 +93,17 @@ func init() {
 
 			// Configure keychain
 			credsFuncs := []resolver.Credential{dockerconfig.NewDockerConfigKeychain(ctx)}
-			if config.Config.KubeconfigKeychainConfig.EnableKeychain {
+			if config.KubeconfigKeychainConfig.EnableKeychain {
 				var opts []kubeconfig.Option
-				if kcp := config.Config.KubeconfigKeychainConfig.KubeconfigPath; kcp != "" {
+				if kcp := config.KubeconfigKeychainConfig.KubeconfigPath; kcp != "" {
 					opts = append(opts, kubeconfig.WithKubeconfigPath(kcp))
 				}
 				credsFuncs = append(credsFuncs, kubeconfig.NewKubeconfigKeychain(ctx, opts...))
 			}
-			if addr := config.CRIKeychainImageServicePath; config.Config.CRIKeychainConfig.EnableKeychain && addr != "" {
+			if addr := config.CRIKeychainImageServicePath; config.CRIKeychainConfig.EnableKeychain && addr != "" {
 				// connects to the backend CRI service (defaults to containerd socket)
 				criAddr := ic.Address
-				if cp := config.Config.CRIKeychainConfig.ImageServicePath; cp != "" {
+				if cp := config.CRIKeychainConfig.ImageServicePath; cp != "" {
 					criAddr = cp
 				}
 				if criAddr == "" {
@@ -155,7 +156,7 @@ func init() {
 
 			// TODO(ktock): print warn if old configuration is specified.
 			// TODO(ktock): should we respect old configuration?
-			return service.NewSociSnapshotterService(ctx, root, &config.Config,
+			return service.NewSociSnapshotterService(ctx, root, &config.ServiceConfig,
 				service.WithCustomRegistryHosts(resolver.RegistryHostsFromCRIConfig(ctx, config.Registry, credsFuncs...)))
 		},
 	})

--- a/service/resolver/registry.go
+++ b/service/resolver/registry.go
@@ -35,42 +35,20 @@ package resolver
 import (
 	"time"
 
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/fs/source"
 	socihttp "github.com/awslabs/soci-snapshotter/util/http"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes/docker"
 )
 
-// Config is config for resolving registries.
-type Config struct {
-	Host map[string]HostConfig `toml:"host"`
-}
-
-type HostConfig struct {
-	Mirrors []MirrorConfig `toml:"mirrors"`
-}
-
-type MirrorConfig struct {
-
-	// Host is the hostname of the host.
-	Host string `toml:"host"`
-
-	// Insecure is true means use http scheme instead of https.
-	Insecure bool `toml:"insecure"`
-
-	// RequestTimeoutSec is timeout seconds of each request to the registry.
-	// RequestTimeoutSec == 0 indicates the default timeout (defaultRequestTimeoutSec).
-	// RequestTimeoutSec < 0 indicates no timeout.
-	RequestTimeoutSec int64 `toml:"request_timeout_sec"`
-}
-
 type Credential func(string, reference.Spec) (string, string, error)
 
 // RegistryHostsFromConfig creates RegistryHosts (a set of registry configuration) from Config.
-func RegistryHostsFromConfig(cfg Config, credsFuncs ...Credential) source.RegistryHosts {
+func RegistryHostsFromConfig(registryConfig config.ResolverConfig, credsFuncs ...Credential) source.RegistryHosts {
 	return func(ref reference.Spec) (hosts []docker.RegistryHost, _ error) {
 		host := ref.Hostname()
-		for _, h := range append(cfg.Host[host].Mirrors, MirrorConfig{
+		for _, h := range append(registryConfig.Host[host].Mirrors, config.MirrorConfig{
 			Host: host,
 		}) {
 			clientConfig := socihttp.NewRetryableClientConfig()

--- a/service/service.go
+++ b/service/service.go
@@ -86,7 +86,7 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	hosts := sOpts.registryHosts
 	if hosts == nil {
 		// Use RegistryHosts based on ResolverConfig and keychain
-		hosts = resolver.RegistryHostsFromConfig(serviceCfg.ResolverConfig, sOpts.credsFuncs...)
+		hosts = resolver.RegistryHostsFromConfig(serviceCfg.ResolverConfig, serviceCfg.FSConfig.RetryableHTTPClientConfig, sOpts.credsFuncs...)
 	}
 	userxattr, err := overlayutils.NeedsUserXAttr(snapshotterRoot(root))
 	if err != nil {

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/util/dbutil"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"


### PR DESCRIPTION
**Issue #, if available:**

Resolves: #608 

**Description of changes:**

This PR contains 2 changes. The first one moves all the config structs to a separate `config` package. The second moves all the parsing of the configs to the newly created `config` package and also adds an `http` toml property to make the `rhttp` client used to fetch artifacts + spans configurable.


`http` toml property. 

```toml

[http]

[http.timeout]
	dial_timeout_msec=3_000
	response_header_timeout_msec=3_000
	request_timeout_msec=30_000 
[http.retry]
	max_retries=8
	min_wait_msec=30
	max_wait_msec=300_000

```


**Testing performed:**

`make test && make integration`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
