### PR TITLE
added xattr flag when creating soci index

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -32,6 +32,7 @@ const (
 	buildToolIdentifier = "AWS SOCI CLI v0.1"
 	spanSizeFlag        = "span-size"
 	minLayerSizeFlag    = "min-layer-size"
+	xattrFlag           = "xattr-optimization"
 )
 
 // CreateCommand creates SOCI index for an image
@@ -54,6 +55,10 @@ var CreateCommand = cli.Command{
 			Usage: "Minimum layer size to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10 MiB.",
 			Value: 10 << 20,
 		},
+		cli.BoolFlag{
+			Name:  xattrFlag,
+			Usage: "If set to true layers without xattr will have xattr disabled, yielding a perfomrance benefit. Does not effect layers where is xattrs are present. Default is False.",
+		},
 	),
 	Action: func(cliContext *cli.Context) error {
 		srcRef := cliContext.Args().Get(0)
@@ -75,6 +80,7 @@ var CreateCommand = cli.Command{
 		}
 		spanSize := cliContext.Int64(spanSizeFlag)
 		minLayerSize := cliContext.Int64(minLayerSizeFlag)
+		xattr := cliContext.Bool(xattrFlag)
 		// Creating the snapshotter's root path first if it does not exist, since this ensures, that
 		// it has the limited permission set as drwx--x--x.
 		// The subsequent oci.New creates a root path dir with too broad permission set.
@@ -104,6 +110,7 @@ var CreateCommand = cli.Command{
 			soci.WithMinLayerSize(minLayerSize),
 			soci.WithSpanSize(spanSize),
 			soci.WithBuildToolIdentifier(buildToolIdentifier),
+			soci.WithXAttrOptimization(xattr),
 		}
 
 		for _, plat := range ps {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -502,6 +502,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		AllowOther: true,   // allow users other than root&mounter to access fs
 		FsName:     "soci", // name this filesystem as "soci"
 		Debug:      fs.debug,
+                DisableXAttrs: l.NoXAttr(),
 	}
 	if _, err := exec.LookPath(fusermountBin); err == nil {
 		mountOpts.Options = []string{"suid"} // option for fusermount; allow setuid inside container

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -45,6 +45,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+        "strconv"
 	"sync"
 	"time"
 
@@ -61,6 +62,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/metadata"
 	"github.com/awslabs/soci-snapshotter/util/lrucache"
 	"github.com/awslabs/soci-snapshotter/util/namedmutex"
+	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/ztoc"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
@@ -102,6 +104,9 @@ type Layer interface {
 
 	// ReadAt reads this layer.
 	ReadAt([]byte, int64, ...remote.Option) (int, error)
+
+        //True if none of the files in the layer has an xattr
+        NoXAttr() bool
 
 	// Done releases the reference to this layer. The resources related to this layer will be
 	// discarded sooner or later. Queries after calling this function won't be serviced.
@@ -338,9 +343,9 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 	if err != nil {
 		return nil, fmt.Errorf("failed to read layer: %w", err)
 	}
-
+        xattr :=  getXAttrAnnotation(sociDesc)
 	// Combine layer information together and cache it.
-	l := newLayer(r, desc, blobR, vr, bgLayerResolver, opCounter)
+	l := newLayer(r, desc, blobR, vr, bgLayerResolver, opCounter, xattr)
 	r.layerCacheMu.Lock()
 	cachedL, done2, added := r.layerCache.Add(name, l)
 	r.layerCacheMu.Unlock()
@@ -402,6 +407,7 @@ func newLayer(
 	vr *reader.VerifiableReader,
 	bgResolver backgroundfetcher.Resolver,
 	opCounter *FuseOperationCounter,
+        hasXAttr bool,
 ) *layer {
 	return &layer{
 		resolver:             resolver,
@@ -410,6 +416,7 @@ func newLayer(
 		verifiableReader:     vr,
 		bgResolver:           bgResolver,
 		fuseOperationCounter: opCounter,
+                hasXAttr: hasXAttr,
 	}
 }
 
@@ -424,6 +431,7 @@ type layer struct {
 	r reader.Reader
 
 	fuseOperationCounter *FuseOperationCounter
+        hasXAttr bool
 
 	closed   bool
 	closedMu sync.Mutex
@@ -492,6 +500,10 @@ func (l *layer) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, erro
 	return l.blob.ReadAt(p, offset, opts...)
 }
 
+func (l *layer) NoXAttr() bool {
+	return !l.hasXAttr
+}
+
 func (l *layer) close() error {
 	l.closedMu.Lock()
 	defer l.closedMu.Unlock()
@@ -515,6 +527,19 @@ func (l *layer) isClosed() bool {
 	closed := l.closed
 	l.closedMu.Unlock()
 	return closed
+}
+
+func getXAttrAnnotation(desc ocispec.Descriptor) bool {
+    stringVal, present := desc.Annotations[soci.IndexAnnotationXattrPresent]
+    if !present {
+        return false
+    }
+    val, err := strconv.ParseBool(stringVal)
+    if err != nil {
+        return false
+    }
+
+    return val
 }
 
 // blobRef is a reference to the blob in the cache. Calling `done` decreases the reference counter

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -51,9 +51,13 @@ const (
 	IndexAnnotationImageLayerDigest = "com.amazon.soci.image-layer-digest"
 	// IndexAnnotationBuildToolIdentifier is the index annotation for build tool identifier
 	IndexAnnotationBuildToolIdentifier = "com.amazon.soci.build-tool-identifier"
+	// IndexAnnotationXattrPresent is the index annotation if the layer has
+        // extended attributes
+	IndexAnnotationXattrPresent = "com.amazon.soci.xattr-present"
 
 	defaultSpanSize            = int64(1 << 22) // 4MiB
 	defaultMinLayerSize        = 10 << 20       // 10MiB
+	defaultXAttr               = false 
 	defaultBuildToolIdentifier = "AWS SOCI CLI v0.1"
 	// emptyJSONObjectDigest is the digest of the content "{}".
 	emptyJSONObjectDigest = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
@@ -203,6 +207,7 @@ type buildConfig struct {
 	buildToolIdentifier string
 	artifactsDb         *ArtifactsDb
 	platform            ocispec.Platform
+        xattr               bool
 }
 
 // BuildOption specifies a config change to build soci indices.
@@ -220,6 +225,14 @@ func WithSpanSize(spanSize int64) BuildOption {
 func WithMinLayerSize(minLayerSize int64) BuildOption {
 	return func(c *buildConfig) error {
 		c.minLayerSize = minLayerSize
+		return nil
+	}
+}
+
+// WithXAttr  
+func WithXAttrOptimization(xattr bool) BuildOption {
+	return func(c *buildConfig) error {
+		c.xattr = xattr
 		return nil
 	}
 }
@@ -265,6 +278,7 @@ func NewIndexBuilder(contentStore content.Store, blobStore orascontent.Storage, 
 		minLayerSize:        defaultMinLayerSize,
 		buildToolIdentifier: defaultBuildToolIdentifier,
 		platform:            defaultPlatform,
+		xattr:               defaultXAttr,
 	}
 
 	for _, opt := range opts {
@@ -457,6 +471,9 @@ func (b *IndexBuilder) buildSociLayer(ctx context.Context, desc ocispec.Descript
 		IndexAnnotationImageLayerMediaType: desc.MediaType,
 		IndexAnnotationImageLayerDigest:    desc.Digest.String(),
 	}
+        if b.config.xattr {
+            ztocDesc.Annotations[IndexAnnotationXattrPresent] = doesZtocHaveXattr(toc)
+        }
 	return &ztocDesc, err
 }
 
@@ -564,4 +581,14 @@ func WriteSociIndex(ctx context.Context, indexWithMetadata *IndexWithMetadata, s
 		CreatedAt:      indexWithMetadata.CreatedAt,
 	}
 	return artifactsDb.WriteArtifactEntry(entry)
+}
+
+func doesZtocHaveXattr(ztoc *ztoc.Ztoc) string {
+    for _, md := range ztoc.TOC.FileMetadata {
+        if len(md.Xattrs) > 0 {
+            return "true"
+        }
+    }
+
+    return "false"
 }


### PR DESCRIPTION
_DO NOT MERGE: Testing still needs to be added, but please feel free to review what is present_

### Why
The listxattr and getxattr fuse operations are quite costly, but the vast majority of files do not have any extended attributes.  Given this we can disable xattrs in the fuse file system.

### What
This PR does two main things:
1) Adds an option to build a soci index that knows at the layer level whether xattrs are present
2) Adds the ability to read this new field in the soci index and disable xattrs in the fuse file system if xattrs are not present in that layer.

**BUILDING THE INDEX**
This PR adds a new **xattr-optimization** flag to the create command (*cmd/soci/commands/create.go*).  This allows the user to opt into a new flow which checks if any files in a given layer have an xattr.  If none of the files have an xattr a new annotation is added to the soci index ocispec.  (*soci/soci_index.go*)

This new feature is turned off by default.

**DISABLING XATTRS IN FUSE**
When the layer is resolved it checks the ocispec for the new annotation (*fs/layer/layer.go*).  If not found it defaults to the original behavior.  This new information is exposed via a new function on the layer interface .  If the annotation indicates there are no xattrs present the fuse.MountOptions are updated to DisableXAttrs (*fs/fs.go*)

### Testing
_Still To Come_
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
