### PR TITLE
Retain original cache.Get error in span manager

### DIFF
--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -396,7 +396,7 @@ func (m *SpanManager) addSpanToCache(spanID compression.SpanID, contents []byte,
 func (m *SpanManager) getSpanFromCache(spanID compression.SpanID, offset, size compression.Offset) (io.Reader, error) {
 	r, err := m.cache.Get(fmt.Sprintf("%d", spanID))
 	if err != nil {
-		return nil, ErrSpanNotAvailable
+		return nil, fmt.Errorf("%w: %w", ErrSpanNotAvailable, err)
 	}
 	runtime.SetFinalizer(r, func(r cache.Reader) {
 		r.Close()


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Before this change, the span manager would replace the error received from `m.cache.Get` with a generic `ErrSpanNotAvailable`. The way we use the cache is really just as an abstraction of disk storage for span data so we don't generally expect `m.cache.Get` to throw an error. If it does, we should keep that context.

Multiple error wraps is a go 1.20 feature, so this is probably the first change that requires >go 1.18. 

**Testing performed:**
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
