### PR TITLE
Using standard error package instead of go-multierror for multierror error.

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -34,6 +34,7 @@ package cache
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -42,7 +43,6 @@ import (
 
 	"github.com/awslabs/soci-snapshotter/util/lrucache"
 	"github.com/awslabs/soci-snapshotter/util/namedmutex"
-	"github.com/hashicorp/go-multierror"
 )
 
 const (
@@ -291,9 +291,9 @@ func (dc *directoryCache) Add(key string, opts ...Option) (Writer, error) {
 			if err := os.MkdirAll(filepath.Dir(c), os.ModePerm); err != nil {
 				var allErr error
 				if err := os.Remove(wip.Name()); err != nil {
-					allErr = multierror.Append(allErr, err)
+					allErr = errors.Join(allErr, err)
 				}
-				return multierror.Append(allErr,
+				return errors.Join(allErr,
 					fmt.Errorf("failed to create cache directory %q: %w", c, err))
 			}
 			return os.Rename(wip.Name(), c)

--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -39,6 +39,7 @@
 package reader
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -50,7 +51,6 @@ import (
 	spanmanager "github.com/awslabs/soci-snapshotter/fs/span-manager"
 	"github.com/awslabs/soci-snapshotter/metadata"
 	"github.com/awslabs/soci-snapshotter/ztoc/compression"
-	"github.com/hashicorp/go-multierror"
 	digest "github.com/opencontainers/go-digest"
 )
 
@@ -188,7 +188,7 @@ func (gr *reader) Close() (retErr error) {
 	}
 	gr.closed = true
 	if err := gr.r.Close(); err != nil {
-		retErr = multierror.Append(retErr, err)
+		retErr = errors.Join(retErr, err)
 	}
 	return
 }

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -41,6 +41,7 @@ package remote
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -62,7 +63,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes/docker"
-	"github.com/hashicorp/go-multierror"
 	rhttp "github.com/hashicorp/go-retryablehttp"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -120,7 +120,7 @@ func (r *Resolver) resolveFetcher(ctx context.Context, hosts source.RegistryHost
 		// TODO: allow to configure the selection of readers based on the hostname in refspec
 		r, size, err := p.Handle(ctx, desc)
 		if err != nil {
-			handlersErr = multierror.Append(handlersErr, err)
+			handlersErr = errors.Join(handlersErr, err)
 			continue
 		}
 		log.G(ctx).WithField("handler name", name).WithField("ref", refspec.String()).WithField("digest", desc.Digest).

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/hanwen/go-fuse/v2 v2.3.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/klauspost/compress v1.16.7
 	github.com/moby/sys/mountinfo v0.6.2
@@ -64,6 +63,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/metadata/util_test.go
+++ b/metadata/util_test.go
@@ -34,6 +34,7 @@ package metadata
 
 import (
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -45,7 +46,6 @@ import (
 
 	"github.com/awslabs/soci-snapshotter/util/testutil"
 	"github.com/awslabs/soci-snapshotter/ztoc"
-	"github.com/hashicorp/go-multierror"
 )
 
 var allowedPrefix = [4]string{"", "./", "/", "../"}
@@ -217,7 +217,7 @@ func newCalledTelemetry() (telemetry *Telemetry, check func() error) {
 		}, func() error {
 			var allErr error
 			if !initMetadataStoreLatencyCalled {
-				allErr = multierror.Append(allErr, fmt.Errorf("metrics initMetadataStoreLatency isn't called"))
+				allErr = errors.Join(allErr, fmt.Errorf("metrics initMetadataStoreLatency isn't called"))
 			}
 			return allErr
 		}

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -35,7 +35,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/platforms"
-	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -568,7 +567,7 @@ func WriteSociIndex(ctx context.Context, indexWithMetadata *IndexWithMetadata, c
 	for i, blob := range indexWithMetadata.Index.Blobs {
 		err = store.LabelGCRefContent(ctx, contentStore, desc, "ztoc."+strconv.Itoa(i), blob.Digest.String())
 		if err != nil {
-			multierror.Append(allErr, err)
+			errors.Join(allErr, err)
 		}
 	}
 	if allErr != nil {

--- a/util/dockershell/compose/compose.go
+++ b/util/dockershell/compose/compose.go
@@ -34,6 +34,7 @@ package compose
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -41,7 +42,6 @@ import (
 	"strings"
 
 	dexec "github.com/awslabs/soci-snapshotter/util/dockershell/exec"
-	"github.com/hashicorp/go-multierror"
 	"github.com/rs/xid"
 )
 
@@ -297,7 +297,7 @@ func (c *Compose) List() (l []string) {
 func (c *Compose) Cleanup() (retErr error) {
 	for _, f := range c.cleanups {
 		if err := f(); err != nil {
-			retErr = multierror.Append(retErr, err)
+			retErr = errors.Join(retErr, err)
 		}
 	}
 	return

--- a/util/testutil/shell.go
+++ b/util/testutil/shell.go
@@ -52,7 +52,6 @@ import (
 
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
-	"github.com/hashicorp/go-multierror"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/rs/xid"
@@ -357,7 +356,7 @@ func KillMatchingProcess(sh *shell.Shell, psLinePattern string) error {
 	var allErr error
 	for _, pid := range targets {
 		if err := sh.Command("kill", "-9", fmt.Sprintf("%d", pid)).Run(); err != nil {
-			multierror.Append(allErr, fmt.Errorf("failed to kill %v: %w", pid, err))
+			errors.Join(allErr, fmt.Errorf("failed to kill %v: %w", pid, err))
 		}
 	}
 	return allErr


### PR DESCRIPTION
**Issue #, if available:**

Changes suggested in #793 

**Description of changes:**

- Using `errors.Join()` to join multiple errors together instead of using `mutlierror.Append()`
- Making sure `go-mutlierror` package is not present as direct dependancy in `go.mod` and `cmd/go.mod`

**Testing performed:**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
