### PR TITLE
Add cli flags to benchmark tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,13 @@ integration: build
 
 benchmarks:
 	@echo "$@"
-	@cd benchmark/performanceTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/PerfTests . && sudo ../bin/PerfTests $(COMMIT) ../singleImage.csv 10
+	@cd benchmark/performanceTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/PerfTests . && sudo ../bin/PerfTests
+	@cd benchmark/comparisonTest ;  GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/CompTests . && sudo ../bin/CompTests
 
-benchmarks-comp:
+build-benchmarks:
 	@echo "$@"
-	@cd benchmark/comparisonTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/CompTests . && sudo ../bin/CompTests $(COMMIT) ../singleImage.csv 10
+	@cd benchmark/performanceTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/PerfTests .
+	@cd benchmark/comparisonTest ;  GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/CompTests .
 
 benchmarks-stargz:
 	@echo "$@"

--- a/benchmark/comparisonTest/main.go
+++ b/benchmark/comparisonTest/main.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/awslabs/soci-snapshotter/benchmark"
@@ -33,30 +32,35 @@ var (
 
 func main() {
 
-	var numberOfTests int
-	var configCsv string
-	var showCom bool
-	var parseFileAccessPatterns bool
+	var (
+		numberOfTests int
+		configCsv     string
+		showCom       bool
+		imageList     []benchmark.ImageDescriptor
+		err           error
+		commit        string
+	)
 
-	flag.BoolVar(&parseFileAccessPatterns, "parseFileAccess", false, "Parse fuse file access patterns.")
 	flag.BoolVar(&showCom, "show-commit", false, "tag the commit hash to the benchmark results")
 	flag.IntVar(&numberOfTests, "count", 5, "Describes the number of runs a benchmarker should run. Default: 5")
-	flag.StringVar(&configCsv, "f", "../imageList.csv", "Path to a csv file describing image details in this order ['Name','Image ref', 'Ready line', 'manifest ref'].")
+	flag.StringVar(&configCsv, "f", "default", "Path to a csv file describing image details in this order ['Name','Image ref', 'Ready line', 'manifest ref'].")
 
 	flag.Parse()
 
-	var commit string
-
 	if showCom {
-		commit, _ = getCommitHash()
+		commit, _ = benchmark.GetCommitHash()
 	} else {
 		commit = "N/A"
 	}
 
-	imageList, err := benchmark.GetImageListFromCsv(configCsv)
-	if err != nil {
-		errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
-		panic(errMsg)
+	if configCsv == "default" {
+		imageList = benchmark.GetDefaultWorkloads()
+	} else {
+		imageList, err = benchmark.GetImageListFromCsv(configCsv)
+		if err != nil {
+			errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
+			panic(errMsg)
+		}
 	}
 
 	err = os.Mkdir(outputDir, 0755)
@@ -100,13 +104,4 @@ func main() {
 		Drivers:   drivers,
 	}
 	benchmarks.Run(ctx)
-}
-
-func getCommitHash() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "HEAD")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return string(output), nil
 }

--- a/benchmark/utils.go
+++ b/benchmark/utils.go
@@ -57,11 +57,65 @@ func GetImageListFromCsv(csvLoc string) ([]ImageDescriptor, error) {
 	return images, nil
 }
 
