### PR TITLE
Add commit policies to Contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,10 @@ To send us a pull request, please:
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass.
 4. Commit to your fork using clear commit messages and a [DCO Sign-Off](https://wiki.linuxfoundation.org/dco) on each commit.
+   1. Every commit should compile successfully.
+   2. Every commit should pass tests.
+   3. No commit should exist solely to fix a bug introduced by another commit in the same PR.
+   4. Squash and rebase commits as necessary so that PRs satisfy these requirements.
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 


### PR DESCRIPTION
**Description of changes:**
Update CONTRIBUTING.md to give rules for commits not breaking builds or tests or fixing intra-PR bugs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
