### PR TITLE
dependabot ignore k8s.io deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,27 @@
 version: 2
 updates:
-  
+ 
   # Automatic upgrade for go modules.
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
-      
+    ignore:
+      # skip k8s deps since they use the latest go version/features that may not be in the go version soci uses
+      # Also ignored in /scripts/bump-deps.sh
+      - dependency-name: "k8s.io/*"
+
   # Automatic upgrade for go modules of cmd package.
   - package-ecosystem: "gomod"
     directory: "/cmd"
     schedule:
       interval: "daily"
-  
+    ignore:
+      # skip k8s deps and soci-snapshotter itself
+      # Also ignored in /scripts/bump-deps.sh
+      - dependency-name: "github.com/awslabs/soci-snapshotter"
+      - dependency-name: "k8s.io/*"
+
   # Automatic upgrade for base images used in the Dockerfile
   - package-ecosystem: "docker"
     directory: "/"

--- a/scripts/bump-deps.sh
+++ b/scripts/bump-deps.sh
@@ -22,15 +22,17 @@ SOCI_SNAPSHOTTER_PROJECT_ROOT="${CUR_DIR}/.."
 pushd ${SOCI_SNAPSHOTTER_PROJECT_ROOT}
 
 # skip k8s deps since they use the latest go version/features that may not be in the go version soci uses
+# Also ignored in /dependabot.yml
 go get -u $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
-    grep -v "k8s.io")
+    grep -v "^k8s.io/")
 make vendor
 
 pushd ./cmd
 # skip k8s deps and soci-snapshotter itself
+# Also ignored in /dependabot.yml
 go get -u $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
-    grep -v "github.com/awslabs/soci-snapshotter" | \
-    grep -v "k8s.io")
+    grep -v "^github.com/awslabs/soci-snapshotter" | \
+    grep -v "^k8s.io/")
 popd
 make vendor
 


### PR DESCRIPTION
**Description of changes:**
Merging #678 led to dependabot updating #670 #671 #672, which may have been opened in response to #636 being merged.
We ignore k8s dependencies in bump-deps.sh "since they use the latest go version/features that may not be in the go version soci uses" so they should also be ignored by dependabot.

Also made minor regex, comment, and trailing whitespace updates.

**Testing performed:**
Ran update script in fresh go environment locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
