### PR TITLE
Add support for containerd content store

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -23,9 +23,9 @@ import (
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
 	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/urfave/cli"
-	"oras.land/oras-go/v2/content/oci"
 )
 
 const (
@@ -85,7 +85,8 @@ var CreateCommand = cli.Command{
 		} else if err != nil {
 			return err
 		}
-		blobStore, err := oci.New(config.SociContentStorePath)
+
+		ctx, blobStore, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/index.go
+++ b/cmd/soci/commands/index/index.go
@@ -16,7 +16,9 @@
 
 package index
 
-import "github.com/urfave/cli"
+import (
+	"github.com/urfave/cli"
+)
 
 var Command = cli.Command{
 	Name:  "index",

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -26,16 +26,15 @@ import (
 	"strings"
 
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
-	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/fs"
 	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/reference"
 	dockercliconfig "github.com/docker/cli/cli/config"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
 	oraslib "oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content/oci"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
@@ -133,9 +132,9 @@ if they are available in the snapshotter's local content store.
 			}, nil
 		}
 
-		src, err := oci.New(config.SociContentStorePath)
+		ctx, src, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
 		if err != nil {
-			return fmt.Errorf("cannot create OCI local store: %w", err)
+			return fmt.Errorf("cannot create local content store: %w", err)
 		}
 
 		dst.Client = authClient

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -23,15 +23,14 @@ import (
 	"io"
 	"os"
 
-	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/awslabs/soci-snapshotter/ztoc"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/content"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
-	"oras.land/oras-go/v2/content/oci"
 )
 
 var getFileCommand = cli.Command{
@@ -61,7 +60,7 @@ var getFileCommand = cli.Command{
 		}
 		defer cancel()
 
-		toc, err := getZtoc(ctx, ztocDigest)
+		toc, err := getZtoc(ctx, cliContext, ztocDigest)
 		if err != nil {
 			return err
 		}
@@ -87,8 +86,8 @@ var getFileCommand = cli.Command{
 	},
 }
 
-func getZtoc(ctx context.Context, d digest.Digest) (*ztoc.Ztoc, error) {
-	blobStore, err := oci.New(config.SociContentStorePath)
+func getZtoc(ctx context.Context, cliContext *cli.Context, d digest.Digest) (*ztoc.Ztoc, error) {
+	ctx, blobStore, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/soci/commands/ztoc/list.go
+++ b/cmd/soci/commands/ztoc/list.go
@@ -46,6 +46,10 @@ var listCommand = cli.Command{
 			Name:  "verbose, v",
 			Usage: "display extra debugging messages",
 		},
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "only display the index digests",
+		},
 	},
 	Action: func(cliContext *cli.Context) error {
 		db, err := soci.NewDB(soci.ArtifactsDbPath())
@@ -55,6 +59,7 @@ var listCommand = cli.Command{
 		ztocDgst := cliContext.String("ztoc-digest")
 		imgRef := cliContext.String("image-ref")
 		verbose := cliContext.Bool("verbose")
+		quiet := cliContext.Bool("quiet")
 
 		var artifacts []*soci.ArtifactEntry
 		if imgRef == "" {
@@ -118,6 +123,13 @@ var listCommand = cli.Command{
 			if ztocDgst != "" && len(artifacts) == 0 {
 				return fmt.Errorf("the specified ztoc doesn't exist or it's not with the specified image")
 			}
+		}
+
+		if quiet {
+			for _, ae := range artifacts {
+				os.Stdout.Write([]byte(fmt.Sprintf("%s\n", ae.Digest)))
+			}
+			return nil
 		}
 
 		writer := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)

--- a/cmd/soci/main.go
+++ b/cmd/soci/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/image"
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/index"
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/ztoc"
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/version"
 	"github.com/containerd/containerd/cmd/ctr/commands/run"
 	"github.com/containerd/containerd/defaults"
@@ -78,6 +79,11 @@ func main() {
 		cli.BoolFlag{
 			Name:  "debug",
 			Usage: "enable debug output",
+		},
+		cli.StringFlag{
+			Name:  "content-store",
+			Usage: "use a specific content store (soci or containerd)",
+			Value: config.DefaultContentStoreType,
 		},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -46,9 +46,6 @@ import (
 )
 
 const (
-	// Default path to OCI-compliant CAS
-	SociContentStorePath = "/var/lib/soci-snapshotter-grpc/content/"
-
 	// Default path to snapshotter root dir
 	SociSnapshotterRootPath = "/var/lib/soci-snapshotter-grpc/"
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -45,7 +45,7 @@ const (
 
 // ServiceConfig defaults
 const (
-	defaultImageServiceAddress = "/run/containerd/containerd.sock"
+	DefaultImageServiceAddress = "/run/containerd/containerd.sock"
 )
 
 // FSConfig defaults
@@ -93,4 +93,7 @@ const (
 	defaultMinWaitMsec = 30
 	// defaultMaxWaitMsec is the default maximum number of milliseconds between attempts. See `RetryConfig.MaxWait`.
 	defaultMaxWaitMsec = 300_000
+
+	// DefaultContentStore chooses the soci or containerd content store as the default
+	DefaultContentStoreType = "soci"
 )

--- a/config/service.go
+++ b/config/service.go
@@ -81,6 +81,6 @@ type SnapshotterConfig struct {
 
 func parseServiceConfig(cfg *Config) {
 	if cfg.CRIKeychainConfig.ImageServicePath == "" {
-		cfg.CRIKeychainConfig.ImageServicePath = defaultImageServiceAddress
+		cfg.CRIKeychainConfig.ImageServicePath = DefaultImageServiceAddress
 	}
 }

--- a/fs/remote/resolver_test.go
+++ b/fs/remote/resolver_test.go
@@ -45,6 +45,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -65,9 +66,8 @@ func TestMirror(t *testing.T) {
 	}
 	var (
 		blobDigest = digest.FromString("dummy")
-		blobPath   = fmt.Sprintf("/v2/%s/blobs/%s",
-			strings.TrimPrefix(refspec.Locator, refspec.Hostname()+"/"), blobDigest.String())
-		refHost = refspec.Hostname()
+		blobPath   = filepath.Join("/v2", strings.TrimPrefix(refspec.Locator, refspec.Hostname()+"/"), "blobs", blobDigest.String())
+		refHost    = refspec.Hostname()
 	)
 
 	tests := []struct {

--- a/soci/store/store.go
+++ b/soci/store/store.go
@@ -1,0 +1,335 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/errdef"
+)
+
+// BasicStore describes the functionality common to oras-go oci.Store, oras-go memory.Store, and containerd ContentStore.
+type BasicStore interface {
+	Exists(ctx context.Context, target ocispec.Descriptor) (bool, error)
+	Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error)
+	Push(ctx context.Context, expected ocispec.Descriptor, reader io.Reader) error
+}
+
+// Store extends BasicStore with functionality that in not present in some BasicStore
+// implementations and may be stubbed in some Store implementations
+type Store interface {
+	BasicStore
+	Label(ctx context.Context, target ocispec.Descriptor, label string, value string) error
+	Delete(ctx context.Context, dgst digest.Digest) error
+	// BatchOpen starts a series of operations that should not be interrupted by garbage collection.
+	// It returns a cleanup function that ends the batch, which should be called after
+	// all associated content operations are finished.
+	BatchOpen(ctx context.Context) (context.Context, CleanupFunc, error)
+}
+
+type ContentStoreType string
+
+const (
+	ContainerdContentStoreType ContentStoreType = "containerd"
+	SociContentStoreType       ContentStoreType = "soci"
+)
+
+// ContentStoreTypes returns a slice of all supported content store types.
+func ContentStoreTypes() []ContentStoreType {
+	return []ContentStoreType{SociContentStoreType, ContainerdContentStoreType}
+}
+
+const (
+	// Default path to containerd content addressable storage
+	DefaultContainerdContentStorePath = "/var/lib/containerd/io.containerd.content.v1.content"
+
+	// Default path to soci content addressable storage
+	DefaultSociContentStorePath = "/var/lib/soci-snapshotter-grpc/content"
+)
+
+func NewStoreConfig(opts ...Option) config.ContentStoreConfig {
+	storeConfig := config.ContentStoreConfig{
+		Type:      config.DefaultContentStoreType,
+		Namespace: namespaces.Default,
+	}
+	for _, o := range opts {
+		o(&storeConfig)
+	}
+	return storeConfig
+}
+
+type Option func(*config.ContentStoreConfig)
+
+func WithNamespace(namespace string) Option {
+	return func(sc *config.ContentStoreConfig) {
+		sc.Namespace = namespace
+	}
+}
+
+func WithType(contentStoreType ContentStoreType) Option {
+	return func(sc *config.ContentStoreConfig) {
+		sc.Type = string(contentStoreType)
+	}
+}
+
+func ErrUnknownContentStoreType(contentStoreType ContentStoreType) error {
+	return fmt.Errorf("unknown content store type: %s; must be one of %s or %s",
+		contentStoreType, ContainerdContentStoreType, SociContentStoreType)
+}
+
+// CanonicalizeContentStoreType resolves the empty string to DefaultContentStoreType,
+// returns other types, or errors on unrecognized types.
+func CanonicalizeContentStoreType(contentStoreType ContentStoreType) (ContentStoreType, error) {
+	switch contentStoreType {
+	case "":
+		return config.DefaultContentStoreType, nil
+	case ContainerdContentStoreType, SociContentStoreType:
+		return contentStoreType, nil
+	default:
+		return "", ErrUnknownContentStoreType(contentStoreType)
+	}
+}
+
+// GetContentStorePath returns the top level directory for the content store.
+func GetContentStorePath(contentStoreType ContentStoreType) (string, error) {
+	contentStoreType, err := CanonicalizeContentStoreType(contentStoreType)
+	if err != nil {
+		return "", err
+	}
+	switch contentStoreType {
+	case ContainerdContentStoreType:
+		return DefaultContainerdContentStorePath, nil
+	case SociContentStoreType:
+		return DefaultSociContentStorePath, nil
+	}
+	return "", errors.New("unexpectedly reached end of GetContentStorePath")
+}
+
+type CleanupFunc func(context.Context) error
+
+func nopCleanup(context.Context) error { return nil }
+
+func NewContentStore(ctx context.Context, opts ...Option) (context.Context, Store, error) {
+	storeConfig := NewStoreConfig(opts...)
+
+	contentStoreType, err := CanonicalizeContentStoreType(ContentStoreType(storeConfig.Type))
+	if err != nil {
+		return ctx, nil, err
+	}
+	switch contentStoreType {
+	case ContainerdContentStoreType:
+		return NewContainerdStore(ctx, storeConfig)
+	case SociContentStoreType:
+		return NewSociStore(ctx)
+	}
+	return ctx, nil, errors.New("unexpectedly reached end of NewContentStore")
+}
+
+// SociStore wraps oci.Store and adds or stubs additional functionality of the Store interface.
+type SociStore struct {
+	*oci.Store
+}
+
+// assert that SociStore implements Store
+var _ Store = (*SociStore)(nil)
+
+// NewSociStore creates a sociStore.
+func NewSociStore(ctx context.Context) (context.Context, *SociStore, error) {
+	store, err := oci.New(DefaultSociContentStorePath)
+	return ctx, &SociStore{store}, err
+}
+
+// Label is a no-op for sociStore until sociStore and ArtifactsDb are better integrated.
+func (s *SociStore) Label(_ context.Context, _ ocispec.Descriptor, _ string, _ string) error {
+	return nil
+}
+
+// Delete is a no-op for sociStore until oci.Store provides this method.
+func (s *SociStore) Delete(_ context.Context, _ digest.Digest) error {
+	return nil
+}
+
+// BatchOpen is a no-op for sociStore; it does not support batching operations.
+func (s *SociStore) BatchOpen(ctx context.Context) (context.Context, CleanupFunc, error) {
+	return ctx, nopCleanup, nil
+}
+
+type ContainerdStore struct {
+	config.ContentStoreConfig
+	client *containerd.Client
+}
+
+// assert that ContainerdStore implements Store
+var _ Store = (*ContainerdStore)(nil)
+
+func NewContainerdStore(ctx context.Context, storeConfig config.ContentStoreConfig) (context.Context, *ContainerdStore, error) {
+	client, err := containerd.New(config.DefaultImageServiceAddress)
+	if err != nil {
+		return ctx, nil, fmt.Errorf("could not connect to containerd socket for content store access: %w", err)
+	}
+
+	ctx = namespaces.WithNamespace(ctx, storeConfig.Namespace)
+
+	containerdStore := ContainerdStore{
+		client: client,
+	}
+
+	containerdStore.ContentStoreConfig = storeConfig
+
+	return ctx, &containerdStore, nil
+}
+
+// Exists returns true iff the described content exists.
+func (s *ContainerdStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	ctx = namespaces.WithNamespace(ctx, s.Namespace)
+	cs := s.client.ContentStore()
+	_, err := cs.Info(ctx, target.Digest)
+	if errors.Is(err, errdefs.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+type sectionReaderAt struct {
+	content.ReaderAt
+	*io.SectionReader
+}
+
+// Fetch fetches the content identified by the descriptor.
+func (s *ContainerdStore) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
+	ctx = namespaces.WithNamespace(ctx, s.Namespace)
+	cs := s.client.ContentStore()
+	ra, err := cs.ReaderAt(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	return sectionReaderAt{ra, io.NewSectionReader(ra, 0, ra.Size())}, nil
+}
+
+// Push pushes the content, matching the expected descriptor.
+// This should be done within a Batch and followed by Label calls to prevent garbage collection.
+func (s *ContainerdStore) Push(ctx context.Context, expected ocispec.Descriptor, reader io.Reader) error {
+	ctx = namespaces.WithNamespace(ctx, s.Namespace)
+	exists, err := s.Exists(ctx, expected)
+	if err != nil {
+		return err
+	}
+	if exists {
+		// error format based on oras.land/oras-go/v2/content/oci.Storage.Push()
+		return fmt.Errorf("%s: %s: %w", expected.Digest, expected.MediaType, errdef.ErrAlreadyExists)
+	}
+
+	cs := s.client.ContentStore()
+
+	// gRPC message size limit includes some overhead that cannot be calculated from here
+	buf := make([]byte, defaults.DefaultMaxRecvMsgSize/2)
+	totalWritten := 0
+	writer, err := cs.Writer(ctx, content.WithRef(expected.Digest.String()))
+	if err != nil {
+		return err
+	}
+	defer writer.Close()
+
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			written, err := writer.Write(buf[:n])
+			if err != nil {
+				return err
+			}
+			totalWritten += written
+		}
+		if err != nil {
+			if err != io.EOF {
+				return err
+			}
+			break
+		}
+		if n == 0 {
+			break
+		}
+	}
+
+	if expected.Size > 0 && expected.Size != int64(totalWritten) {
+		return fmt.Errorf("unexpected copy size %d, expected %d: %w", totalWritten, expected.Size, errdefs.ErrFailedPrecondition)
+	}
+
+	return writer.Commit(ctx, expected.Size, expected.Digest)
+}
+
+// LabelGCRoot labels the target resource to prevent garbage collection of itself.
+func LabelGCRoot(ctx context.Context, store Store, target ocispec.Descriptor) error {
+	return store.Label(ctx, target, "containerd.io/gc.root", time.Now().Format(time.RFC3339))
+}
+
+// LabelGCRefContent labels the target resource to prevent garbage collection of another resource identified by digest
+// with an optional ref to allow and disambiguate multiple content labels.
+func LabelGCRefContent(ctx context.Context, store Store, target ocispec.Descriptor, ref string, digest string) error {
+	if len(ref) > 0 {
+		ref = "." + ref
+	}
+	return store.Label(ctx, target, "containerd.io/gc.ref.content"+ref, digest)
+}
+
+// Label creates or updates the named label with the given value.
+func (s *ContainerdStore) Label(ctx context.Context, target ocispec.Descriptor, name string, value string) error {
+	ctx = namespaces.WithNamespace(ctx, s.Namespace)
+	cs := s.client.ContentStore()
+	info := content.Info{
+		Digest: target.Digest,
+		Labels: map[string]string{name: value},
+	}
+	paths := []string{"labels." + name}
+	_, err := cs.Update(ctx, info, paths...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete removes the described content.
+func (s *ContainerdStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	ctx = namespaces.WithNamespace(ctx, s.Namespace)
+	cs := s.client.ContentStore()
+	return cs.Delete(ctx, dgst)
+}
+
+// BatchOpen creates a lease, ensuring that no content created within the batch will be garbage collected.
+// It returns a cleanup function that ends the lease, which should be called after content is created and labeled.
+func (s *ContainerdStore) BatchOpen(ctx context.Context) (context.Context, CleanupFunc, error) {
+	ctx, leaseDone, err := s.client.WithLease(ctx)
+	if err != nil {
+		return ctx, nopCleanup, fmt.Errorf("unable to open batch: %w", err)
+	}
+	return ctx, leaseDone, nil
+}

--- a/soci/store/store_test.go
+++ b/soci/store/store_test.go
@@ -1,0 +1,187 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+func TestStoreCanonicalizeContentStoreType(t *testing.T) {
+	tests := []struct {
+		input  string
+		output ContentStoreType
+		fail   bool
+	}{
+		{
+			input:  "",
+			output: config.DefaultContentStoreType,
+		},
+		{
+			input:  "soci",
+			output: SociContentStoreType,
+		},
+		{
+			input:  "containerd",
+			output: ContainerdContentStoreType,
+		},
+		{
+			input: "bad",
+			fail:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			output, err := CanonicalizeContentStoreType(ContentStoreType(tt.input))
+			if err != nil {
+				if !tt.fail {
+					t.Fatalf("content store type \"%s\" canonicalized to \"%s\" and produced unexpected error %v", tt.input, output, err)
+				}
+			} else {
+				if tt.output != output {
+					t.Fatalf("content store type \"%s\" canonicalized to \"%s\", expected %s", tt.input, output, tt.output)
+				}
+			}
+		})
+	}
+
+}
+
+func TestStoreGetContentStorePath(t *testing.T) {
+	var defaultContentStorePath string
+	switch ContentStoreType(config.DefaultContentStoreType) {
+	case SociContentStoreType:
+		defaultContentStorePath = DefaultSociContentStorePath
+	case ContainerdContentStoreType:
+		defaultContentStorePath = DefaultContainerdContentStorePath
+	default:
+		t.Fatalf("test invalidated by unrecognized default content store type: %s", config.DefaultContentStoreType)
+	}
+
+	tests := []struct {
+		input  string
+		output string
+		fail   bool
+	}{
+		{
+			input:  "",
+			output: defaultContentStorePath,
+		},
+		{
+			input:  "soci",
+			output: DefaultSociContentStorePath,
+		},
+		{
+			input:  "containerd",
+			output: DefaultContainerdContentStorePath,
+		},
+		{
+			input: "bad",
+			fail:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			output, err := GetContentStorePath(ContentStoreType(tt.input))
+			if err != nil {
+				if !tt.fail {
+					t.Fatalf("content store type \"%s\" produced path %s with unexpected error %v", tt.input, output, err)
+				}
+			} else {
+				if tt.output != output {
+					t.Fatalf("content store type \"%s\" produced path %s, expected %s", tt.input, output, tt.output)
+				}
+			}
+		})
+	}
+
+}
+
+type fakeStore struct {
+	*memory.Store
+	Labels  [][]string
+	Deleted []string
+}
+
+// assert that FakeStore implements Store
+var _ Store = (*fakeStore)(nil)
+
+func newFakeStore() *fakeStore {
+	fakeStore := fakeStore{}
+	fakeStore.Store = memory.New()
+	return &fakeStore
+}
+
+// TODO read and record namespace from context
+// Label fakes labeling resources by maintaining an array of labels that have been added
+func (s *fakeStore) Label(_ context.Context, desc ocispec.Descriptor, name string, value string) error {
+	s.Labels = append(s.Labels, []string{desc.Digest.String(), name, value})
+	return nil
+}
+
+// Delete fakes deleting resources by maintaining an array of resources that have been "deleted"
+func (s *fakeStore) Delete(_ context.Context, dgst digest.Digest) error {
+	s.Deleted = append(s.Deleted, dgst.String())
+	return nil
+}
+
+// BatchOpen is a TODO to mock and test
+func (s *fakeStore) BatchOpen(ctx context.Context) (context.Context, CleanupFunc, error) {
+	return ctx, func(context.Context) error { return nil }, nil
+}
+
+func TestStoreLabelGCRoot(t *testing.T) {
+	store := newFakeStore()
+	testTarget, _ := digest.Parse("sha256:7b236f6c6ca259a4497e98c204bc1dcf3e653438e74af17bfe39da5329789f4a")
+	LabelGCRoot(context.Background(), store, ocispec.Descriptor{Digest: testTarget})
+	if len(store.Labels) != 1 {
+		t.Fatalf("wrong number of labels applied, expected 1, got %d", len(store.Labels))
+	}
+	if store.Labels[0][0] != testTarget.String() {
+		t.Fatalf("label applied to wrong digest, expected \"%s\", got \"%s\"", testTarget.String(), store.Labels[0][0])
+	}
+	if store.Labels[0][1] != "containerd.io/gc.root" {
+		t.Fatalf("label applied with wrong name, expected \"containerd.io/gc.root\", got \"%s\"", store.Labels[0][1])
+	}
+}
+
+func TestStoreLabelGCRefContent(t *testing.T) {
+	store := newFakeStore()
+	testTarget, _ := digest.Parse("sha256:7b236f6c6ca259a4497e98c204bc1dcf3e653438e74af17bfe39da5329789f4a")
+	testRef := "testRef"
+	testDigest, _ := digest.Parse("sha256:4452aadba3e99771ff3559735dab16279c5a352359d79f38737c6fdca941c6e5")
+	LabelGCRefContent(context.Background(), store, ocispec.Descriptor{Digest: testTarget}, testRef, testDigest.String())
+	if len(store.Labels) != 1 {
+		t.Fatalf("wrong number of labels applied, expected 1, got %d", len(store.Labels))
+	}
+	if store.Labels[0][0] != testTarget.String() {
+		t.Fatalf("label applied to wrong digest, expected \"%s\", got \"%s\"", testTarget.String(), store.Labels[0][0])
+	}
+	if store.Labels[0][1] != "containerd.io/gc.ref.content."+testRef {
+		t.Fatalf("label applied with wrong name, expected \"containerd.io/gc.ref.content."+testRef+"\", got \"%s\"", store.Labels[0][1])
+	}
+	if store.Labels[0][2] != testDigest.String() {
+		t.Fatalf("label references wrong digest, expected \"%s\", got \"%s\"", testDigest.String(), store.Labels[0][2])
+	}
+}

--- a/util/testutil/store.go
+++ b/util/testutil/store.go
@@ -1,0 +1,48 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package testutil
+
+import (
+	"path/filepath"
+
+	"github.com/awslabs/soci-snapshotter/soci/store"
+)
+
+// GetContentStoreBlobPath returns the bottom level directory for the content store, e.g. "/blobs/sha256".
+func GetContentStoreBlobPath(contentStoreType store.ContentStoreType) (string, error) {
+	contentStorePath, err := store.GetContentStorePath(contentStoreType)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(contentStorePath, "blobs", "sha256"), nil
+}


### PR DESCRIPTION
**Issue #, if available:**
Closes #423 

**Description of changes:**
This PR adds support for storing SOCI artifacts in the containerd content store (usually found on disk at `/var/lib/containerd/io.containerd.content.v1.content`). This support is optional, enabled for the cli via `soci --namespace foo ...` and for the snapshotter via the following config:
```
[content_store]
type = "containerd"
```

Both places also take a `namespace` parameter, which is passed on and honored by containerd, but soci's ArtifactsDB doesn't understand or honor namespaces so commands like `soci index list` also will not.

This feature adds a dependency on a running containerd service for most `soci` CLI operations and also access to content by `soci-snapshotter-grpc`.

Support for multiple content stores is accomplished by abstracting to a new `store.Store` interface, for which there are two implementations, one wrapping the prior use of the OCI content store, the other wrapping the use of containerd's content store via the GRPC api. Similar abstraction was also required for integration tests and helpers that perform behind-the-scenes access to the content store in order to test content functionality.

Most tests still run on the default content store, which is soci for now, but some integration tests run on both stores to verify functionality of the new store:
- TestSociCreate/test_create_for_drupal
- TestOptimizeConsistentSociArtifact
- TestRebuildArtifactsDB
- TestOverlayFallbackMetric

This implementation is optional and non-default. The primary reason behind this is uncertainty regarding potential database deadlocks. When containerd is communicating with the soci snapshotter, that may happen within a write lock of the underlying metadata and content store database. If soci then attempts to write content into the content store, that would block and deadlock. Further research and investigation into why this is not happening is required before stating that this feature is certainly safe.

**Testing performed:**
`make test`, `make integration`, both including new tests, and also separately both with the default store set to containerd.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
