### PR TITLE
Add separate DCO workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,26 +19,6 @@ on:
       - 'scripts/**'
 
 jobs:
-  check:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          # check-dco will check the last 20 commits, but commit ranges
-          # exclude the start commit in the result, but need that commit
-          # in order to calculate the range. i.e. HEAD~20..HEAD includes
-          # 20 commits, but including HEAD it needs 21 commits.
-          fetch-depth: 21
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '1.18.10'
-      - run: wget https://github.com/google/flatbuffers/releases/download/v22.9.29/Linux.flatc.binary.g++-10.zip
-      - run: unzip Linux.flatc.binary.g++-10.zip
-      - run: ./scripts/install-check-tools.sh
-      - run: ./scripts/check-ltag.sh
-      - run: ./scripts/check-dco.sh
-      - run: ./scripts/check-lint.sh
-      - run: PATH=$PATH:$(pwd) ./scripts/check-flatc.sh
   test:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -1,0 +1,29 @@
+name: Pre-build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # check-dco will check the last 20 commits, but commit ranges
+          # exclude the start commit in the result, but need that commit
+          # in order to calculate the range. i.e. HEAD~20..HEAD includes
+          # 20 commits, but including HEAD it needs 21 commits.
+          fetch-depth: 21
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.18.10'
+      - run: wget https://github.com/google/flatbuffers/releases/download/v22.9.29/Linux.flatc.binary.g++-10.zip
+      - run: unzip Linux.flatc.binary.g++-10.zip
+      - run: ./scripts/install-check-tools.sh
+      - run: ./scripts/check-ltag.sh
+      - run: ./scripts/check-dco.sh
+      - run: ./scripts/check-lint.sh
+      - run: PATH=$PATH:$(pwd) ./scripts/check-flatc.sh


### PR DESCRIPTION
This commit adds a new workflow called 'prebuild' which contains the DCO and lint checks. The Dco check needs to run on every code change regardless of whether it is a documentation or code change hence seperating it out into a different workflow, this will run for all pull and merge requests

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
