### PR TITLE
Set bump-deps author to GitHub

### DIFF
--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -34,4 +34,5 @@ jobs:
         body: "This PR created by [create-pull-request](https://github.com/peter-evans/create-pull-request) must be closed and reopened manually to trigger automated checks."
         labels: dependencies
         delete-branch: true
+        author: "GitHub <no-reply@github.com>"
         signoff: true


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently, the author of the commit for the bump deps workflow is the user that triggered the workflow. That makes some sense when the workflow is manually triggered, but doesn't make sense when it is triggered by the cron expression. It seems to take the user that commited the cron expression as the user that triggered the workflow. This change sets the author to GitHub since it really is automated and not a manual trigger.

**Testing performed:**
Example commit: https://github.com/Kern--/soci-snapshotter/pull/63/commits/0ffa82134cfcdebd1d76fa3b9a4fc4e05a87abef

Please ignore the other commits in that PR, they were just to allow the action to run against my fork.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
