### PR TITLE
Remove orphaned zTOCs. Remove content store files.

### DIFF
--- a/cmd/soci/commands/index/rm.go
+++ b/cmd/soci/commands/index/rm.go
@@ -17,12 +17,38 @@
 package index
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
+	"github.com/awslabs/soci-snapshotter/fs/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
+	"oras.land/oras-go/v2/content/oci"
 )
+
+func fetchIndex(ctx context.Context, storage *oci.Store, digestString string) (*soci.Index, error) {
+	dgst, err := digest.Parse(digestString)
+	if err != nil {
+		return nil, err
+	}
+	reader, err := storage.Fetch(ctx, v1.Descriptor{Digest: dgst})
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	var index soci.Index
+	if err := soci.DecodeIndex(reader, &index); err != nil {
+		return nil, err
+	}
+
+	return &index, nil
+
+}
 
 var rmCommand = cli.Command{
 	Name:        "remove",
@@ -48,8 +74,62 @@ var rmCommand = cli.Command{
 			return err
 		}
 		if ref == "" {
+			ctx, cancelTimeout := context.WithTimeout(context.Background(), cliContext.GlobalDuration("timeout"))
+			defer cancelTimeout()
+			storage, err := oci.New(config.SociContentStorePath)
+			if err != nil {
+				return err
+			}
+			maybeOrphanZtocDigests := make(map[digest.Digest]bool)
 			for _, desc := range args {
-				err := db.RemoveArtifactEntryByIndexDigest(desc)
+				index, err := fetchIndex(ctx, storage, desc)
+				if err != nil {
+					return err
+				}
+
+				// add all zTOC digests from the index manifest to the set of potential orphans
+				for _, blob := range index.Blobs {
+					maybeOrphanZtocDigests[blob.Digest] = true
+				}
+
+				// TODO remove the index manifest file
+
+				// remove the index manifest artifact
+				err = db.RemoveArtifactEntryByIndexDigest(desc)
+				if err != nil {
+					return err
+				}
+			}
+			err = db.Walk(func(ae *soci.ArtifactEntry) error {
+				if ae.Type == soci.ArtifactEntryTypeIndex {
+					index, err := fetchIndex(ctx, storage, ae.Digest)
+					if err != nil {
+						return err
+					}
+
+					// remove still-referenced ztocs from the list of potentially orphaned ztoc digests
+					for _, blob := range index.Blobs {
+						// FIXME why does go-staticcheck think this guard is unnecessary for just {delete()}?
+						if _, ok := maybeOrphanZtocDigests[blob.Digest]; ok {
+							fmt.Printf("keeping ztoc digest %s referenced by index manifest %s\n", blob.Digest.String(), ae.Digest)
+							delete(maybeOrphanZtocDigests, blob.Digest)
+							// bail out early if there are no more potential orphans
+							if len(maybeOrphanZtocDigests) == 0 {
+								return soci.ErrWalkBailout
+							}
+						}
+					}
+				}
+				return nil
+			})
+			if err != nil && !errors.Is(err, soci.ErrWalkBailout) {
+				return err
+			}
+
+			// all remaining potential orphans are actually orphaned
+			for dgst := range maybeOrphanZtocDigests {
+				fmt.Printf("removing orphaned ztoc digest %s\n", dgst.String())
+				err = db.RemoveArtifactEntryByZtocDigest(dgst.String())
 				if err != nil {
 					return err
 				}
@@ -66,6 +146,7 @@ var rmCommand = cli.Command{
 			if err != nil {
 				return err
 			}
+			// TODO use the new logic above here as well
 			return db.RemoveArtifactEntryByImageDigest(img.Target.Digest.String())
 		}
 		return nil

--- a/cmd/soci/commands/prune_content_store.go
+++ b/cmd/soci/commands/prune_content_store.go
@@ -1,0 +1,39 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package commands
+
+import (
+	"context"
+
+	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/urfave/cli"
+)
+
+var PruneContentStoreCommand = cli.Command{
+	Name:  "prune-content-store",
+	Usage: "remove files from the local content store that are not represented in the artifacts database.",
+	Action: func(cliContext *cli.Context) error {
+		ctx, cancelTimeout := context.WithTimeout(context.Background(), cliContext.GlobalDuration("timeout"))
+		defer cancelTimeout()
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath())
+		if err != nil {
+			return err
+		}
+		return artifactsDb.PruneLocalStore(ctx, config.SociContentStorePath)
+	},
+}

--- a/cmd/soci/commands/ztoc/remove_orphans.go
+++ b/cmd/soci/commands/ztoc/remove_orphans.go
@@ -1,0 +1,41 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ztoc
+
+import (
+	"context"
+
+	"github.com/awslabs/soci-snapshotter/fs/config"
+	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/urfave/cli"
+)
+
+var removeOrphansCommand = cli.Command{
+	Name:        "remove-orphans",
+	Usage:       "remove orphan zTOCs",
+	Description: "remove all zTOCs that are not referenced by any index manifest (cleanup after `soci index rm --keep-orphan-ztocs`)",
+	Action: func(cliContext *cli.Context) error {
+		db, err := soci.NewDB(soci.ArtifactsDbPath())
+		if err != nil {
+			return err
+		}
+		ctx, cancelTimeout := context.WithTimeout(context.Background(), cliContext.GlobalDuration("timeout"))
+		defer cancelTimeout()
+		db.RemoveOrphanZtocs(ctx, config.SociContentStorePath)
+		return nil
+	},
+}

--- a/cmd/soci/commands/ztoc/ztoc.go
+++ b/cmd/soci/commands/ztoc/ztoc.go
@@ -25,5 +25,6 @@ var Command = cli.Command{
 		infoCommand,
 		getFileCommand,
 		listCommand,
+		removeOrphansCommand,
 	},
 }

--- a/cmd/soci/main.go
+++ b/cmd/soci/main.go
@@ -91,6 +91,7 @@ func main() {
 		commands.PushCommand,
 		run.Command,
 		commands.RebuildDBCommand,
+		commands.PruneContentStoreCommand,
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -375,9 +375,9 @@ func (db *ArtifactsDb) RemoveArtifactEntryByIndexDigest(digest string) error {
 	})
 }
 
