### PR TITLE
Encode random filename to avoid unprintable characters

### DIFF
--- a/integration/ztoc_test.go
+++ b/integration/ztoc_test.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -250,7 +251,7 @@ func TestSociZtocGetFile(t *testing.T) {
 
 	var (
 		tempOutputStream = "test.txt"
-		randomFile       = string(testutil.RandomByteData(10))
+		randomFile       = base64.StdEncoding.EncodeToString(testutil.RandomByteData(12))
 		randomZtocDigest = testutil.RandomDigest()
 	)
 


### PR DESCRIPTION
**Issue #, if available:**
Fixes #707

**Description of changes:**
Base64 encode the random bytes used for the filename argument to `soci ztoc get-file`

**Testing performed:**
`GO_TEST_FLAGS="-run=TestSociZtocGetFile -failfast -count=1" make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
