### PR TITLE
Update Getting Started Doc to v0.4.0

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,8 +54,8 @@ directory (`/usr/local/bin`):
 > You can find other download link in the release page that matches your machine.
 
 ```shell
-wget https://github.com/awslabs/soci-snapshotter/releases/download/v0.3.0/soci-snapshotter-0.3.0-linux-amd64.tar.gz
-sudo tar -C /usr/local/bin -xvf soci-snapshotter-0.3.0-linux-amd64.tar.gz soci soci-snapshotter-grpc
+wget https://github.com/awslabs/soci-snapshotter/releases/download/v0.4.0/soci-snapshotter-0.4.0-linux-amd64.tar.gz
+sudo tar -C /usr/local/bin -xvf soci-snapshotter-0.4.0-linux-amd64.tar.gz soci soci-snapshotter-grpc
 ```
 
 Now you should be able to use the `soci` CLI (and `soci-snapshotter-grpc` containerd plugin shortly):


### PR DESCRIPTION
**Issue #, if available:**
None

**Description of changes:**
Changed the Getting Started guide to use v0.4.0 instead of v0.3.0

**Testing performed:**
Ensured the `wget` command still worked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
