### PR TITLE
Add ARM testing to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ on:
       - 'Dockerfile'
       - 'integration/**'
       - 'scripts/**'
+env:
+  GO_VERSION: '1.20.6'
 
 jobs:
   test:
@@ -25,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.6'
+          go-version: ${{ env.GO_VERSION }}
       - run: make
       - run: make test
   integration:
@@ -40,5 +42,51 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.6'
+          go-version: ${{ env.GO_VERSION }}
       - run: make integration
+
+  integration-arm64:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        containerd: ["1.7.0"]
+        arch: ["arm64"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: uraimo/run-on-arch-action@v2.5.1
+        id: integration-tests-arm64
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          env: |
+            DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"
+          dockerRunArgs: |
+            -v /tmp:/tmp
+            -v ${{ github.workspace }}:/soci-snapshotter
+          shell: /bin/bash
+          install: |
+            apt-get update
+            apt-get -y install curl gcc git make libz-dev wget
+            
+            wget -nv https://go.dev/dl/go${{ env.GO_VERSION }}.linux-arm64.tar.gz
+            rm -rf /usr/local/go && tar -C /usr/local -xzf go${{ env.GO_VERSION }}.linux-arm64.tar.gz
+
+            curl -fsSL https://get.docker.com -o get-docker.sh
+            sh ./get-docker.sh --version
+
+            curl -SL https://github.com/docker/compose/releases/download/v2.19.0/docker-compose-linux-aarch64 -o /usr/local/bin/docker-compose
+            chmod +x /usr/local/bin/docker-compose
+          run: |
+            echo ${{ github.workspace }}
+            dpkg --add-architecture arm64
+            export PATH=$PATH:/usr/local/go/bin
+
+            uname -m
+            go version
+            docker info
+            docker-compose --version
+            containerd --version
+
+            cd /soci-snapshotter
+            STATIC=1 GOFLAGS="-buildvcs=false" make integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ ARG TARGETARCH
 COPY . $GOPATH/src/github.com/awslabs/soci-snapshotter
 ENV GOPROXY direct
 RUN apt-get update -y && apt-get install -y libbtrfs-dev libseccomp-dev libz-dev gcc fuse pigz
+RUN if [ "$TARGETARCH" = "aarch64" ] ; then apt-get install -y glibc-static ; fi
+
 RUN cp $GOPATH/src/github.com/awslabs/soci-snapshotter/out/soci /usr/local/bin/ && \
     cp $GOPATH/src/github.com/awslabs/soci-snapshotter/out/soci-snapshotter-grpc /usr/local/bin/ && \
     mkdir /etc/soci-snapshotter-grpc && \


### PR DESCRIPTION
**Issue #, if available:**
#394 

**Description of changes:**
Attempted to create automated testing for ARM64 architecture via [run-on-arch](https://github.com/marketplace/actions/run-on-architecture) using the `aarch64` arch option. This essentially sets up a container emulating ARM64, so you will have to run all setup manually inside of there.

**This is not working in its current state.** However, if this gets picked up in the future, I think this is a good place to start.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
