### PR TITLE
Revert removal of layer size fetch, conditional on size annotation unavailable

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -66,7 +66,6 @@ import (
 	rhttp "github.com/hashicorp/go-retryablehttp"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -336,13 +335,13 @@ func getLayerSize(ctx context.Context, hf *httpFetcher) (int64, error) {
 	// HEAD request (2020).
 	req, err = http.NewRequestWithContext(ctx, "GET", hf.url, nil)
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed to make request to the registry")
+		return 0, fmt.Errorf("failed to make request to the registry: %w", err)
 	}
 	req.Close = false
 	req.Header.Set("Range", "bytes=0-1")
 	res, err = hf.tr.RoundTrip(req)
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed to request")
+		return 0, fmt.Errorf("failed to request: %w", err)
 	}
 	defer func() {
 		io.Copy(io.Discard, res.Body)

--- a/fs/source/source.go
+++ b/fs/source/source.go
@@ -81,7 +81,7 @@ const (
 	// TargetSizeLabel is a label which contains layer size.
 	TargetSizeLabel = "containerd.io/snapshot/remote/soci.size"
 
-	// targetImageLayersSizeLabel is a label which contains layer digests contained in
+	// targetImageLayersSizeLabel is a label which contains layer sizes contained in
 	// the target image.
 	targetImageLayersSizeLabel = "containerd.io/snapshot/remote/image.layers.size"
 


### PR DESCRIPTION
**Issue #, if available:**
fixes #536

**Description of changes:**
Partial revert of https://github.com/awslabs/soci-snapshotter/commit/86ddfcdb2c521586177bf3c33eed7e7dcb516f86

When setting up `newHTTPFetcher`, if the descriptor Size is missing (due to the layer size annotation not being available for the layer) then run the previously-removed function to get the size from the remote host.

**Testing performed:**
Needs new integration test. PR is Draft until then.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
