### PR TITLE
Set TARGETARCH as a build ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ FROM golang-base AS containerd-snapshotter-base
 ARG CONTAINERD_VERSION
 ARG RUNC_VERSION
 ARG NERDCTL_VERSION
+ARG TARGETARCH
 COPY . $GOPATH/src/github.com/awslabs/soci-snapshotter
 ENV GOPROXY direct
 RUN apt-get update -y && apt-get install -y libbtrfs-dev libseccomp-dev libz-dev gcc fuse pigz


### PR DESCRIPTION
Since we are using `TARGETARCH` inside of our build stage it is locally scoped, therefore we have to define it inside the stage. Otherwise, it will be undefined and we will always default to `amd64` which will obviously break our integration tests on other platforms.

**Issue #, if available:**

Part of: #696 

**Description of changes:**

**Testing performed:**

Run integration tests on arm

```
# Without fix

$ make integration
    shell.go:76: >>> Running(1/100): [ctr snapshots --snapshotter soci prepare connectiontest-dummy-cifemf4tkdpt93vht080 ]
OCI runtime exec failed: exec failed: unable to start container process: exec /usr/local/bin/ctr: exec format error: unknown

# With fix

$ make integration
[ctr snapshots --snapshotter soci prepare connectiontest-dummy-cifen2ktkdptu3mp9om0 ]
{"emitMetricPeriod":10000000000,"fetchPeriod":500000000,"level":"info","maxQueueSize":100,"msg":"constructing background fetcher","silencePeriod":30000000000,"time":"2023-06-30T14:49:46.830829476Z"}

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
