### PR TITLE
Add shell script to check regression

### DIFF
--- a/scripts/check_regression.sh
+++ b/scripts/check_regression.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+# Check if two arguments are provided (paths to past.json and current.json)
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <path_to_past.json> <path_to_current.json>"
+    exit 1
+fi
+
+# Extract the file paths from command-line arguments
+past_json_path="$1"
+current_json_path="$2"
+
+# Read the contents of past.json and current.json into variables
+past_data=$(cat "$past_json_path")
+current_data=$(cat "$current_json_path")
+
+# Function to compare P90 values for a given statistic
+compare_stat_p90() {
+    local past_value="$1"
+    local current_value="$2"
+    local stat_name="$3"
+
+    # Calculate 110% of the past value
+    local threshold=$(calculate_threshold "$past_value")
+
+    # Compare the current value with the threshold
+    if (( $(awk 'BEGIN {print ("'"$current_value"'" > "'"$threshold"'")}') )); then
+        echo "ERROR: $stat_name - Current P90 value ($current_value) exceeds the 110% threshold ($threshold) of the past P90 value ($past_value)"
+        return 1
+    fi
+
+    return 0
+}
+
+calculate_threshold() {
+    local past_value="$1"
+    awk -v past="$past_value" 'BEGIN { print past * 1.1 }'
+}
+
+# Loop through each object in past.json and compare P90 values with current.json for all statistics
+compare_p90_values() {
+    local past_json="$1"
+    local current_json="$2"
+
+    local test_names=$(echo "$past_json" | jq -r '.benchmarkTests[].testName')
+
+    # Use a flag to indicate if any regression has been detected
+    local regression_detected=0
+
+    for test_name in $test_names; do
+        echo "Checking for regression in '$test_name'"
+        for stat_name in "fullRunStats" "pullStats" "lazyTaskStats" "localTaskStats"; do
+            local past_p90=$(echo "$past_json" | jq -r --arg test "$test_name" '.benchmarkTests[] | select(.testName == $test) | .'"$stat_name"'.pct90')
+            local current_p90=$(echo "$current_json" | jq -r --arg test "$test_name" '.benchmarkTests[] | select(.testName == $test) | .'"$stat_name"'.pct90')
+
+            # Call the compare_stat_p90 function
+            compare_stat_p90 "$past_p90" "$current_p90" "$stat_name" || regression_detected=1
+        done
+    done
+
+    # Check if any regression has been detected and return the appropriate exit code
+    return $regression_detected
+}
+
+# ... (remaining code)
+
+# Call compare_p90_values and store the exit code in a variable
+compare_p90_values "$past_data" "$current_data"
+exit_code=$?
+
+# Check the return status and display appropriate message
+if [ $exit_code -eq 0 ]; then
+    echo "Comparison successful. No regressions detected, all P90 values are within the acceptable range."
+else
+    echo "Comparison failed. Regression detected."
+fi
+
+# Set the final exit code to indicate if any regression occurred
+exit $exit_code


### PR DESCRIPTION
This commit adds a 'check_regression.sh' script that accepts two results json files and compares the p90 of all the stats and checks for regression. Regression once identified is echo'd on to the console and the shell exits. The workflow that uses this shell script will handle the exit.

The script accepts two files as cli arguments, it compares the second file (newer) p90 value against the p90 values of the first file (older) and checks if the new p90 value is greater than 110% of the older values.
**Usage:** ` ./check_regression.sh <path_to_past>.json <path_to_current>.json ` 

**Json format:** Same as the results generated by the benchmark framework
```json
{
    "commit": "N/A",
    "benchmarkTests": [
     {
      "testName": "SociFullECR-public-ffmpeg",
      "numberOfTests": 1,
      "fullRunStats": {
       "BenchmarkTimes": [
        7.681071871
       ],
       "stdDev": 0,
       "mean": 7.681071871,
       "min": 7.681071871,
       "pct25": 7.681071871,
       "pct50": 7.681071871,
       "pct75": 7.681071871,
       "pct90": 7.681071871,
       "max": 7.681071871
      },
      "pullStats": {
       "BenchmarkTimes": [
        7.523
       ],
       "stdDev": 0,
       "mean": 7.523,
       "min": 7.523,
       "pct25": 7.523,
       "pct50": 7.523,
       "pct75": 7.523,
       "pct90": 7.523,
       "max": 7.523
      },
      "lazyTaskStats": {
       "BenchmarkTimes": [
        0.005
       ],
       "stdDev": 0,
       "mean": 0.005,
       "min": 0.005,
       "pct25": 0.005,
       "pct50": 0.005,
       "pct75": 0.005,
       "pct90": 0.005,
       "max": 0.005
      },
      "localTaskStats": {
       "BenchmarkTimes": [
        0.005
       ],
       "stdDev": 0,
       "mean": 0.005,
       "min": 0.005,
       "pct25": 0.005,
       "pct50": 0.005,
       "pct75": 0.005,
       "pct90": 0.005,
       "max": 0.005
      }
     }    
   ]
}
```

**Output:**
```
Testing - 'SociFullECR-public-ffmpeg'
Testing - 'SociFullECR-public-tensorflow'
Testing - 'SociFullECR-public-tensorflow_gpu'
Testing - 'SociFullECR-public-node'
Testing - 'SociFullECR-public-busybox'
Testing - 'SociFullECR-public-mongo'
Testing - 'SociFullECR-public-rabbitmq'
ERROR: fullRunStats - Current P90 value (12.328233926) exceeds the 110% threshold (11.3611) of the past P90 value (10.328233926)
Comparison failed. Regression detected.
```


**Issue #, if available:**

**Description of changes:**
 
- Added a script check_regression.sh
 
**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
