### PR TITLE
Add custom User-Agent when fetching spans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ vendor:
 
 test:
 	@echo "$@"
-	@GO111MODULE=$(GO111MODULE_VALUE) go test $(GO_TEST_FLAGS) -race ./...
+	@GO111MODULE=$(GO111MODULE_VALUE) go test $(GO_TEST_FLAGS) $(GO_LD_FLAGS) -race ./...
 
 integration: build
 	@echo "$@"

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -413,6 +413,7 @@ func (f *httpFetcher) fetch(ctx context.Context, rs []region, retry bool) (multi
 	}
 	req.Header.Add("Range", fmt.Sprintf("bytes=%s", ranges[:len(ranges)-1]))
 	req.Header.Add("Accept-Encoding", "identity")
+	req.Header.Add("User-Agent", socihttp.UserAgent)
 	req.Close = false
 
 	// Recording the roundtrip latency for remote registry GET operation.

--- a/util/http/retry.go
+++ b/util/http/retry.go
@@ -18,15 +18,21 @@ package http
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/awslabs/soci-snapshotter/version"
 	"github.com/containerd/containerd/log"
 	rhttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/sirupsen/logrus"
+)
+
+var (
+	UserAgent = fmt.Sprintf("soci-snapshotter/%s", version.Version)
 )
 
 // NewRetryableClient creates a go http.Client which will automatically

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -32,12 +32,10 @@
 
 package version
 
-const Unset = "<unknown>"
+import "testing"
 
-var (
-	// Version is the version number. Filled in at linking time (via Makefile).
-	Version = Unset
-
-	// Revision is the VCS (e.g. git) revision. Filled in at linking time (via Makefile).
-	Revision = Unset
-)
+func TestVersion(t *testing.T) {
+	if Version == Unset {
+		t.Fatalf("version is unset")
+	}
+}


### PR DESCRIPTION
**Issue #, if available:**

Resolves: #744 

**Description of changes:**

Add custom `User-Agent` when fetching spans. This could provide some useful information to registry owners.

Add extra link flags to `make test` to ensure that the version is set in our unit tests.

**Testing performed:**

`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
