### PR TITLE
add static built binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,19 @@ OUTDIR ?= $(CURDIR)/out
 PKG=github.com/awslabs/soci-snapshotter
 VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
-GO_LD_FLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) $(GO_EXTRA_LDFLAGS)'
+
+GO_BUILDTAGS ?=
+ifneq ($(STATIC),)
+	GO_BUILDTAGS += osusergo netgo static_build
+endif
+GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(strip $(GO_BUILDTAGS))",)
+
+GO_LD_FLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) $(GO_EXTRA_LDFLAGS)
+ifneq ($(STATIC),)
+	GO_LD_FLAGS += -extldflags "-static"
+endif
+GO_LD_FLAGS+='
+
 SOCI_SNAPSHOTTER_PROJECT_ROOT ?= $(shell pwd)
 LTAG_TEMPLATE_FLAG=-t ./.headers
 FBS_FILE_PATH=$(CURDIR)/ztoc/fbs/ztoc.fbs
@@ -41,10 +53,10 @@ build: $(CMD)
 FORCE:
 
 soci-snapshotter-grpc: FORCE
-	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) ./soci-snapshotter-grpc
+	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) $(GO_TAGS) ./soci-snapshotter-grpc
 
 soci: FORCE
-	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) ./soci
+	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) $(GO_TAGS) ./soci
 
 check:
 	cd scripts/ ; ./check-all.sh


### PR DESCRIPTION
Fix: #475 

This patch enables build statically linked binaries with the following command:

```
make STATIC=1
```

Tested on alpine docker image for both commands:

<details>
  <summary>soci</summary>

```
/soci # ./soci create docker.io/library/ubuntu:latest
layer sha256:dbf6a9befcdeecbb8813406afbd62ce81394e3869d84599f19f941aa5c74f3d1 -> ztoc sha256:372417343d4b4b741e6b940c5829a7cb5d934c3edcae0af504e6ff9d5e029cdd
```
</details>

<details>
  <summary>soci-snapshotter-grpc</summary>

```
/soci # ./soci-snapshotter-grpc
{"level":"info","msg":"starting soci-snapshotter-grpc","revision":"3f21ac241646e219b4986578a6f6e59a98d94f64","time":"2023-05-12T05:28:57.964955078Z","version":"3f21ac2"}
{"error":"failed to mount overlay: operation not permitted","level":"fatal","msg":"snapshotter is not supported","time":"2023-05-12T05:28:57.965572192Z"}
```
The snapshotter failed to due to missing overlay fs. But the binary was able to run.
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
