### PR TITLE
Protect node.ents and node.entsCached with a mutex in fs/layer/node.go

### DIFF
--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -252,11 +252,13 @@ func (fs *fs) inodeOfID(id uint32) (uint64, error) {
 // node is a filesystem inode abstraction.
 type node struct {
 	fusefs.Inode
-	fs         *fs
-	id         uint32
-	attr       metadata.Attr
+	fs   *fs
+	id   uint32
+	attr metadata.Attr
+
 	ents       []fuse.DirEntry
 	entsCached bool
+	entsMu     sync.Mutex
 }
 
 func (n *node) logOperation(ctx context.Context, operationName string) {
@@ -300,9 +302,13 @@ func (n *node) readdir() ([]fuse.DirEntry, syscall.Errno) {
 	start := time.Now() // set start time
 	defer commonmetrics.MeasureLatencyInMicroseconds(commonmetrics.NodeReaddir, n.fs.layerDigest, start)
 
+	n.entsMu.Lock()
 	if n.entsCached {
-		return n.ents, 0
+		ents := n.ents
+		n.entsMu.Unlock()
+		return ents, 0
 	}
+	n.entsMu.Unlock()
 
 	var ents []fuse.DirEntry
 	whiteouts := map[string]uint32{}
@@ -361,6 +367,8 @@ func (n *node) readdir() ([]fuse.DirEntry, syscall.Errno) {
 	sort.Slice(ents, func(i, j int) bool {
 		return ents[i].Name < ents[j].Name
 	})
+	n.entsMu.Lock()
+	defer n.entsMu.Unlock()
 	n.ents, n.entsCached = ents, true // cache it
 
 	return ents, 0
@@ -414,6 +422,7 @@ func (n *node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fu
 	}
 
 	// early return if this entry doesn't exist
+	n.entsMu.Lock()
 	if n.entsCached {
 		var found bool
 		for _, e := range n.ents {
@@ -422,9 +431,11 @@ func (n *node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fu
 			}
 		}
 		if !found {
+			n.entsMu.Unlock()
 			return nil, syscall.ENOENT
 		}
 	}
+	n.entsMu.Unlock()
 
 	id, ce, err := n.fs.r.Metadata().GetChild(n.id, name)
 	if err != nil {


### PR DESCRIPTION
**Issue #, if available:**
None

**Description of changes:**
We run a modified version of the soci-snapshotter in production at BuildBuddy and recently enabled the golang race detector in our dev environment. It flagged racy accesses to `node.ents` and `node.entsCached`, I've attached the [logs](https://github.com/awslabs/soci-snapshotter/files/12591454/datarace.txt) for line numbers (which should be unmodified). This PR protects access to those two fields with a mutex.



**Testing performed:**
In addition to the PR checks, I pulled and ran an indexed image and it seemed to work fine, but didn't do any additional testing beyond that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