-func getCommitHash() (string, error) {
+func GetCommitHash() (string, error) {
 	cmd := exec.Command("git", "rev-parse", "HEAD")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
 	return string(output), nil
+}
+
+func GetDefaultWorkloads() []ImageDescriptor {
+	return []ImageDescriptor{
+		{
+			ShortName:            "ECR-public-ffmpeg",
+			ImageRef:             "public.ecr.aws/soci-workshop-examples/ffmpeg:latest",
+			SociIndexManifestRef: "ef63578971ebd8fc700c74c96f81dafab4f3875e9117ef3c5eb7446e169d91cb",
+			ReadyLine:            "Hello World",
+		},
+		{
+			ShortName:            "ECR-public-tensorflow",
+			ImageRef:             "public.ecr.aws/soci-workshop-examples/tensorflow:latest",
+			SociIndexManifestRef: "27546e0267465279e40a8c8ebc8d34836dd5513c6e7019257855c9e0f04a9f34",
+			ReadyLine:            "Hello World with TensorFlow!",
+		},
+		{
+			ShortName:            "ECR-public-tensorflow_gpu",
+			ImageRef:             "public.ecr.aws/soci-workshop-examples/tensorflow_gpu:latest",
+			SociIndexManifestRef: "a40b70bc941216cbb29623e98970dfc84e9640666a8b9043564ca79f6d5cc137",
+			ReadyLine:            "Hello World with TensorFlow!",
+		},
+		{
+			ShortName:            "ECR-public-node",
+			ImageRef:             "public.ecr.aws/soci-workshop-examples/node:latest",
+			SociIndexManifestRef: "544d42d3447fe7833c2e798b8a342f5102022188e814de0aa6ce980e76c62894",
+			ReadyLine:            "Server ready",
+		},
+		{
+			ShortName:            "ECR-public-busybox",
+			ImageRef:             "public.ecr.aws/soci-workshop-examples/busybox:latest",
+			SociIndexManifestRef: "deaaf67bb4baa293dadcfbeb1f511c181f89a05a042ee92dd2e43e7b7295b1c0",
+			ReadyLine:            "Hello World",
+		},
+		{
+			ShortName:            "ECR-public-mongo",
+			ImageRef:             "public.ecr.aws/soci-workshop-examples/mongo:latest",
+			SociIndexManifestRef: "ecdd6dcc917d09ec7673288e8ba83270542b71959db2ac731fbeb42aa0b038e0",
+			ReadyLine:            "Waiting for connections",
+		},
+		{
+			ShortName:            "ECR-public-rabbitmq",
+			ImageRef:             "public.ecr.aws/soci-workshop-examples/rabbitmq:latest",
+			SociIndexManifestRef: "3882f9609c0c2da044173710f3905f4bc6c09228f2a5b5a0a5fdce2537677c17",
+			ReadyLine:            "Server startup complete",
+		},
+		{
+			ShortName:            "ECR-public-redis",
+			ImageRef:             "public.ecr.aws/soci-workshop-examples/redis:latest",
+			SociIndexManifestRef: "da171fda5f4ccf79f453fc0c5e1414642521c2e189f377809ca592af9458287a",
+			ReadyLine:            "Ready to accept connections",
+		},
+	}
+
 }

--- a/benchmark/utils.go
+++ b/benchmark/utils.go
@@ -20,6 +20,7 @@ import (
 	"encoding/csv"
 	"errors"
 	"os"
+	"os/exec"
 )
 
 type ImageDescriptor struct {
@@ -54,4 +55,13 @@ func GetImageListFromCsv(csvLoc string) ([]ImageDescriptor, error) {
 			SociIndexManifestRef: sociIndexManifestRef})
 	}
 	return images, nil
+}
+
+func getCommitHash() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
 }

--- a/docs/build.md
+++ b/docs/build.md
@@ -91,9 +91,8 @@ can run these tests using the following `Makefile` targets:
 
 - `make test`: run all unit tests.
 - `make integration`: run all integration tests.
-- `make benchmarks` (experimental): run all benchmark tests. This requires some
-setup and preparation for public images with SOCI index which are used for benchmarking.
-It is tracked in [#245](https://github.com/awslabs/soci-snapshotter/issues/245).
+- `make benchmarks`: run all benchmark tests. Runs the benchmark tests on a set of publicly hosted images. Output results are available in the ouptut folder within the comparisonTest and performanceTest subfolders.
+- `make build-benchmarks`: generate benchmark binaries of perfomance and comparision Tests. The binaries are available for use within the benchmanrk/bin directory. Use `-f`, `-count`,`show-commit` flags to customize the benchmark test.
 
 To speed up develop-test cycle, you can run individual test(s) by utilizing `go test`'s
 `-run` flag. For example, suppose you only want to run a test named `TestFooBar`, you can:


### PR DESCRIPTION
This commit adds three new cli flags to the perfomanceTest and comparisionTests of the benchmark frame work. It also adds default workloads into the binary itself.

- -count allows users to specify the number of runs the benchmark should run
- -show-commit will tag the current commit hash of the soci project to the benchmark results 
- -f accepts a path to the csv file describing custom image details to run the benchmarker on

**Issue #, if available:**

**Description of changes:**
- Added GetDefaultWorkloads() function to utils.go provides hardcoded workloads to the benchmark framework
- Added flags to the main functions of comparison and performance tests

**Testing performed:**
- Verified that the benchmarker runs on default workloads without having to provide any config files
- Verified that the benchmark tests can be customized through the use of flags



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
