### PR TITLE
Fix label size mismatch edgecase

### DIFF
--- a/fs/source/source.go
+++ b/fs/source/source.go
@@ -184,8 +184,15 @@ func AppendDefaultLabelsHandlerWrapper(indexDigest string, wrapper func(images.H
 						c.Annotations[TargetSizeLabel] = fmt.Sprintf("%d", c.Size)
 						c.Annotations[TargetSociIndexDigestLabel] = indexDigest
 
+						remainingLayerDigestsCount := len(strings.Split(c.Annotations[ctdsnapshotters.TargetImageLayersLabel], ","))
+
 						var layerSizes string
-						for _, l := range children[i:] {
+						/*
+							We must ensure that the counts of layer sizes and layer digests are equal.
+							We will limit the # of neighboring label sizes to equal the # of neighboring
+							ayer digests for any given layer.
+						*/
+						for _, l := range children[i : i+remainingLayerDigestsCount] {
 							if images.IsLayerType(l.MediaType) {
 								ls := fmt.Sprintf("%d,", l.Size)
 								// This avoids the label hits the size limitation.


### PR DESCRIPTION
containerd provides the ability to append several different labels to every layer in an image. [One of these labels](https://github.com/containerd/containerd/blob/main/pkg/snapshotters/annotations.go#L44) contain the digests of all the neighboring layers of a layer. The SOCI client utilizes this ability and also adds additional, SOCI specific, metadata to each layer [one of which contains the sizes](https://github.com/awslabs/soci-snapshotter/blob/main/fs/source/source.go#L86) of all the neighboring layers. Before adding such labels containerd performs a [validation](https://github.com/containerd/containerd/blob/main/labels/validate.go#L32) to make sure that the length of a label is less than 4 KiB. This means that there can be a scenario in which an image with alot layers can cause the size of the neighboring layer digests label to be > 4 KiB in size causing it to be truncated to conform to the label validation constraint. At the same time, the label containing the neighboring layer sizes can remain under the 4 KiB threshold and thus not be truncated, since layer sizes are always smaller than length of digests. This can cause a mismatch in the cardinality of these labels, causing the snapshotter to fallback to containerd which by default begins [pre-fetching all remaining layers](https://github.com/containerd/containerd/blob/main/pkg/unpack/unpacker.go#L352-L367), and we end up losing the benefit of lazy loading.

**Issue #, if available:**

**Description of changes:**

Limit the size of `targetImageLayersSizeLabel` to be equal to the size of `TargetImageLayersLabel` when appending additional info.

**Testing performed:**

I created an image with 59 layers, enough to trigger the `TargetImageLayersLabel` overflow.

```bash

# Without fix

$ soci image rpull <ACCOUNT_ID>.dkr.ecr.us-west-2.amazonaws.com/alot_of_layers:latest
fetching sha256:232d77aa... application/vnd.docker.distribution.manifest.v2+json
fetching sha256:c4706233... application/vnd.docker.container.image.v1+json
fetching sha256:3f94e4e4... application/vnd.docker.image.rootfs.diff.tar.gzip
fetching sha256:db57c9c4... application/vnd.docker.image.rootfs.diff.tar.gzip
fetching sha256:9a805df3... application/vnd.docker.image.rootfs.diff.tar.gzip
fetching sha256:5772356f... application/vnd.docker.image.rootfs.diff.tar.gzip
fetching sha256:e5a9e889... application/vnd.docker.image.rootfs.diff.tar.gzip
fetching sha256:0988b461... application/vnd.docker.image.rootfs.diff.tar.gzip
fetching sha256:a4754374... application/vnd.docker.image.rootfs.diff.tar.gzip
....

# With fix

$ soci image rpull <ACCOUNT_ID>.dkr.ecr.us-west-2.amazonaws.com/alot_of_layers:latest

fetching sha256:232d77aa... application/vnd.docker.distribution.manifest.v2+json
fetching sha256:c4706233... application/vnd.docker.container.image.v1+json

$ mount | grep soci
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs type fuse.rawBridge (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=131072)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/2/fs type fuse.rawBridge (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=131072)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/3/fs type fuse.rawBridge (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=131072)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/4/fs type fuse.rawBridge (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=131072)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/5/fs type fuse.rawBridge (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=131072)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/6/fs type fuse.rawBridge (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=131072)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/7/fs type fuse.rawBridge (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=131072)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/8/fs type fuse.rawBridge (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=131072)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/9/fs type fuse.rawBridge (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=131072)
soci on /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/10/fs type fuse.rawBridge (rw,nosuid,nodev,relatime,user_id=0,group_id=0,allow_other,max_read=131072)
....

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
