### PR TITLE
Add new workflow and benchmark job

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,34 @@
+name: Benchmark
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**'
+      - '!docs/**' # ignore docs changes
+      - '!**.md' # ignore markdown changes
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.*'
+      - 'cmd/go.*'
+      - 'Makefile'
+      - 'Dockerfile'
+      - 'integration/**'
+      - 'scripts/**'
+            
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.18.10'
+      - run: make
+      - name: Run benchmark
+        run: make benchmarks-perf-test
+      - run: cd benchmark/performanceTest && cat output/results.json
+      

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -1,0 +1,17 @@
+name: Comparision Tests
+
+on:
+  schedule:
+    - cron: "0 0 */2 * *" # every 2 days
+
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.18.10'
+      - run: make
+      - run: make benchmarks
+      - run: cd benchmark/comparisonTest && cat output/results.json

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,10 @@ build-benchmarks:
 	@cd benchmark/performanceTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/PerfTests .
 	@cd benchmark/comparisonTest ;  GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/CompTests .
 
+benchmarks-perf-test:
+	@echo "$@"
+	@cd benchmark/performanceTest ; sudo rm -rf output ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/PerfTests . && sudo ../bin/PerfTests -show-commit
+
 benchmarks-stargz:
 	@echo "$@"
 	@cd benchmark/stargzTest ; GO111MODULE=$(GO111MODULE_VALUE) go build -o ../bin/StargzTests . && sudo ../bin/StargzTests $(COMMIT) ../singleImage.csv 10 $(STARGZ_BINARY)


### PR DESCRIPTION
This commit adds comparison-test workflow which runs the comparsion tests once every 2 days. This commit also adds a new make target 'benchmarks-test' which is invoked in the benchmark workflow. The make target runs the performance tests and outputs the results onto the console.

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
