### PR TITLE
Fix blob resolver redirection

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -292,10 +292,7 @@ func redirect(ctx context.Context, blobURL string, tr http.RoundTripper, timeout
 	}()
 
 	if res.StatusCode/100 == 2 {
-		url = blobURL
-	} else if redir := res.Header.Get("Location"); redir != "" && res.StatusCode/100 == 3 {
-		// TODO: Support nested redirection
-		url = redir
+		url = res.Request.URL.String()
 	} else {
 		return "", fmt.Errorf("failed to access to the registry with code %v", res.StatusCode)
 	}

--- a/fs/remote/resolver_test.go
+++ b/fs/remote/resolver_test.go
@@ -209,11 +209,10 @@ func (tr *sampleRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	}
 	for host, rurl := range tr.redirectURL {
 		if ok, _ := regexp.Match(host, []byte(req.URL.String())); ok {
-			header := make(http.Header)
-			header.Add("Location", rurl)
+			u, _ := url.Parse(rurl)
+			req.URL = u
 			return &http.Response{
-				StatusCode: http.StatusMovedPermanently,
-				Header:     header,
+				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte{})),
 				Request:    req,
 			}, nil


### PR DESCRIPTION
There is a single retryable `http.Client` embedded as the inner transport of the `http.Client` used to fetch spans and SOCI artifacts. The default behavior of the embedded client is to follow up to 10 redirects. When resolving a layer we attempt to follow any redirects to get the actual location of the blob. However, since by default the client follows redirects we end up making a full `RoundTrip` and end up setting the redirected url to be the original url. We should instead set the redirected url to be the last url that a request was sent to get a 200 response.


**Issue #, if available:**

Resolves: #655 

**Description of changes:**

**Testing performed:**

`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
