### PR TITLE
Add additional stats to benchmark results

### DIFF
--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -19,6 +19,7 @@ package benchmark
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/awslabs/soci-snapshotter/benchmark/framework"
 	"github.com/containerd/containerd"
@@ -107,10 +108,13 @@ func SociFullRun(
 	defer sociProcess.StopProcess()
 	sociContainerdProc := SociContainerdProcess{containerdProcess}
 	b.ResetTimer()
+	pullStart := time.Now()
 	log.G(ctx).WithField("benchmark", "Test").WithField("event", "Start").Infof("Start Test")
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Start").Infof("Start Pull Image")
 	image, err := sociContainerdProc.SociRPullImageFromRegistry(ctx, imageRef, indexDigest)
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Stop").Infof("Stop Pull Image")
+	pullDuration := time.Since(pullStart)
+	b.ReportMetric(float64(pullDuration.Milliseconds()), "pullDuration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -129,8 +133,11 @@ func SociFullRun(
 	}
 	defer cleanupTask()
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Start").Infof("Start Run Task")
+	runLazyTaskStart := time.Now()
 	cleanupRun, err := sociContainerdProc.RunContainerTaskForReadyLine(ctx, taskDetails, readyLine)
+	lazyTaskDuration := time.Since(runLazyTaskStart)
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Stop").Infof("Stop Run Task")
+	b.ReportMetric(float64(lazyTaskDuration.Milliseconds()), "lazyTaskDuration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -146,8 +153,11 @@ func SociFullRun(
 	}
 	defer cleanupTaskSecondRun()
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Start").Infof("Start Run Task Twice")
+	runLocalStart := time.Now()
 	cleanupRunSecond, err := sociContainerdProc.RunContainerTaskForReadyLine(ctx, taskDetailsSecondRun, readyLine)
+	localTaskStats := time.Since(runLocalStart)
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Stop").Infof("Stop Run Task Twice")
+	b.ReportMetric(float64(localTaskStats.Milliseconds()), "localTaskStats")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -173,8 +183,11 @@ func OverlayFSFullRun(
 	b.ResetTimer()
 	log.G(ctx).WithField("benchmark", "Test").WithField("event", "Start").Infof("Start Test")
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Start").Infof("Start Pull Image")
+	pullStart := time.Now()
 	image, err := containerdProcess.PullImageFromRegistry(ctx, imageRef, platform)
+	pullDuration := time.Since(pullStart)
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Stop").Infof("Stop Pull Image")
+	b.ReportMetric(float64(pullDuration.Milliseconds()), "pullDuration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -199,8 +212,11 @@ func OverlayFSFullRun(
 	}
 	defer cleanupTask()
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Start").Infof("Start Run Task")
+	runLazyTaskStart := time.Now()
 	cleanupRun, err := containerdProcess.RunContainerTaskForReadyLine(ctx, taskDetails, readyLine)
+	lazyTaskDuration := time.Since(runLazyTaskStart)
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Stop").Infof("Stop Run Task")
+	b.ReportMetric(float64(lazyTaskDuration.Milliseconds()), "lazyTaskDuration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -216,8 +232,11 @@ func OverlayFSFullRun(
 	}
 	defer cleanupTaskSecondRun()
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Start").Infof("Start Run Task Twice")
+	runLocalStart := time.Now()
 	cleanupRunSecond, err := containerdProcess.RunContainerTaskForReadyLine(ctx, taskDetailsSecondRun, readyLine)
+	localTaskStats := time.Since(runLocalStart)
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Stop").Infof("Stop Run Task Twice")
+	b.ReportMetric(float64(localTaskStats.Milliseconds()), "localTaskStats")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}


### PR DESCRIPTION
This commit adds additional details like standard deviation,mean,p90 etc.. for individual events - 'Pull','Lazy Task' and 'LocalTask(Running task without FUSE overhead)'

**Example of how the result.json looks like after the change.**

```json {
 "commit": "N/A",
 "benchmarkTests": [
  {
   "testName": "SociFullECR-public-ffmpeg",
   "numberOfTests": 1,
   "fullRunStats": {
    "BenchmarkTimes": [
     8.078231528
    ],
    "stdDev": 0,
    "mean": 8.078231528,
    "min": 8.078231528,
    "pct25": 8.078231528,
    "pct50": 8.078231528,
    "pct75": 8.078231528,
    "pct90": 8.078231528,
    "max": 8.078231528
   },
   "pullStats": {
    "BenchmarkTimes": [
     7.94
    ],
    "stdDev": 0,
    "mean": 7.94,
    "min": 7.94,
    "pct25": 7.94,
    "pct50": 7.94,
    "pct75": 7.94,
    "pct90": 7.94,
    "max": 7.94
   },
   "lazyTaskStats": {
    "BenchmarkTimes": [
     0.005
    ],
    "stdDev": 0,
    "mean": 0.005,
    "min": 0.005,
    "pct25": 0.005,
    "pct50": 0.005,
    "pct75": 0.005,
    "pct90": 0.005,
    "max": 0.005
   },
   "localTaskStats": {
    "BenchmarkTimes": [
     0.004
    ],
    "stdDev": 0,
    "mean": 0.004,
    "min": 0.004,
    "pct25": 0.004,
    "pct50": 0.004,
    "pct75": 0.004,
    "pct90": 0.004,
    "max": 0.004
   }
  }
```
**Issue #, if available:**

**Description of changes:**

- Made results.json more readable by moving the common statistics related keys into a separate struct `BenchmarkTestStats`
- Used `ReportMetric` function to report additional metrics like pull times and run task times

**Testing performed:**

`make benchmarks` run successfully

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
