### PR TITLE
Add TOC entry validation on first read

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -91,8 +91,11 @@ type Reader interface {
 }
 
 type File interface {
+	Name() string
 	GetUncompressedFileSize() compression.Offset
 	GetUncompressedOffset() compression.Offset
+	TarHeaderOffset() compression.Offset
+	TarHeaderSize() compression.Offset
 }
 
 type Options struct {

--- a/util/ioutils/positiontrackerreader.go
+++ b/util/ioutils/positiontrackerreader.go
@@ -1,0 +1,48 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ioutils
+
+import (
+	"io"
+)
+
+// PositionTrackerReader is an `io.Reader` that tracks the current read position
+// in an underlying `io.Reader`
+type PositionTrackerReader struct {
+	r   io.Reader
+	pos int64
+}
+
+// NewPositionTrackerReader creates a new PositionTrackerReader with the initial position
+// set to 0.
+func NewPositionTrackerReader(r io.Reader) *PositionTrackerReader {
+	return &PositionTrackerReader{r, 0}
+}
+
+// Read reads from the PositionTrackerReader into the provided byte slice.
+// The number position of the PositionTrackerReader is updated based on the
+// number of bytes read
+func (p *PositionTrackerReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	p.pos += int64(n)
+	return n, err
+}
+
+// CurrentPos is the current position of the PositionTrackerReader
+func (p *PositionTrackerReader) CurrentPos() int64 {
+	return p.pos
+}

--- a/util/ioutils/positiontrackerreader_test.go
+++ b/util/ioutils/positiontrackerreader_test.go
@@ -1,0 +1,90 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ioutils
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+var bs []byte = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+
+func copy(b []byte, n int) error {
+	if len(b) < n {
+		return errors.New("buffer is too short")
+	}
+	for i := 0; i < n; i++ {
+		b[i] = bs[i]
+	}
+	return nil
+}
+
+type testReader struct {
+	n   int
+	err error
+}
+
+func (s *testReader) Read(b []byte) (int, error) {
+	copy(b, s.n)
+	return s.n, s.err
+}
+
+func TestPositionTrackingReader(t *testing.T) {
+	tests := []struct {
+		name        string
+		r           io.Reader
+		expectedPos int64
+		expectedErr error
+	}{
+		{
+			name:        "full read tracks position correctly",
+			r:           bytes.NewReader(bs),
+			expectedPos: 10,
+			expectedErr: nil,
+		},
+		{
+			name:        "short read tracks position correctly",
+			r:           &testReader{5, nil},
+			expectedPos: 5,
+			expectedErr: nil,
+		},
+		{
+			name:        "err read tracks position correctly",
+			r:           &testReader{5, io.ErrUnexpectedEOF},
+			expectedPos: 5,
+			expectedErr: io.ErrUnexpectedEOF,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			pt := NewPositionTrackerReader(tc.r)
+			b := make([]byte, 10)
+			_, err := pt.Read(b)
+			if pt.CurrentPos() != tc.expectedPos {
+				t.Fatalf("incorrect position. Expected %d, Actual %d", tc.expectedPos, pt.CurrentPos())
+			}
+			if tc.expectedErr != nil && !errors.Is(err, tc.expectedErr) {
+				t.Fatalf("incorrect error. Expected %v, Actual %v", tc.expectedErr, err)
+			}
+		})
+	}
+
+}

--- a/ztoc/tar.go
+++ b/ztoc/tar.go
@@ -1,0 +1,31 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ztoc
+
+import "github.com/awslabs/soci-snapshotter/ztoc/compression"
+
+// TarBlockSize is the size of a tar block
+const TarBlockSize = 512
+
+// AlignToTarBlock aligns an offset to the next larger multiple of TarBlockSize
+func AlignToTarBlock(o compression.Offset) compression.Offset {
+	offset := o % TarBlockSize
+	if offset > 0 {
+		o += TarBlockSize - offset
+	}
+	return o
+}

