### PR TITLE
Update check tools

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,14 @@ linters:
   disable:
     - errcheck
 
+issues:
+  exclude-rules:
+    - linters:
+        - revive
+      # Ignore unused parameter rule. It's not enforced by go and it can make it hard
+      # to understand what the unused parameter was supposed to be used for.
+      text: "unused-parameter:"
+
 run:
   deadline: 4m
   skip-dirs:

--- a/metadata/reader.go
+++ b/metadata/reader.go
@@ -136,10 +136,7 @@ func (r *reader) init(toc ztoc.TOC, rOpts Options) (retErr error) {
 		return fmt.Errorf("failed to get a unique id for metadata reader")
 	}
 
-	if err := r.initNodes(toc); err != nil {
-		return err
-	}
-	return nil
+	return r.initNodes(toc)
 }
 
 func (r *reader) initRootNode(fsID string) error {

--- a/scripts/install-check-tools.sh
+++ b/scripts/install-check-tools.sh
@@ -17,6 +17,6 @@
 echo "Install soci check tools"
 set -eux -o pipefail
 
-curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
-go install github.com/kunalkushwaha/ltag@v0.2.3
-go install github.com/vbatts/git-validation@v1.1.0
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.3
+go install github.com/kunalkushwaha/ltag@v0.2.4
+go install github.com/vbatts/git-validation@v1.2.0

--- a/ztoc/toc_builder.go
+++ b/ztoc/toc_builder.go
@@ -124,9 +124,8 @@ func metadataFromTarReader(r io.Reader) ([]FileMetadata, compression.Offset, err
 		if err != nil {
 			if err == io.EOF {
 				break
-			} else {
-				return nil, 0, fmt.Errorf("error while reading tar header: %w", err)
 			}
+			return nil, 0, fmt.Errorf("error while reading tar header: %w", err)
 		}
 
 		fileType, err := getType(hdr)


### PR DESCRIPTION
Updates our check tools to the latest version. This is a prerequisite for updating the go version

**Issue #, if available:**
Part of https://github.com/awslabs/soci-snapshotter/issues/752

**Description of changes:**
Updates the check tools to the latest versions. golangci-lint v1.49.0 was panicking with go 1.20.6 so this is a prerequisite to updating the go version.

The code changes are to address new lint rules that we got by updating. 

**Testing performed:**
```
$ rm -rf ~/go
$ go mod tidy
$ ./scripts/install-check-tools.sh
$ $(go env GOPATH)/bin/golangci-lint --version
golangci-lint has version 1.53.3 built with go1.20.5 from 2dcd82f3 on 2023-06-15T10:50:11Z
$ make check && make test && make integration
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
