### PR TITLE
Deterministically close open span cache file descriptors

### DIFF
--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -225,6 +225,7 @@ func (sf *file) ReadAt(p []byte, offset int64) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to read the file: %w", err)
 	}
+	defer r.Close()
 
 	// TODO this is not the right place for this metric to be. It needs to go down the BlobReader, when the HTTP request is issued
 	commonmetrics.IncOperationCount(commonmetrics.SynchronousReadRegistryFetchCount, sf.gr.layerSha) // increment the number of on demand file fetches from remote registry
@@ -234,6 +235,7 @@ func (sf *file) ReadAt(p []byte, offset int64) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("unexpected copied data size for on-demand fetch. read = %d, expected = %d", n, expectedSize)
 	}
+
 	commonmetrics.AddBytesCount(commonmetrics.SynchronousBytesServed, sf.gr.layerSha, int64(n)) // measure the number of bytes served synchronously
 
 	return n, nil


### PR DESCRIPTION
The snapshotter stores fetched spans in a cache either in memory or on disk. When reading from the cache on disk we use a [Finalizer](https://github.com/awslabs/soci-snapshotter/blob/main/fs/span-manager/span_manager.go#L401 ) construct to close the open file descriptors when the Go garbage collector sees that the fd is no longer being referenced. The issue with this is that we don't have control over when the GC runs (although it's possible), and so the process could hold on too open fds for a unknown amount of time causing a sort of leak. On systems where the snapshotter is bounded by a ulimit in the number of open files, this can cause the snapshotter span cache get calls to fail, causing `file.Read` failures for the running container/process. This change wraps the readers returned by the cache in `io.ReadCloser`'s, so we can deterministically close the files once the content has been read from them.

**Issue #, if available:**

**Description of changes:**


**Testing performed:**

To test the change we can set a `ulimit` on the snapshotter and then pull an image and run a container with and without the change. In theory, we should see `failed to read the file: span not available in cache` errors without the change and none with it.

### Determine ulimit

We can determine `nofile ulimit` by dry running a container and curling the metrics endpoint to examine the amount of open fd's when idle (not running the container), when running the container, and a little while after the container fetches the spans.

```shell

$ soci image rpull public.ecr.aws/soci-workshop-examples/rabbitmq:latest
# run a script that continuously calls the metrics endpoint for around 20s and dumps the results in a file
$ ./collector.sh
# start container 
$ ctr run -d --snapshotter soci --net-host public.ecr.aws/soci-workshop-examples/rabbitmq:latest sociExample
$ cat fd.txt
process_open_fds 46
...
process_open_fds 79
...
process_open_fds 118
...
process_open_fds 46
```
It looks like the idle open fd is around 46 and can spike up to 100+ when running the container without the change. We have also ran the exact test with the change and the open fd's seem to be fairly stable and only ever goes up to around 47.

### Running test

Without change
``` 
$ sudo prlimit --pid soci --nofile=70:70 
$ soci image rpull public.ecr.aws/soci-workshop-examples/rabbitmq:latest
$ ctr run -d --snapshotter soci --net-host public.ecr.aws/soci-workshop-examples/rabbitmq:latest sociExample
# Cat logs
$ cat ~/soci_log | grep "span not available in cache"
{"digest":"sha256:99803d4b97f3db529ae9ca4174b0951afac6b309e7deaa8ec3214c584e02b3a8","error":"file.Read: failed to read the file: span not available in cache: failed to open blob file for \"0\": open /var/lib/soci-snapshotter-grpc/soci/spancache/3753186881/0: too many open files","fetchedPercent":0,"fetchedSize":0,"level":"error","msg":"statFile error","size":28578563,"time":"2023-08-18T14:39:10.708256919Z"}
{"digest":"sha256:778d7f6440dcc8d94f29eab78819fdbd296217cbeee40364f4cc9e9fc41790a3","error":"file.Read: failed to read the file: span not available in cache: failed to open blob file for \"0\": open /var/lib/soci-snapshotter-grpc/soci/spancache/1121699285/0: too many open files","fetchedPercent":0,"fetchedSize":0,"level":"error","msg":"statFile error","size":54901810,"time":"2023-08-18T14:39:11.976654170Z"}
{"digest":"sha256:778d7f6440dcc8d94f29eab78819fdbd296217cbeee40364f4cc9e9fc41790a3","error":"file.Read: failed to read the file: span not available in cache: failed to open blob file for \"0\": open /var/lib/soci-snapshotter-grpc/soci/spancache/1121699285/0: too many open files","fetchedPercent":0,"fetchedSize":0,"level":"error","msg":"statFile error","size":54901810,"time":"2023-08-18T14:39:11.976737217Z"}
{"digest":"sha256:778d7f6440dcc8d94f29eab78819fdbd296217cbeee40364f4cc9e9fc41790a3","error":"file.Read: failed to read the file: span not available in cache: failed to open blob file for \"0\": open /var/lib/soci-snapshotter-grpc/soci/spancache/1121699285/0: too many open files","fetchedPercent":0,"fetchedSize":0,"level":"error","msg":"statFile error","size":54901810,"time":"2023-08-18T14:39:11.976799974Z"}
```
With change
``` 
$ sudo prlimit --pid soci --nofile=70:70 
$ soci image rpull public.ecr.aws/soci-workshop-examples/rabbitmq:latest
$ ctr run -d --snapshotter soci --net-host public.ecr.aws/soci-workshop-examples/rabbitmq:latest sociExample
# Cat logs
$ cat ~/soci_log | grep "span not available in cache"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
