### PR TITLE
Add example config TOML

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -174,6 +174,7 @@ func main() {
 	if err != nil {
 		log.G(ctx).WithError(err).Fatalf("failed to configure metadata store")
 	}
+
 	fsOpts = append(fsOpts, fs.WithMetadataStore(mt))
 	rs, err := service.NewSociSnapshotterService(ctx, *rootDir, &cfg.ServiceConfig,
 		service.WithCredsFuncs(credsFuncs...), service.WithFilesystemOptions(fsOpts...))

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,0 +1,126 @@
+# An example config showing all of the toml variables used.
+
+# Copy to /etc/soci-snapshotter-grpc/config.toml
+# to use on your system.
+
+# NOTE: Many variables set to zero are just an indicator
+# to use the built-in default. These values may change over time,
+# which is why the config uses zeroes.
+
+# TODO: Can we put these inside dedicated TOML vars to refer to them?
+
+# config/fs.go FSConfig
+http_cache_type=""
+filesystem_cache_type=""
+resolve_result_entry=0 # Actually zero
+debug=false
+allow_no_verification=true
+# disable_verification=false
+# Causes TestRunWithDefaultConfig to break, but
+# fine to use in /etc/soci-snapshotter-grpc-config.toml
+max_concurrency=0  # Actually zero
+no_prometheus=false
+mount_timeout_sec=0
+fuse_metrics_emit_wait_duration_sec=0
+
+## config/config.go Config
+
+metrics_address=""
+metrics_network="" # Uses default metrics network
+# no_prometheus=true # Defined above, can't be redeclared
+debug_address=""
+metadata_store="db"
+
+[http]
+MaxRetries=0
+MinWaitMsec=0
+MaxWaitMsec=0
+DialTimeoutMsec=0
+ResponseHeaderTimeoutMsec=0
+RequestTimeoutMsec=0
+
+#
+## config/fs.go
+#
+
+[blob]
+valid_interval=0
+check_always=false
+fetching_timeout_sec=0
+force_single_range_mode=false
+# max_retries=0 # Set by http.
+# min_wait_msec=0 # Set by http.
+# max_wait_msec=0 # Set by http.
+max_span_verification_retries=0 # Actually zero
+
+[directory_cache]
+max_lru_cache_entry=0 # Actually zero
+max_cache_fds=0 # Actually zero
+sync_add=false
+direct=true
+
+[fuse]
+attr_timeout=0
+entry_timeout=0
+negative_timeout=0
+log_fuse_operations=false
+
+[background_fetch]
+disable=false
+silence_period_msec=0
+fetch_period_msec=0
+max_queue_size=0
+emit_metric_period_sec=0
+
+[content_store]
+type="" # will set to 'soci' by default
+namespace="" # will set to 'default' by default
+   
+#
+## config/resolver.go
+#
+
+[resolver]
+  [resolver.host]
+
+#
+## config/service.go
+#
+
+[kubeconfig_keychain]
+enable_keychain=false
+kubeconfig_path=""
+
+[cri_keychain]
+enable_keychain=false
+image_service_path="" # Uses default image service address
+
+[snapshotter]
+min_layer_size=0 # Actually zero
+allow_invalid_mounts_on_restart=false
+
+#
+## service/resolver/cri.go
+#
+
+[registry]
+config_path=""
+mirrors={}
+configs={}
+
+[Mirror]
+endpoint={}
+
+[RegistryConfig]
+
+[auth]
+username=""
+password=""
+auth=""
+identitytoken=""
+
+[tls]
+insecure_skip_verify=false
+ca_file=""
+cert_file=""
+key_file=""

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -39,6 +39,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -48,6 +49,21 @@ import (
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
 )
+
+func TestRunWithDefaultConfig(t *testing.T) {
+	b, err := os.ReadFile("../config/config.toml") // example toml file
+	if err != nil {
+		t.Fatalf("error fetching example toml")
+	}
+	config := string(b)
+
+	sh, c := newSnapshotterBaseShell(t)
+	defer c()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false, config))
+	// This will error internally if it fails to boot. If it boots successfully,
+	// the config was successfully parsed and snapshotter is running
+}
 
 // TestRunMultipleContainers runs multiple containers at the same time and performs a test in each
 func TestRunMultipleContainers(t *testing.T) {


### PR DESCRIPTION
**Issue #, if available:**
#758 

**Description of changes:**
Added an example TOML in config/config.toml documenting most of the available variables that can be changed in the TOML file. I omitted some variables that are known to be unused (particularly the `Config` struct in in service/plugin/plugin.go), but there are probably still some variables in this example that have no effect. If any of them are known to do nothing, they can be changed in a later PR.

I additionally left some comments attempting to clarify what certain variables do. For example, `MaxWaitMsec=0` under `[http]` will actually set the variable to the default value stored in the codebase for MaxWaitMsec, which in this case would be 300,000. This makes sense in this context (as waiting 0ms would never allow it to happen), but for something like `min_layer_size=0` under `[snapshotter]`, where a user might want no minimum layer size, it could cause some confusion. I did my best to outline this in the comments, but perhaps this confusion could be cleared in the future (e.g. by defaulting numeric values to -1 instead of 0).

**Testing performed:**
Created a new integration test in `run_test.go` called `TestRunWithDefaultConfig`, which creates a snapshotter base shell and reboots containerd with the example TOML. If it cannot parse the example TOML, it fails.

I also verified the TOML structure by getting the config and marshalling it with gotoml (right before line 178 in cmd/soci-snapshotter-grps/main.go [here](https://github.com/awslabs/soci-snapshotter/blob/31a8bcc683f7522d146d0505d034558909e53433/cmd/soci-snapshotter-grpc/main.go#L178)), then printing to stdout.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
