### PR TITLE
Support xattrs

### DIFF
--- a/fs/layer/util_test.go
+++ b/fs/layer/util_test.go
@@ -264,7 +264,7 @@ func testExistenceWithOpaque(t *testing.T, factory metadata.Store, opaque Overla
 			},
 			want: []check{
 				hasOpaque("foo/"),
-				hasNodeXattrs("foo/", "SCHILY.xattr.foo", "bar"),
+				hasNodeXattrs("foo/", "foo", "bar"),
 				fileNotExist("foo/.wh..wh..opq"),
 			},
 		},

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -155,7 +155,7 @@ log_fuse_operations = true
 		for i, md := range zt.FileMetadata {
 			md.UncompressedOffset += 2
 			md.UncompressedSize = math.MaxInt64
-			md.Xattrs = map[string]string{"foo": "bar"}
+			md.PAXHeaders = map[string]string{"foo": "bar"}
 			zt.FileMetadata[i] = md
 		}
 	}

--- a/metadata/reader.go
+++ b/metadata/reader.go
@@ -575,7 +575,7 @@ func attrFromZtocEntry(src *ztoc.FileMetadata, dst *Attr) *Attr {
 	dst.DevMajor = int(src.Devmajor)
 	dst.DevMinor = int(src.Devminor)
 	xattrs := make(map[string][]byte)
-	for k, v := range src.Xattrs {
+	for k, v := range src.Xattrs() {
 		xattrs[k] = []byte(v)
 	}
 	dst.Xattrs = xattrs

--- a/metadata/util_test.go
+++ b/metadata/util_test.go
@@ -92,7 +92,7 @@ func testReader(t *testing.T, factory readerFactory) {
 				hasModTime("xxx.txt", sampleTime),
 				hasFile("y.txt", 0),
 				// For details on the keys of Xattrs, see https://pkg.go.dev/archive/tar#Header
-				hasXattrs("y.txt", map[string]string{"SCHILY.xattr.testkey": "testval"}),
+				hasXattrs("y.txt", map[string]string{"testkey": "testval"}),
 			},
 		},
 		{
@@ -116,7 +116,7 @@ func testReader(t *testing.T, factory readerFactory) {
 				hasMode("foo", os.ModeDir|0600|os.ModeSticky),
 				hasOwner("foo/bar", 1000, 1000),
 				hasModTime("foo/a", sampleTime),
-				hasXattrs("foo/a/1", map[string]string{"SCHILY.xattr.testkey": "testval"}),
+				hasXattrs("foo/a/1", map[string]string{"testkey": "testval"}),
 				hasFile("foo/bar/baz.txt", 8),
 				hasFile("foo/bar/xxxx", 1),
 				hasFile("foo/bar/yyy", 3),

--- a/ztoc/fbs/ztoc.fbs
+++ b/ztoc/fbs/ztoc.fbs
@@ -22,7 +22,7 @@ table FileMetadata {
 	devmajor : long;		// Major device number (valid for TypeChar or TypeBlock)
 	devminor : long;		// Minor device number (valid for TypeChar or TypeBlock)
 
-	xattrs : [Xattr];
+	xattrs : [Xattr];       // Raw PAXRecords from the tar file. The name is wrong, but changing it is backwards incompatible
 }
 
 enum CompressionAlgorithm : byte { Gzip = 1, Uncompressed }

--- a/ztoc/toc_builder.go
+++ b/ztoc/toc_builder.go
@@ -150,7 +150,7 @@ func metadataFromTarReader(r io.Reader) ([]FileMetadata, compression.Offset, err
 			ModTime:            hdr.ModTime,
 			Devmajor:           hdr.Devmajor,
 			Devminor:           hdr.Devminor,
-			Xattrs:             hdr.PAXRecords,
+			PAXHeaders:         hdr.PAXRecords,
 		}
 		md = append(md, metadataEntry)
 		// The next file's tar header can be found immediately after the current file + padding

--- a/ztoc/ztoc.go
+++ b/ztoc/ztoc.go
@@ -87,7 +87,7 @@ type FileMetadata struct {
 	Devmajor int64     // Major device number (valid for TypeChar or TypeBlock)
 	Devminor int64     // Minor device number (valid for TypeChar or TypeBlock)
 
-	Xattrs map[string]string
+	PAXHeaders map[string]string
 }
 
 // FileMode gets file mode for the file metadata
@@ -127,15 +127,19 @@ func (src FileMetadata) Equal(o FileMetadata) bool {
 		src.Devminor != o.Devminor {
 		return false
 	}
-	if len(src.Xattrs) != len(o.Xattrs) {
+	if len(src.PAXHeaders) != len(o.PAXHeaders) {
 		return false
 	}
-	for k, v := range src.Xattrs {
-		if o.Xattrs[k] != v {
+	for k, v := range src.PAXHeaders {
+		if o.PAXHeaders[k] != v {
 			return false
 		}
 	}
 	return true
+}
+
+func (src FileMetadata) Xattrs() map[string]string {
+	return Xattrs(src.PAXHeaders)
 }
 
 // MetadataEntry is used to locate a file based on its metadata.

--- a/ztoc/ztoc_marshaler.go
+++ b/ztoc/ztoc_marshaler.go
@@ -126,13 +126,13 @@ func flatbufferToTOC(fbtoc *ztoc_flatbuffers.TOC) (TOC, error) {
 		me.ModTime = *modTime
 		me.Devmajor = metadataEntry.Devmajor()
 		me.Devminor = metadataEntry.Devminor()
-		me.Xattrs = make(map[string]string)
+		me.PAXHeaders = make(map[string]string)
 		for j := 0; j < metadataEntry.XattrsLength(); j++ {
 			xattrEntry := new(ztoc_flatbuffers.Xattr)
 			metadataEntry.Xattrs(xattrEntry, j)
 			key := string(xattrEntry.Key())
 			value := string(xattrEntry.Value())
-			me.Xattrs[key] = value
+			me.PAXHeaders[key] = value
 		}
 
 		toc.FileMetadata[i] = me
@@ -266,16 +266,16 @@ func prepareMetadataOffset(builder *flatbuffers.Builder, me FileMetadata) flatbu
 }
 
 func prepareXattrsOffset(me FileMetadata, builder *flatbuffers.Builder) flatbuffers.UOffsetT {
-	keys := make([]string, 0, len(me.Xattrs))
-	for k := range me.Xattrs {
+	keys := make([]string, 0, len(me.PAXHeaders))
+	for k := range me.PAXHeaders {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
-	xattrOffsetList := make([]flatbuffers.UOffsetT, 0, len(me.Xattrs))
+	xattrOffsetList := make([]flatbuffers.UOffsetT, 0, len(me.PAXHeaders))
 	for _, key := range keys {
 		keyOffset := builder.CreateString(key)
-		valueOffset := builder.CreateString(me.Xattrs[key])
+		valueOffset := builder.CreateString(me.PAXHeaders[key])
 		ztoc_flatbuffers.XattrStart(builder)
 		ztoc_flatbuffers.XattrAddKey(builder, keyOffset)
 		ztoc_flatbuffers.XattrAddValue(builder, valueOffset)
@@ -286,7 +286,7 @@ func prepareXattrsOffset(me FileMetadata, builder *flatbuffers.Builder) flatbuff
 	for j := len(xattrOffsetList) - 1; j >= 0; j-- {
 		builder.PrependUOffsetT(xattrOffsetList[j])
 	}
-	xattrs := builder.EndVector(len(me.Xattrs))
+	xattrs := builder.EndVector(len(me.PAXHeaders))
 	return xattrs
 }
 

--- a/ztoc/ztoc_test.go
+++ b/ztoc/ztoc_test.go
@@ -502,8 +502,8 @@ func testZtocSerialization(t *testing.T, compressionAlgo string, generator tarGe
 			// append xattrs
 			for i := 0; i < len(createdZtoc.FileMetadata); i++ {
 				for key := range tc.xattrs {
-					createdZtoc.FileMetadata[i].Xattrs = make(map[string]string)
-					createdZtoc.FileMetadata[i].Xattrs[key] = tc.xattrs[key]
+					createdZtoc.FileMetadata[i].PAXHeaders = make(map[string]string)
+					createdZtoc.FileMetadata[i].PAXHeaders[key] = tc.xattrs[key]
 				}
 			}
 


### PR DESCRIPTION
**Issue #, if available:**

Fixes #812 

**Description of changes:**
Before this change, SOCI stored all PAX header records as linux xattrs. PAX header records are a generic key-value pair for TAR files, not specifically linux xattrs. While go does support linux xattrs by prefixing them with SCHILY.xattr, since we didn't parse them back to linux xattrs, they did not behave correctly with SOCI. The most likely way users would experience this is that file capabilities don't work with SOCI.

This change keeps all PAX header records in the ztoc format, but parses out just the linux xattrs without the prefix when creating the filesystem metadata from a ztoc.

Docker, buildkit, buildah/podman, and kaniko all use the go tarHeader.Xattrs to add xattrs which uses the `SCHILY.xattr.` prefix. While there are technically other ways to encode xattrs (e.g. `LIBARCHIVE.xattr.`) it doesn't seem common.

**Testing performed:**
`make check && make test && make integration`

I also re-performed the security capability test from #812 to verify that it works with SOCI now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
