### PR TITLE
Replace fmt.Sprintf's with strconv.Format's

### DIFF
--- a/fs/remote/blob_test.go
+++ b/fs/remote/blob_test.go
@@ -383,7 +383,7 @@ func (c *callsCountRoundTripper) RoundTrip(req *http.Request) (res *http.Respons
 	time.Sleep(50 * time.Millisecond) // sleep for 50 milliseconds to emulate the http call and to make sure that we can run tests on parallel goroutines
 	convertBody := func(r io.ReadCloser) io.ReadCloser { return r }
 	header := make(http.Header)
-	header.Add("Content-Length", fmt.Sprintf("%d", len(c.content)))
+	header.Add("Content-Length", strconv.FormatInt(int64(len(c.content)), 10))
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     header,
@@ -477,7 +477,7 @@ func multiRoundTripper(t *testing.T, contents []byte, opts ...interface{}) Round
 			if max >= int64(len(contents)-1) && !sparse {
 				t.Logf("serving whole range %q = %d", ranges, len(contents))
 				header := make(http.Header)
-				header.Add("Content-Length", fmt.Sprintf("%d", len(contents)))
+				header.Add("Content-Length", strconv.FormatInt(int64(len(contents)), 10))
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     header,
@@ -501,7 +501,7 @@ func multiRoundTripper(t *testing.T, contents []byte, opts ...interface{}) Round
 				}
 			}
 			header := make(http.Header)
-			header.Add("Content-Length", fmt.Sprintf("%d", target.size()))
+			header.Add("Content-Length", strconv.FormatInt(target.size(), 10))
 			header.Add("Content-Range",
 				fmt.Sprintf("bytes %d-%d/%d", target.b, target.e, len(contents)))
 			header.Add("Content-Type", "application/octet-stream")

--- a/fs/source/source.go
+++ b/fs/source/source.go
@@ -183,7 +183,7 @@ func AppendDefaultLabelsHandlerWrapper(indexDigest string, wrapper func(images.H
 							c.Annotations = make(map[string]string)
 						}
 
-						c.Annotations[TargetSizeLabel] = fmt.Sprintf("%d", c.Size)
+						c.Annotations[TargetSizeLabel] = strconv.FormatInt(c.Size, 10)
 						c.Annotations[TargetSociIndexDigestLabel] = indexDigest
 
 						remainingLayerDigestsCount := len(strings.Split(c.Annotations[ctdsnapshotters.TargetImageLayersLabel], ","))

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"strconv"
 
 	"github.com/awslabs/soci-snapshotter/cache"
 	"github.com/awslabs/soci-snapshotter/ztoc"
@@ -374,7 +375,7 @@ func (m *SpanManager) uncompressSpan(s *span, compressedBuf []byte) ([]byte, err
 // addSpanToCache adds contents of the span to the cache.
 // A non-nil error is returned if the data is not written to the cache.
 func (m *SpanManager) addSpanToCache(spanID compression.SpanID, contents []byte, opts ...cache.Option) error {
-	w, err := m.cache.Add(fmt.Sprintf("%d", spanID), opts...)
+	w, err := m.cache.Add(strconv.FormatInt(int64(spanID), 10), opts...)
 	if err != nil {
 		return err
 	}
@@ -394,7 +395,7 @@ func (m *SpanManager) addSpanToCache(spanID compression.SpanID, contents []byte,
 // `offset` is the offset of the requested contents within the span.
 // `size` is the size of the requested contents.
 func (m *SpanManager) getSpanFromCache(spanID compression.SpanID, offset, size compression.Offset) (io.Reader, error) {
-	r, err := m.cache.Get(fmt.Sprintf("%d", spanID))
+	r, err := m.cache.Get(strconv.FormatInt(int64(spanID), 10))
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrSpanNotAvailable, err)
 	}

--- a/integration/util_soci_test.go
+++ b/integration/util_soci_test.go
@@ -36,6 +36,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/awslabs/soci-snapshotter/config"
@@ -140,8 +141,8 @@ func buildIndex(sh *shell.Shell, src imageInfo, opt ...indexBuildOption) string 
 		"--namespace", indexBuildConfig.namespace,
 		"--content-store", string(indexBuildConfig.contentStoreType),
 		"create", src.ref,
-		"--min-layer-size", fmt.Sprintf("%d", indexBuildConfig.minLayerSize),
-		"--span-size", fmt.Sprintf("%d", indexBuildConfig.spanSize),
+		"--min-layer-size", strconv.FormatInt(indexBuildConfig.minLayerSize, 10),
+		"--span-size", strconv.FormatInt(indexBuildConfig.minLayerSize, 10),
 		"--platform", platforms.Format(src.platform),
 	}
 

--- a/util/testutil/shell.go
+++ b/util/testutil/shell.go
@@ -356,7 +356,7 @@ func KillMatchingProcess(sh *shell.Shell, psLinePattern string) error {
 
 	var allErr error
 	for _, pid := range targets {
-		if err := sh.Command("kill", "-9", fmt.Sprintf("%d", pid)).Run(); err != nil {
+		if err := sh.Command("kill", "-9", strconv.FormatInt(int64(pid), 10)).Run(); err != nil {
 			multierror.Append(allErr, fmt.Errorf("failed to kill %v: %w", pid, err))
 		}
 	}


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Non-functional (performance)

Replaces usage of `fmt.Sprintf` for itoa to builtin `strconv.Format`.

**Testing performed:**
```
var numToConvert uint = 100000000

func BenchmarkFmt(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = fmt.Sprintf("%d", numToConvert)
	}
}

func BenchmarkStrconv(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = strconv.FormatUint(uint64(numToConvert), 10)
	}
}
```

```
BenchmarkFmt-8           7690650               154.8 ns/op
BenchmarkStrconv-8      21786693                53.33 ns/op
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
