### PR TITLE
Set layer fs folder permission to 0755

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -651,7 +651,7 @@ func (o *snapshotter) prepareDirectory(ctx context.Context, snapshotDir string, 
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
-	if err := os.Mkdir(filepath.Join(td, "fs"), 0711); err != nil {
+	if err := os.Mkdir(filepath.Join(td, "fs"), 0755); err != nil {
 		return td, err
 	}
 


### PR DESCRIPTION
**Issue #, if available:**
Fixes #664

**Description of changes:**
When the SOCI snapshotter performs a local mount (e.g. because there is no ztoc for a layer), it creates an fs folder to house the layer's content in the layer's state directory. In an attempt to lock down the SOCI state directory, the permissions were set to 0711. This folder gets mounted into the container and the permission is retained which results in a non-root user being unable to read the contents of the mount root.

Containerd and stargz-snapshotter set the permissions to 0755. The FUSE mountpoints created by SOCI have permissions set to 0755. We should be consistent here too.

**Testing performed:**
```
make check
GO_TEST_FLAGS="-run TestRootFolderPermission" make integration
```

I also verified that the new test fails before making my change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
