### PR TITLE
Fix integrations tests with cgroupv2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ARG CONTAINERD_VERSION
 ARG RUNC_VERSION
 ARG NERDCTL_VERSION
 ARG TARGETARCH
+COPY ./integ_entrypoint.sh /integ_entrypoint.sh
 COPY . $GOPATH/src/github.com/awslabs/soci-snapshotter
 ENV GOPROXY direct
 RUN apt-get update -y && apt-get install -y libbtrfs-dev libseccomp-dev libz-dev gcc fuse pigz

--- a/integ_entrypoint.sh
+++ b/integ_entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+#   Copyright The Soci Snapshotter Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -x
+
+# copied from moby/moby https://github.com/moby/moby/blob/52c92be4c5f94cdb93f775099d42c0ee6b66ccc7/hack/dind#L28-L38
+# Apache v2.0 License
+# Copyright 2012-2017 Docker, Inc.
+# cgroup v2: enable nesting
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+       # move the processes from the root group to the /init group,
+       # otherwise writing subtree_control fails with EBUSY.
+       # An error during moving non-existent process (i.e., "cat") is ignored.
+       mkdir -p /sys/fs/cgroup/init
+       xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+       # enable controllers
+       sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+               > /sys/fs/cgroup/cgroup.subtree_control
+fi
+
+sleep infinity

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -137,7 +137,7 @@ services:
    image: soci_base:soci_test
    privileged: true
    init: true
-   entrypoint: [ "sleep", "infinity" ]
+   entrypoint: [ "/integ_entrypoint.sh" ]
    environment:
     - NO_PROXY=127.0.0.1,localhost
    tmpfs:
@@ -154,7 +154,7 @@ services:
   image: soci_base:soci_test
   privileged: true
   init: true
-  entrypoint: [ "sleep", "infinity" ]
+  entrypoint: [ "/integ_entrypoint.sh" ]
   environment:
    - NO_PROXY=127.0.0.1,localhost,{{.RegistryHost}}:443
   tmpfs:
@@ -185,7 +185,7 @@ services:
     image: soci_base:soci_test
     privileged: true
     init: true
-    entrypoint: [ "sleep", "infinity" ]
+    entrypoint: [ "/integ_entrypoint.sh" ]
     environment:
     - NO_PROXY=127.0.0.1,localhost,{{.RegistryHost}}:443
     tmpfs:


### PR DESCRIPTION
**Issue #, if available:**
closes #735 

**Description of changes:**
With cgroupv2, dind doesn't work out of the box because the inner docker process is in the (containerized) root cgroup so it can't create the inner container's cgroups because doing so would make the inner docker a process on an interior cgroup node. cgroupv2 only allows processes on the leaf nodes.

The solution is to move docker to a child cgroup (called init) so that the container can exist as a sibling.

**Testing performed:**
`make check && make integration` on an al2023 instance which uses cgroupv2. 

Before this change the tests failed with:
```
ctr: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to apply cgroup configuration: cannot enter cgroupv2 "/sys/fs/cgroup/default" with domain controllers -- it is in an invalid state: unknown
```

after this change, the tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
