### PR TITLE
Allow manually tirggering bump-deps on forks

### DIFF
--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -16,7 +16,7 @@ jobs:
     name: Bump Deps
 
     # Don't bother bumping deps on forks.
-    if: ${{ github.repository == 'awslabs/soci-snapshotter' }}
+    if: ${{ github.repository == 'awslabs/soci-snapshotter' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
**Issue #, if available:**
Related to #765 

**Description of changes:**
By default, bump-deps doesn't run on forks since forks will generally get updates by rebasing on awslabs/soci-snapshotter. When making changes to dump-deps.sh, however, we generally want to test on a fork before merging the change upstream. Before this change, users had to temporarily enable the cron workflow on their fork to manually test, then re-disable it before submitting a PR. With this change, you can manually run bump-deps on a fork without any changes.

**Testing performed:**
Manually triggered bump deps on my fork: https://github.com/Kern--/soci-snapshotter/actions/runs/6017833020

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
