### PR TITLE
Add ARM testing to workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ on:
       - 'Dockerfile'
       - 'integration/**'
       - 'scripts/**'
+env:
+  GO_VERSION: '1.20.6'
 
 jobs:
   test:
@@ -25,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.6'
+          go-version: ${{ env.GO_VERSION }}
       - run: make
       - run: make test
   integration:
@@ -40,5 +42,63 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.6'
+          go-version: ${{ env.GO_VERSION }}
       - run: make integration
+
+  integration-arm64:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        containerd: ["1.7.0"]
+        arch: ["arm64"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: uraimo/run-on-arch-action@v2.5.1
+        id: integration-tests-arm64
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          env: |
+            DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"
+          dockerRunArgs: |
+            -v /tmp:/tmp
+            -v ${{ github.workspace }}:/soci-snapshotter
+          shell: /bin/bash
+          install: |
+            dpkg --add-architecture arm64
+
+            apt-get update
+            apt-get -y install curl gcc git make libz-dev wget
+            
+            wget -nv https://go.dev/dl/go${{ env.GO_VERSION }}.linux-arm64.tar.gz
+            rm -rf /usr/local/go && tar -C /usr/local -xzf go${{ env.GO_VERSION }}.linux-arm64.tar.gz
+
+            curl -fsSL https://get.docker.com -o get-docker.sh
+            
+            # Force arm64 arch package installation
+            sed -i 's/arch=$(dpkg --print-architecture)/arch=arm64/g' get-docker.sh
+            sed -i 's/containerd.io/containerd.io:arm64/g' get-docker.sh
+            sed -i 's/pkg_version%=}/pkg_version%=}:arm64/g' get-docker.sh
+            sed -i 's/docker-compose-plugin/docker-compose-plugin:arm64/g' get-docker.sh
+            sed -i 's/docker-ce-rootless-extras$pkg_version/docker-ce-rootless-extras$pkg_version:arm64/g' get-docker.sh
+            sed -i 's/docker-buildx-plugin/docker-buildx-plugin:arm64/g' get-docker.sh
+
+            sh ./get-docker.sh
+            
+            curl -SL https://github.com/docker/compose/releases/download/v2.19.0/docker-compose-linux-aarch64 -o /usr/local/bin/docker-compose
+            chmod +x /usr/local/bin/docker-compose
+          run: |
+            echo ${{ github.workspace }}
+            dpkg --add-architecture arm64
+            export PATH=$PATH:/usr/local/go/bin
+            
+            uname -m
+            go version
+            docker info
+            docker-compose --version
+            containerd --version
+            go env
+
+            cd /soci-snapshotter
+            STATIC=1 GOFLAGS="-buildvcs=false" make integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ ARG TARGETARCH
 COPY . $GOPATH/src/github.com/awslabs/soci-snapshotter
 ENV GOPROXY direct
 RUN apt-get update -y && apt-get install -y libbtrfs-dev libseccomp-dev libz-dev gcc fuse pigz
+RUN if [ "$TARGETARCH" = "aarch64" ] ; then apt-get install -y glibc-static ; fi
+
 RUN cp $GOPATH/src/github.com/awslabs/soci-snapshotter/out/soci /usr/local/bin/ && \
     cp $GOPATH/src/github.com/awslabs/soci-snapshotter/out/soci-snapshotter-grpc /usr/local/bin/ && \
     mkdir /etc/soci-snapshotter-grpc && \


### PR DESCRIPTION
**Issue #, if available:**
#394 

**Description of changes:**
GH Actions does not natively support ARM architecture. By using [run-on-arch](https://github.com/marketplace/actions/run-on-architecture) emulator, I attempted to automate ARM testing.

I added a new workflow step dedicated to testing vs ARM64. (This was given its own step separate from the other testing matrix as a bug with arch detection was present prior to v1.7, so it makes no sense to test on previous versions of containerd with an ARM instance._ Within it, I use run-on-arch to spin up an ARM64-emulated container, mount the `/tmp` directory (to access files references by the Docker daemon) and the current `soci-snapshotter` repository. From there, I set up the testing environment manually in the barebones container. I additionally print some versioning information as debugging/reference before running the tests.

**THIS DOES NOT WORK AS INTENDED.** This is only to serve as a reference point for future work.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