-// RemoveArtifactEntryByIndexDigest removes an index's artifact entry using the image digest
-func (db *ArtifactsDb) RemoveArtifactEntryByImageDigest(digest string) error {
-	return db.db.Update(func(tx *bolt.Tx) error {
+func (db *ArtifactsDb) GetIndexDigestsByImageDigest(digest string) (*[]string, error) {
+	indexDigests := make([]string, 0, 1)
+	err := db.db.View(func(tx *bolt.Tx) error {
 		bucket, err := getArtifactsBucket(tx)
 		if err != nil {
 			return err
@@ -387,11 +387,12 @@ func (db *ArtifactsDb) RemoveArtifactEntryByImageDigest(digest string) error {
 		for k, _ := c.First(); k != nil; k, _ = c.Next() {
 			artifactBucket := bucket.Bucket(k)
 			if indexBucket(artifactBucket) && hasImageDigest(artifactBucket, digest) {
-				bucket.DeleteBucket(k)
+				indexDigests = append(indexDigests, string(k))
 			}
 		}
 		return nil
 	})
+	return &indexDigests, err
 }
 
 // Determines whether a bucket represents a zTOC, as opposed to an index

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -680,21 +679,6 @@ func RemoveIndexes(ctx context.Context, digestStrings []string, removeOrphanedZt
 				return err
 			}
 		}
-	}
-
-	return nil
-}
-
-func RemoveContentStoreBlobByDigest(ctx context.Context, digestString string) error {
-	dgst, err := digest.Parse(digestString)
-	if err != nil {
-		return err
-	}
-
-	// path defined by https://github.com/opencontainers/image-spec/blob/v1.0/image-layout.md
-	err = os.Remove(filepath.Join(config.SociContentStorePath, "blobs", dgst.Algorithm().String(), dgst.Encoded()))
-	if err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
This PR is not ready for review.

**Issue #, if available:**
Closes #423

**Description of changes:**
This is a work in progress. This description will be updated to reflect the current state of the PR.

- [x] `soci index rm DIGEST` remove newly orphaned zTOCs from the artifact db
- [x] `soci index rm --ref REF` ditto
- [x] Make orphan zTOC removal optional
- [x] Remove files after removing artifact db entries
- [x] Add new command `soci prune-content-store` to remove content files with missing artifacts
- [x] Add new command `soci ztoc remove-orphans`
- [ ] Add test coverage for new functionality
- [ ] Audit existing content store access for possible race conditions

**Testing performed:**
Running unit and integration tests as development proceeds. Testing will not be complete until this is converted from Draft.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.