### PR TITLE
Make verbiage consistent in our docs

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -1,7 +1,8 @@
-# Build soci-snapshotter from source
+# Build SOCI from source
 
 This document is helpful if you plan to contribute to the project (thanks!) or
-want to use the latest soci snapshotter/cli in the main branch.
+want to use the latest version of either `soci-snapshotter-grpc` or `soci` CLI 
+in the main branch.
 
 This document includes the following sections:
 
@@ -9,8 +10,8 @@ This document includes the following sections:
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Dependencies](#dependencies)
-- [Build soci-snapshotter](#build-soci-snapshotter)
-- [Test soci-snapshotter](#test-soci-snapshotter)
+- [Build SOCI](#build-soci)
+- [Test SOCI](#test-soci)
 - [(Optional) Contribute your change](#optional-contribute-your-change)
 - [Development tooling](#development-tooling)
 
@@ -18,9 +19,10 @@ This document includes the following sections:
 
 ## Dependencies
 
-soci-snapshotter has the following dependencies. Please follow the links or commands
+The project binaries have the following dependencies. Please follow the links or commands
 to install them on your machine:
 
+> **Note**
 > We only mention the direct dependencies of the project. Some dependencies may
 > have their own dependencies (e.g., containerd depends on runc/cni). Please refer
 > to their doc for a complete installation guide (mainly containerd).
@@ -28,13 +30,13 @@ to install them on your machine:
 - **[go](https://go.dev/doc/install) >= 1.18** - required to build the project;
 to confirm please check with `go version`.
 - **[containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) >= 1.4** -
-required to run soci-snapshotter; to confirm please check with `sudo containerd --version`.
+required to run the SOCI snapshotter; to confirm please check with `sudo containerd --version`.
 - **fuse** - used for mounting without root access (`sudo yum install fuse`).
-- **zlib** - used for decompression and ztoc creation; soci builds zlib statically into its binaries
+- **zlib** - used for decompression and ztoc creation; Both the CLI and the SOCI snapshotter build zlib statically
 (`sudo yum install zlib-devel zlib-static`).
-- **gcc** - used for compiling SOCI's c code, gzip's zinfo implementation (`sudo yum install gcc`).
-- **[flatc](https://github.com/google/flatbuffers)** - used for compiling ztoc
-flatbuffer file and generating corresponding go code.
+- **gcc** - used for compiling C code, gzip's zinfo implementation (`sudo yum install gcc`).
+- **[flatc](https://github.com/google/flatbuffers)** - used for compiling zTOC
+flatbuffer file and generating corresponding Go code.
 
 For fuse/zlib/gcc, they can be installed by your Linux package manager (e.g., `yum` or `apt-get`).
 
@@ -47,7 +49,7 @@ sudo unzip Linux.flatc.binary.g++-10.zip -d /usr/local
 rm Linux.flatc.binary.g++-10.zip
 ```
 
-## Build soci-snapshotter
+## Build SOCI
 
 First you need `git` to clone the repository (if you intend to contribute, you
 can fork the repository and clone your own fork):
@@ -57,8 +59,8 @@ git clone https://github.com/awslabs/soci-snapshotter.git
 cd soci-snapshotter
 ```
 
-soci-snapshotter uses `make` as the build tool. Assuming you're in the root directory
-of the repository, you can build soci-snapshotter by:
+SOCI uses `make` as the build tool. Assuming you're in the root directory
+of the repository, you can build the CLI and the snapshotter by running:
 
 ```shell
 make
@@ -69,11 +71,13 @@ to a `PATH` directory (`/usr/local/bin`) with:
 
 ```shell
 sudo make install
-# check soci can be found in PATH
+# check to make sure the SOCI CLI can be found in PATH
 sudo soci --help
+# check to make sure the SOCI snapshotter can be found in PATH
+sudo soci-snapshotter-grpc --help
 ```
 
-When changing the ztoc's flatbuffer definition, you need to regenerate the generated
+When changing the zTOC flatbuffer definition, you need to regenerate the generated
 code package with:
 
 > It's rare to make such a change, especially delete a field which is a breaking
@@ -83,16 +87,16 @@ code package with:
 make flatc
 ```
 
-## Test soci-snapshotter
+## Test SOCI
 
 We have unit tests and integration tests as part of our automated CI, as well as
-benchmark tests that can be used to test the performance of soci-snapshotter. You
+benchmark tests that can be used to test the performance of the SOCI snapshotter. You
 can run these tests using the following `Makefile` targets:
 
 - `make test`: run all unit tests.
 - `make integration`: run all integration tests.
-- `make benchmarks`: run all benchmark tests. Runs the benchmark tests on a set of publicly hosted images. Output results are available in the ouptut folder within the comparisonTest and performanceTest subfolders.
-- `make build-benchmarks`: generate benchmark binaries of perfomance and comparision Tests. The binaries are available for use within the benchmanrk/bin directory. Use `-f`, `-count`,`show-commit` flags to customize the benchmark test.
+- `make benchmarks`: run all benchmark tests. Runs the benchmark tests on a set of publicly hosted images. Output results are available in the output folder within the comparisonTest and performanceTest subfolder's.
+- `make build-benchmarks`: generate benchmark binaries of performance and comparison Tests. The binaries are available for use within the benchmark/bin directory. Use `-f`, `-count`,`show-commit` flags to customize the benchmark test.
 
 To speed up develop-test cycle, you can run individual test(s) by utilizing `go test`'s
 `-run` flag. For example, suppose you only want to run a test named `TestFooBar`, you can:
@@ -122,6 +126,7 @@ provide a script (`./scripts/add-ltag.sh`) that can do this.
 
 4. As a final step, run `make check` to verify your change passes these checks.
 
+> **Note**
 > `make check` requires some checking tools (`golangci`, `ltag`,
 > `git-validation`). We provide a script (`./scripts/install-check-tools.sh`) to
 > help install all these checking tools.
@@ -130,4 +135,4 @@ Once you pass all the tests and checks. You're ready to make your PR!
 
 ## Development tooling
 
-This repository contains two go modules, one in the root directory and the other in [`cmd`](../cmd). To describe this arrangement to tools like `gopls` (and, by extension, vscode), you need a `go.work` file listing the module locations. An example such file is included in this repositiry as `go.work.example` which you could rename to `go.work` to use as-is.
+This repository contains two go modules, one in the root directory and the other in [`cmd`](../cmd). To describe this arrangement to tools like `gopls` (and, by extension, vscode), you need a `go.work` file listing the module locations. An example such file is included in this repository as `go.work.example` which you could rename to `go.work` to use as-is.

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,4 +1,4 @@
-# Debugging SOCI snapshotter
+# Debugging the SOCI snapshotter
 
 This document outlines where to find/access logs and metrics for the snapshotter. It attempts to provide some common error paths that a user might run into while using the snapshotter and provides some guidance on how to either root-cause the issue or resolve it.
 
@@ -34,7 +34,7 @@ sudo journalctl -u soci-snapshotter.unit
 ```
 
 > **Note**
-> The command above assumes that you have used the unit file definition [soci-snapshotter.service](../soci-snapshotter.service) we have provided. If you have created your own unit file for SOCI replace `soci-snapshotter.unit` with the one you have made.
+> The command above assumes that you have used the unit file definition [soci-snapshotter.service](../soci-snapshotter.service) we have provided. If you have created your own unit file for `soci-snapshotter-grpc` and replace `soci-snapshotter.unit` with the one you have made.
  
 If you have started `soci-snapshotter-grpc` manually, logs will either be emitted to stderr/stdout or to the destination of your choice.
 
@@ -64,7 +64,6 @@ Below are a list of metrics emitted by the snapshotter:
 * Mount
     * **operation_duration_mount (ms)** - defines how long does it take to mount a layer during `rpull`. `rpull` should only take a couple of seconds. If this value is higher than 3-5 seconds this can indicate an issue while mounting.
     * **operation_duration_init_metadata_store (ms)** - measures the time it takes to parse a zTOC and prepare the respective metadata records in metadata bbolt db (it records layer digest as well). This is one of the components of `rpull`, therefore there should be a correlation between the time to parse a zTOC with updating of metadata db and the duration of layer mount operation. 
-
 * Fetch from remote registry
     * **operation_duration_remote_registry_get (ms)** - measures the time it takes to complete a `GET` operation from remote registry for a specific layer. This metric should help in identifying network issues, when lazily fetching layer data and seeing increased container start time.
 * FUSE
@@ -161,9 +160,9 @@ Look for  `failed to read the file` or `unexpected copied data size for on-deman
 
 **Network Failures**
 
-The snapshotter contains custom retry logic when fetching spans(data) from the remote registry. By default it will try to fetch from remote a maximum of 5 times before returning an error.
+The snapshotter contains custom retry logic when fetching spans(data) from the remote registry. By default it will try to fetch from remote a maximum of 9 times before returning an error.
 
-* You can look for `Retrying request` within the logs to determine the error and response returned from the remote registry.
+* You can look for `retrying request` within the logs to determine the error and response returned from the remote registry.
 * You can also check `operation_duration_remote_registry_get` metric to see how long it takes to complete `GET` from remote registry.
 
 # Debugging Tools

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,22 +1,22 @@
-# Getting Started With soci-snapshotter
+# Getting Started With the SOCI Snapshotter
 
-This document walks through how to use soci-snapshotter, including building SOCI
+This document walks through how to use the SOCI snapshotter, including building a SOCI
 index, pushing/pulling an image and associated SOCI index, and running a container
-with soci-snapshotter.
+with the SOCI snapshotter.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Dependencies](#dependencies)
-- [Install soci-snapshotter](#install-soci-snapshotter)
+- [Install the SOCI snapshotter](#install-the-soci-snapshotter)
 - [Push an image to your registry](#push-an-image-to-your-registry)
 - [Create and push SOCI index](#create-and-push-soci-index)
   - [Create SOCI index](#create-soci-index)
-  - [(Optional) Inspect SOCI index and ztoc](#optional-inspect-soci-index-and-ztoc)
+  - [(Optional) Inspect SOCI index and zTOC](#optional-inspect-soci-index-and-ztoc)
   - [Push SOCI index to registry](#push-soci-index-to-registry)
-- [Run container with soci-snapshotter](#run-container-with-soci-snapshotter)
+- [Run container with the SOCI snapshotter](#run-container-with-the-soci-snapshotter)
   - [Configure containerd](#configure-containerd)
-  - [Start soci-snapshotter](#start-soci-snapshotter)
+  - [Start the SOCI snapshotter](#start-the-soci-snapshotter)
   - [Lazily pull image](#lazily-pull-image)
   - [Run container](#run-container)
 
@@ -24,23 +24,24 @@ with soci-snapshotter.
 
 ## Dependencies
 
-soci-snapshotter has the following runtime dependencies. Please follow the links or commands
+The SOCI snapshotter has the following runtime dependencies. Please follow the links or commands
 to install them on your machine:
 
+> **Note**
 > We only mention the direct dependencies of the project. Some dependencies may
 > have their own dependencies (e.g., containerd depends on runc/cni). Please refer
 > to their doc for a complete installation guide (mainly containerd).
 
 - **[containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) >= 1.4** -
-required to run soci-snapshotter; to confirm please check with `sudo ctr version`.
+required to run the SOCI snapshotter; to confirm please check with `sudo ctr version`.
 - **[ctr](https://github.com/containerd/containerd/blob/main/docs/getting-started.md)** -
 required for this doc to interact with containerd/registry.
 - **fuse** - used for mounting without root access (`sudo yum install fuse` or
 other Linux package manager like `apt-get`, depending on your Linux distro).
 
-## Install soci-snapshotter
+## Install the SOCI snapshotter
 
-The soci-snapshotter project produces 2 binaries:
+The SOCI project produces 2 binaries:
 
 - `soci`: the CLI tool used to build/manage SOCI indices.
 - `soci-snapshotter-grpc`: the daemon (a containerd snapshotter plugin) used for lazy loading.
@@ -103,7 +104,7 @@ can use `aws ecr describe-images --repository-name rabbitmq --region $AWS_REGION
 
 ## Create and push SOCI index
 
-Instead of converting the image format, soci-snapshotter uses the SOCI index
+Instead of converting the image format, the SOCI snapshotter uses the SOCI index
 associated with an image to implement its lazy loading. For more details
 please see [README](../README.md#no-image-conversion).
 
@@ -139,7 +140,7 @@ the entire SOCI index to a particular image manifest (i.e. a particular image fo
 From the above output, we can see that SOCI creates ztocs for 3 layers and skips
 7 layers, which means only the 3 layers with ztocs will be lazily pulled.
 
-### (Optional) Inspect SOCI index and ztoc
+### (Optional) Inspect SOCI index and zTOC
 
 We can inspect one of these ztocs from the output of previous command (replace
 the digest with one in your command output). This command will print the ztoc,
@@ -173,11 +174,11 @@ sudo soci push --user $REGISTRY_USER:$REGISTRY_PASSWORD $REGISTRY/rabbitmq:lates
 
 Credentials here can be omitted if `docker login` has stored credentials for this registry.
 
-## Run container with soci-snapshotter
+## Run container with the SOCI snapshotter
 
 ### Configure containerd
 
-We need to reconfigure and restart containerd to enable soci-snapshotter. This
+We need to reconfigure and restart containerd to enable the SOCI snapshotter. This
 section assume your containerd is managed by `systemd`. First let's stop containerd:
 
 ```shell
@@ -185,7 +186,7 @@ sudo systemctl stop containerd
 ```
 
 Next we need to modify containerd's config file (`/etc/containerd/config.toml`).
-Let's add the following config to the file to enable soci-snapshotter as a plugin:
+Let's add the following config to the file to enable the SOCI snapshotter as a plugin:
 
 ```toml
 [proxy_plugins]
@@ -197,7 +198,7 @@ Let's add the following config to the file to enable soci-snapshotter as a plugi
 This config section tells containerd that there is a snapshot plugin named `soci`
 and to communicate with it via a socket file.
 
-Now let's restart containerd and confirm containerd knows about soci-snapshotter plugin:
+Now let's restart containerd and confirm containerd knows about the SOCI snapshotter plugin:
 
 ```shell
 sudo systemctl restart containerd
@@ -207,7 +208,7 @@ sudo ctr plugin ls id==soci
 `ctr plugin ls` lists all of the plugins from which you should see there is a
 `soci` plugin of type `io.containerd.snapshotter.v1`.
 
-### Start soci-snapshotter
+### Start the SOCI snapshotter
 
 First we need to start the snapshotter grpc service by running the `soci-snapshotter-grpc` binary in background and simply redirecting logs to an arbitrary file:
 
@@ -224,7 +225,7 @@ sudo soci-snapshotter-grpc 2> ~/soci-snapshotter-errors 1> ~/soci-snapshotter-lo
 ### Lazily pull image
 
 Once the snapshotter is running we can call the `rpull` command from SOCI CLI.
-This command reads the manifest from the registry and mounts FUSE filesystems
+This command reads the manifest from the registry and mounts a FUSE filesystem
 for each layer.
 
 > The optional flag `--soci-index-digest` needs to be the digest of the SOCI index manifest.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,8 +1,8 @@
-# Install soci-snapshotter
+# Install the SOCI snapshotter
 
-This doc walks through how to install soci-snapshotter as a component managed by systemd.
+This doc walks through how to install the SOCI snapshotter as a component managed by systemd.
 
-The soci-snapshotter project produces 2 binaries:
+The SOCI snapshotter produces 2 binaries:
 
 - `soci`: the CLI tool used to build/manage SOCI indices.
 - `soci-snapshotter-grpc`: the daemon (a containerd snapshotter plugin) used for lazy loading.
@@ -14,40 +14,42 @@ or [build them from source](./build.md).
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Dependencies](#dependencies)
-- [Configure soci-snapshotter (optional)](#configure-soci-snapshotter-optional)
+- [Configure SOCI snapshotter (optional)](#configure-soci-snapshotter-optional)
 - [Confirm installation](#confirm-installation)
-- [Install soci-snapshotter for containerd with systemd](#install-soci-snapshotter-for-containerd-with-systemd)
+- [Install the SOCI snapshotter for containerd with systemd](#install-the-soci-snapshotter-for-containerd-with-systemd)
 - [Config containerd](#config-containerd)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Dependencies
 
-soci-snapshotter has the following dependencies. Please follow the links or commands
+The SOCI snapshotter has the following dependencies. Please follow the links or commands
 to install them on your machine:
 
+> **Note**
 > We only mention the direct dependencies of the project. Some dependencies may
 > have their own dependencies (e.g., containerd depends on runc/cni). Please refer
 > to their doc for a complete installation guide (mainly containerd).
 
 - **[containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) >= 1.4** -
-required to run soci-snapshotter; to confirm please check with `sudo containerd --version`.
+required to run the SOCI snapshotter; to confirm please check with `sudo containerd --version`.
 - **fuse** - used for mounting without root access (`sudo yum install fuse`).
 
 For fuse/zlib, they can be installed by your Linux package manager (e.g., `yum` or `apt-get`).
 
-## Configure soci-snapshotter (optional)
+## Configure SOCI snapshotter (optional)
 
-Similar to containerd, soci-snapshotter has a toml config file which is located at
+Similar to containerd, the SOCI snapshotter has a toml config file which is located at
 `/etc/soci-snapshotter-grpc/config.toml` by default. If such a file doesn't exist,
-soci-snapshotter will use default values for all configurations.
+SOCI snapshotter will use default values for all configurations.
 
+> **Note**
 > Whenever you make changes to the config file, you need to stop the snapshotter
 > first before making changes, and restart the snapshotter after the changes.
 
 ## Confirm installation
 
-To validate soci-snapshotter is installed, let's check the snapshotter's version.
+To validate that the SOCI snapshotter is installed, let's check the snapshotter's version.
 The output should show the version that you installed.
 
 ```shell
@@ -55,9 +57,9 @@ $ sudo soci-snapshotter-grpc --version
 soci-snapshotter-grpc version f855ff1.m f855ff1bcf7e161cf0e8d3282dc3d797e733ada0.m
 ```
 
-## Install soci-snapshotter for containerd with systemd
+## Install the SOCI snapshotter for containerd with systemd
 
-If you plan to use systemd to manage your soci-snapshotter process, you can download
+If you plan to use systemd to manage your SOCI snapshotter process, you can download
 the [`soci-snapshotter.service` unit file](../soci-snapshotter.service) in the
 repository root directory into `/usr/local/lib/systemd/system/soci-snapshotter.service`,
 and run the following commands:
@@ -67,7 +69,7 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now soci-snapshotter
 ```
 
-To validate soci-snapshotter is now running:
+To validate the SOCI snapshotter is now running:
 
 ```shell
 sudo systemctl status soci-snapshotter
@@ -75,11 +77,11 @@ sudo systemctl status soci-snapshotter
 
 ## Config containerd
 
-We need to configure and restart containerd to enable soci-snapshotter (this
+We need to configure and restart containerd to enable the SOCI snapshotter (this
 section assume your containerd is also managed by `systemd`):
 
 - Stop containerd: `sudo systemctl stop containerd`;
-- Update containerd config to include soci-snapshotter plugin. The config file
+- Update containerd config to include the SOCI snapshotter plugin. The config file
 is usually in `/etc/containerd/config.toml`, and you need to add the following:
 
 ```toml
@@ -90,7 +92,7 @@ is usually in `/etc/containerd/config.toml`, and you need to add the following:
 ```
 
 - Restart containerd: `sudo systemctl restart containerd`;
-- (Optional) Check soci-snapshotter is recognized by containerd: `sudo ctr plugin ls id==soci`.
+- (Optional) Check to make sure the SOCI snapshotter is recognized by containerd: `sudo ctr plugin ls id==soci`.
 You will see output like below. If not, consult containerd logs to determine the cause
 or reach out on [our discussion](https://github.com/awslabs/soci-snapshotter/discussions).
 

--- a/docs/pull-modes.md
+++ b/docs/pull-modes.md
@@ -1,6 +1,6 @@
-# Pull modes of soci-snapshotter
+# Pull modes of the SOCI snapshotter
 
-soci-snapshotter is a remote snapshotter. It is able to lazily load the contents
+The SOCI snapshotter is a remote snapshotter. It is able to lazily load the contents
 of a container image when a *SOCI index* is present in the remote registry. If
 a SOCI index is not found, it will download and uncompress the image layers at
 launch time, just like the default snapshotter does.
@@ -9,15 +9,25 @@ SOCI indices can also be "sparse", meaning that any individual layer may not be
 indexed. In that case, that layer will be downloaded at launch time, while the
 indexed layers will be lazily loaded.
 
-A layer will be mounted as a fuse mountpoint if it's being lazily loaded, or as
+A layer will be mounted as a FUSE mountpoint if it's being lazily loaded, or as
 a normal overlay layer if it's not.
 
-Overall, lazily pulling a container image with soci-snapshotter
+Overall, lazily pulling a container image with the SOCI snapshotter
 (via the `soci image rpull` command) involves the following steps:
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Pull modes of the SOCI snapshotter](#pull-modes-of-the-soci-snapshotter)
+  - [Step 1: specify SOCI index digest](#step-1-specify-soci-index-digest)
+  - [Step 2: fetch SOCI artifacts](#step-2-fetch-soci-artifacts)
+  - [Step 3: fetch image layers](#step-3-fetch-image-layers)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Step 1: specify SOCI index digest
 
-To enable lazy pulling and loading an image with soci-snapshotter, first you need
+To enable lazy pulling and loading an image with the SOCI snapshotter, first you need
 to `rpull` the image via the [`soci` CLI](./getting-started.md#install-soci-snapshotter).
 The CLI accepts an optional flag `--soci-index-digest`, which is the sha256 of the
 SOCI index manifest and will be passed to the snapshotter.
@@ -29,6 +39,7 @@ If not provided, the snapshotter will use the OCI distribution-spec's
 to fetch a list of available indices. An index will be chosen from the list of available indices,
 but the selection process is undefined and it may not choose the same index every time.
 
+> **Note**
 > Check out [this doc](./getting-started.md#lazily-pull-image) for how to
 > validate if this step is successful or not, and [the debug doc](./debug.md#common-scenarios)
 > for the common scenarios where `rpull` might fail and how to debug/fix them.
@@ -45,7 +56,7 @@ fallback to default snapshotter configured (eg: overlayfs) entirely.
 
 ## Step 3: fetch image layers
 
-The SOCI index will instruct containerd and soci-snapshotter when to fetch/pull
+The SOCI index will instruct containerd and the SOCI snapshotter when to fetch/pull
 image layers. There can be two cases:
 
 1. There’s no zTOC for a specific layer. In this case, there will be an error log:
@@ -56,7 +67,7 @@ as a fuse mountpoint, and will be lazily loaded while a container is running.
 
 > Whether a layer belongs to 1 or 2 depends on its size. When creating a SOCI
 > index, SOCI only creates zTOC for layers larger than a given size which is
-> specificed by the `--min-layer-size` flag of
+> specified by the `--min-layer-size` flag of
 [`soci create` command](https://github.com/awslabs/soci-snapshotter/blob/9ff88817f3f2635b926f9fd32f6f05f389f7ecee/cmd/soci/commands/create.go#L56).
 
 With debug logging enabled, you can see an entry in logs for each layer.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -4,6 +4,19 @@ SOCI is compatible with most registries. To check if your registry of choice is 
 
 For most use-cases, compatibility is the only concern. However, there is a difference in *how* registries work with SOCI that could cause surprising edge cases. The rest of this document is a technical dive into how SOCI indices are stored and retrieved from registries and the surprises you might encounter.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Registry Requirements](#registry-requirements)
+- [Referrers API vs Fallback](#referrers-api-vs-fallback)
+  - [Referrers API](#referrers-api)
+  - [Fallback](#fallback)
+- [How SOCI Indices Appear to Registries](#how-soci-indices-appear-to-registries)
+- [List of Registry Compatibility](#list-of-registry-compatibility)
+  - [Failure Examples](#failure-examples)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Registry Requirements
 
 In order for a registry to be compatible SOCI it must support the following features of the OCI distribution and image specs:
@@ -18,17 +31,17 @@ This adds convenience around retrieving SOCI indices from the registry. If it is
 
 The SOCI snapshotter can retrieve SOCI indices and ztocs either through the [OCI referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers) or a [Fallback mechanism](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#unavailable-referrers-api). The referrers API is part of the not-yet-released [OCI Distribution Spec v1.1](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md) so registry support is limited. The Fallback is supported by all registries, but has notable edge cases.
 
-The SOCI CLI and soci-snapshotter automatically uses the referrers API if the registry supports it or the fallback mechanism otherwise.
+The SOCI CLI and the SOCI snapshotter automatically uses the referrers API if the registry supports it or the fallback mechanism otherwise.
 
 ### Referrers API
 
-The [referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers) is a registry endpoint where an agent can query for all artifacts that reference a given image digest, optionally filtering by artifact type. The registry indexes artifacts for the referrers API when the artifact is pushed. When a container is launched, the soci-snapshotter can query this API to find SOCI indices that reference the digest of the image.
+The [referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers) is a registry endpoint where an agent can query for all artifacts that reference a given image digest, optionally filtering by artifact type. The registry indexes artifacts for the referrers API when the artifact is pushed. When a container is launched, the SOCI snapshotter can query this API to find SOCI indices that reference the digest of the image.
 
 ### Fallback
 
 If the referrers API is not available, the OCI distribution spec defines a [fallback mechanism that works with existing registries](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#unavailable-referrers-api). In this mechanism, the contents that would normally be returned by the referrers API are instead put into an [OCI Image Index](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/image-index.md) which is tagged in the registry with the digest of the manifest to which it refers.
 
-For example, imagine you had an image `myregistry.com/image:latest` with digest `sha:123`. If you created and pushed a SOCI index for that image, there would also be a new image index `myregistry.com/image:sha-123` which contains the SOCI index' descriptor. At runtime, the soci-snapshotter will pull the `myregistry.com/image:sha-123` index and apply client side filtering to discover the SOCI index.
+For example, imagine you had an image `myregistry.com/image:latest` with digest `sha:123`. If you created and pushed a SOCI index for that image, there would also be a new image index `myregistry.com/image:sha-123` which contains the SOCI index' descriptor. At runtime, the SOCI snapshotter will pull the `myregistry.com/image:sha-123` index and apply client side filtering to discover the SOCI index.
 
 For clarity in the rest of this section, we will refer to `myregistry.com/image:sha-123` as the "fallback" (as opposed to image index) to distinguish it from the SOCI index.
 


### PR DESCRIPTION
Make the use of soci (CLI binary), soci-snapshotter-grpc (gRPC daemon binary), and "the SOCI snapshotter" (the remote snapshotter within the SOCI project) and SOCI (Seekable OCI - the project) consistent across our documentation.

**Issue #, if available:**
Resolves: #709 
**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
