### PR TITLE
Add option to disable file verification

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -466,6 +466,8 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	// Verification is needed to instantiate reader
 	l.SkipVerify()
 	log.G(ctx).Infof("Verification forcefully skipped")
+	// Maybe we should reword the log here or remove it entirely,
+	// since the old Verify() function no longer serves any purpose.
 
 	node, err := l.RootNode(0)
 	if err != nil {

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -94,6 +94,7 @@ type Layer interface {
 
 	// Verify verifies this layer using the passed TOC Digest.
 	// Nop if Verify() or SkipVerify() was already called.
+	// NOTE: Legacy stargz code, this is never called.
 	Verify(tocDigest digest.Digest) (err error)
 
 	// SkipVerify skips verification for this layer.
@@ -456,6 +457,7 @@ func (l *layer) Refresh(ctx context.Context, hosts source.RegistryHosts, refspec
 	return l.blob.Refresh(ctx, hosts, refspec, desc)
 }
 
+// Never used, should probably just have it return nil.
 func (l *layer) Verify(tocDigest digest.Digest) (err error) {
 	if l.isClosed() {
 		return fmt.Errorf("layer is already closed")

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -229,7 +229,7 @@ func newCache(root string, cacheType string, cfg config.FSConfig) (cache.BlobCac
 }
 
 // Resolve resolves a layer based on the passed layer blob information.
-func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refspec reference.Spec, desc, sociDesc ocispec.Descriptor, opCounter *FuseOperationCounter, metadataOpts ...metadata.Option) (_ Layer, retErr error) {
+func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refspec reference.Spec, desc, sociDesc ocispec.Descriptor, opCounter *FuseOperationCounter, disableVerification bool, metadataOpts ...metadata.Option) (_ Layer, retErr error) {
 	name := refspec.String() + "/" + desc.Digest.String()
 
 	// Wait if resolving this layer is already running. The result
@@ -334,7 +334,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts source.RegistryHosts, refs
 		bgLayerResolver = backgroundfetcher.NewSequentialResolver(desc.Digest, spanManager)
 		r.bgFetcher.Add(bgLayerResolver)
 	}
-	vr, err := reader.NewReader(meta, desc.Digest, spanManager)
+	vr, err := reader.NewReader(meta, desc.Digest, spanManager, disableVerification)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read layer: %w", err)
 	}

--- a/fs/layer/util_test.go
+++ b/fs/layer/util_test.go
@@ -168,7 +168,7 @@ func makeNodeReader(t *testing.T, contents []byte, spanSize int64, factory metad
 		t.Fatalf("failed to create reader: %v", err)
 	}
 	spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
-	vr, err := reader.NewReader(mr, digest.FromString(""), spanManager)
+	vr, err := reader.NewReader(mr, digest.FromString(""), spanManager, false)
 	if err != nil {
 		mr.Close()
 		t.Fatalf("failed to make new reader: %v", err)
@@ -330,7 +330,7 @@ func testExistenceWithOpaque(t *testing.T, factory metadata.Store, opaque Overla
 				}
 				defer mr.Close()
 				spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
-				vr, err := reader.NewReader(mr, digest.FromString(""), spanManager)
+				vr, err := reader.NewReader(mr, digest.FromString(""), spanManager, false)
 				if err != nil {
 					t.Fatalf("failed to make new reader: %v", err)
 				}

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -156,7 +156,7 @@ func makeFile(t *testing.T, contents []byte, factory metadata.Store, spanSize in
 		t.Fatalf("failed to create reader: %v", err)
 	}
 	spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
-	vr, err := NewReader(mr, digest.FromString(""), spanManager)
+	vr, err := NewReader(mr, digest.FromString(""), spanManager, false)
 	if err != nil {
 		mr.Close()
 		t.Fatalf("failed to make new reader: %v", err)
@@ -212,7 +212,7 @@ func testFailReader(t *testing.T, factory metadata.Store) {
 				t.Fatalf("free ID not found")
 			}
 			spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
-			vr, err := NewReader(mr, digest.FromString(""), spanManager)
+			vr, err := NewReader(mr, digest.FromString(""), spanManager, false)
 			if err != nil {
 				mr.Close()
 				t.Fatalf("failed to make new reader: %v", err)


### PR DESCRIPTION
**Issue #, if available:**
#819

**Description of changes:**
#819 made an argument for allowing the user to disable file header verification if they want maximum performance. I refactored the `disable_verification` TOML variable (from legacy stargz code) so that, on true, it would skip this function call. This requires changing a couple of function headers, so this will have to be explicitly assigned. I considered making it an option of but figured it might be best to state this explicitly. Please let me know if that's not the case.

The first commit is of the above change. The second commit just highlights some minor functions that seemed deprecated but not big enough to warrant its own PR. Happy to remove/squash/make changes to that commit if needed.

**Testing performed:**
Some primitive print statements were used at the `Verify()` function calls to ensure the correct config value was passed through. I'm not sure if there's a good way to ensure the variable was plumbed through properly.

Ideally we also make sure that `Verify()` is doing its job properly, but that is probably outside of the scope of this issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
