### PR TITLE
Add go.work and go.work.sum to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /out
 *.db
 .vscode/
+go.work
+go.work.sum
 /benchmark/*/output/
 /benchmark/bin/


### PR DESCRIPTION
**Description of changes:**
Tell git to ignore go.work and go.work.sum which will be created after following the instructions added in #611 and would otherwise need to be skipped in future commits.

**Testing performed:**
`git status`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
