### PR TITLE
Skip grpc in bump-deps.sh

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,10 @@ updates:
     schedule:
       interval: "daily"
     ignore:
+      # skip grpc because the current latest is not compatible with containerd 1.7
       # skip k8s deps since they use the latest go version/features that may not be in the go version soci uses
       # Also ignored in /scripts/bump-deps.sh
+      - dependency-name: "google.golang.org/grpc"
       - dependency-name: "k8s.io/*"
 
   # Automatic upgrade for go modules of cmd package.
@@ -17,9 +19,11 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # skip k8s deps and soci-snapshotter itself
+      # skip grpc because the current latest is not compatible with containerd 1.7
+      # skip k8s deps since they use the latest go version/features that may not be in the go version soci uses
       # Also ignored in /scripts/bump-deps.sh
       - dependency-name: "github.com/awslabs/soci-snapshotter"
+      - dependency-name: "google.golang.org/grpc"
       - dependency-name: "k8s.io/*"
 
   # Automatic upgrade for base images used in the Dockerfile

--- a/scripts/bump-deps.sh
+++ b/scripts/bump-deps.sh
@@ -22,16 +22,20 @@ SOCI_SNAPSHOTTER_PROJECT_ROOT="${CUR_DIR}/.."
 pushd ${SOCI_SNAPSHOTTER_PROJECT_ROOT}
 
 # skip k8s deps since they use the latest go version/features that may not be in the go version soci uses
+# skip grpc because it's not compatible with containerd 1.7
 # Also ignored in /dependabot.yml
-go get -u $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
+go get $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
+    grep -v "^google.golang.org/grpc" | \
     grep -v "^k8s.io/")
 make vendor
 
 pushd ./cmd
 # skip k8s deps and soci-snapshotter itself
+# skip grpc because it's not compatible with containerd 1.7
 # Also ignored in /dependabot.yml
-go get -u $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
+go get $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
     grep -v "^github.com/awslabs/soci-snapshotter" | \
+    grep -v "^google.golang.org/grpc" | \
     grep -v "^k8s.io/")
 popd
 make vendor


### PR DESCRIPTION
**Issue #, if available:**
Related to https://github.com/awslabs/soci-snapshotter/issues/765

**Description of changes:**
The latest version of grpc is not compatible with the version containerd is using. Skip automatic updates.

This change also stops using the `-u` flag in `go get`. The flag causes `go get` to update transitive depdendencies which means that grpc was getting update whenever we tried to update containerd.


**Testing performed:**
Example of the new bump-deps passing in my fork:
https://github.com/Kern--/soci-snapshotter/pull/84
https://github.com/Kern--/soci-snapshotter/actions/runs/6112565587?pr=84


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