--- a/ztoc/ztoc.go
+++ b/ztoc/ztoc.go
@@ -75,6 +75,7 @@ type FileMetadata struct {
 	Type               string
 	UncompressedOffset compression.Offset
 	UncompressedSize   compression.Offset
+	TarHeaderOffset    compression.Offset
 	Linkname           string // Target name of link (valid for TypeLink or TypeSymlink)
 	Mode               int64  // Permission and mode bits
 	UID                int    // User ID of owner
@@ -107,6 +108,34 @@ func (src FileMetadata) FileMode() (m os.FileMode) {
 		m |= os.ModeNamedPipe
 	}
 	return m
+}
+
+func (src FileMetadata) Equal(o FileMetadata) bool {
+	if src.Name != o.Name ||
+		src.Type != o.Type ||
+		src.UncompressedOffset != o.UncompressedOffset ||
+		src.UncompressedSize != o.UncompressedSize ||
+		src.TarHeaderOffset != o.TarHeaderOffset ||
+		src.Linkname != o.Linkname ||
+		src.Mode != o.Mode ||
+		src.UID != o.UID ||
+		src.GID != o.GID ||
+		src.Uname != o.Uname ||
+		src.Gname != o.Gname ||
+		src.ModTime != o.ModTime ||
+		src.Devmajor != o.Devmajor ||
+		src.Devminor != o.Devminor {
+		return false
+	}
+	if len(src.Xattrs) != len(o.Xattrs) {
+		return false
+	}
+	for k, v := range src.Xattrs {
+		if o.Xattrs[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // MetadataEntry is used to locate a file based on its metadata.

--- a/ztoc/ztoc_marshaler_test.go
+++ b/ztoc/ztoc_marshaler_test.go
@@ -1,0 +1,164 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ztoc
+
+import (
+	"errors"
+	"testing"
+
+	ztoc_flatbuffers "github.com/awslabs/soci-snapshotter/ztoc/fbs/ztoc"
+	flatbuffers "github.com/google/flatbuffers/go"
+)
+
+// roundtrip serializes and then immediately deserializes
+// a TOC. This is useful for verifying the deserialization logic.
+func roundtrip(toc *TOC) (TOC, error) {
+	builder := flatbuffers.NewBuilder(0)
+	tocFB := tocToFlatbuffer(toc, builder)
+	builder.Finish(tocFB)
+	bytes := builder.FinishedBytes()
+
+	fbtoc := ztoc_flatbuffers.GetRootAsTOC(bytes, 0)
+	return flatbufferToTOC(fbtoc)
+}
+
+func TestPositiveTOCRoundtrip(t *testing.T) {
+	// The two files in this test are aligned like a well-formatted tar file with one
+	// header+data following the other. The offsets/sizes are mostly arbitrary except
+	// that offsets are aligned to 512 as expected for tar.
+	//
+	//  1 tar hdr            1 data     2 tar hdr  2 tar data
+	// |--------------------|----------|----------|--------------------|
+	// 0                  1024       1536       2048                 3072
+
+	testFile1 := FileMetadata{
+		Name:               "file1",
+		UncompressedOffset: 1024,
+		UncompressedSize:   500,
+		TarHeaderOffset:    0,
+	}
+	testFile2 := FileMetadata{
+		Name:               "file2",
+		UncompressedOffset: 2048,
+		UncompressedSize:   1000,
+		TarHeaderOffset:    testFile1.UncompressedOffset + 512,
+	}
+	tests := []struct {
+		name        string
+		toc         TOC
+		expectedTOC TOC
+	}{
+		{
+			name: "serialize -> deserialize produces same toc",
+			toc: TOC{
+				[]FileMetadata{
+					testFile1,
+					testFile2,
+				},
+			},
+			expectedTOC: TOC{
+				[]FileMetadata{
+					testFile1,
+					testFile2,
+				},
+			},
+		},
+		{
+			name: "files are reordered by uncompressed offset",
+			toc: TOC{
+				[]FileMetadata{
+					testFile2,
+					testFile1,
+				},
+			},
+			expectedTOC: TOC{
+				[]FileMetadata{
+					testFile1,
+					testFile2,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actualTOC, err := roundtrip(&tc.toc)
+			if err != nil {
+				t.Fatalf("toc deserialization produced unexpected error: %v", err)
+			}
+			if len(actualTOC.FileMetadata) != len(tc.expectedTOC.FileMetadata) {
+				t.Fatalf("toc did not deserialize as expected. Actual %v, expected %v", actualTOC, tc.expectedTOC)
+			}
+			for i := range actualTOC.FileMetadata {
+				actualEntry := actualTOC.FileMetadata[i]
+				expectedEntry := tc.expectedTOC.FileMetadata[i]
+				if !actualEntry.Equal(expectedEntry) {
+					t.Fatalf("toc entry did not deserialize as expected. Actual %v, expected %v", actualEntry, expectedEntry)
+				}
+			}
+		})
+	}
+}
+
+func TestNegativeTOCRoundtrip(t *testing.T) {
+	var anyError error
+	// The two files in this test are aligned as if overlapped.
+	//
+	//  1 tar hdr            1 data
+	// |--------------------|----------|
+	//                      |----------|--------------------|
+	//                       2 tar hdr  2 tar data
+	//   0                1024       1536                 2560
+	testFile1 := FileMetadata{
+		UncompressedOffset: 1024,
+		UncompressedSize:   500,
+	}
+	overlapTestFile1 := FileMetadata{
+		UncompressedOffset: testFile1.UncompressedOffset,
+		UncompressedSize:   500,
+	}
+	tests := []struct {
+		name          string
+		toc           TOC
+		expectedError error
+	}{
+		{
+			name: "overlapping files are invalid",
+			toc: TOC{
+				[]FileMetadata{
+					testFile1,
+					overlapTestFile1,
+				},
+			},
+			expectedError: ErrInvalidTOCEntry,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := roundtrip(&tc.toc)
+			if err == nil {
+				t.Fatal("toc deserialization did not produce expected error")
+			}
+			if tc.expectedError != anyError && !errors.Is(err, tc.expectedError) {
+				t.Fatalf("toc deserializtion did not produce the correct error. Actual %v, expected %v", err, tc.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION

**Issue #, if available:**

**Description of changes:**
This change validates that when a file is read, the TOC entry is checked to be sure that it matches the TAR header in the image layer.


**Testing performed:**
`make check && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
