### PR TITLE
Remove remote snapshot key from local mount logs

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -339,16 +339,16 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 			// count also AlreadyExists as "success"
 			// there's no need to provide any details on []mount.Mount because mounting is already taken care of
 			// by snapshotter
-			log.G(lCtx).WithField(remoteSnapshotLogKey, prepareSucceeded).Info("local snapshot successfully prepared")
+			log.G(lCtx).Info("local snapshot successfully prepared")
 			return nil, fmt.Errorf("target snapshot %q: %w", target, errdefs.ErrAlreadyExists)
 		}
-		log.G(lCtx).WithField(remoteSnapshotLogKey, prepareFailed).WithError(err).Warn("failed to internally commit local snapshot")
+		log.G(lCtx).WithError(err).Warn("failed to internally commit local snapshot")
 		// Don't fallback here (= prohibit to use this key again) because the FileSystem
 		// possible has done some work on this "upper" directory.
 		return nil, err
 	}
 
-	log.G(lCtx).WithField(remoteSnapshotLogKey, prepareFailed).WithError(err).Warn("failed to prepare snapshot; deferring to container runtime")
+	log.G(lCtx).WithError(err).Warn("failed to prepare snapshot; deferring to container runtime")
 	return mounts, nil
 }
 


### PR DESCRIPTION


**Issue #, if available:**

**Description of changes:**
In an attempt to make it more clear when we aren't lazily loading layers, we emit logs with a "remote-snapshot-prepared":"false" context. This often happens when a layer doesn't have a ztoc.

When we skipped lazy loading, we emitted a log saying that we skipped, but we also emitted a confusing (and incorrect) message like:

```
{"msg":"local snapshot successfully prepared","remote-snapshot-prepared":"true"}
```

This could say "remote-snapshot-prepared":"false", but this change is more clear because there is exactly 1 log line that contains the key per image layer. By inspecting the logs, you can count how many layers weren't lazily loaded by counting the number of log lines with "remote-snapshot-prepared":"false".

**Testing performed:**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
