### PR TITLE
Upgrade to go 1.21 to fix `go get` panic when upgrading dependencies

### DIFF
--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.6'
+        go-version: '1.21.3'
 
     - run: ./scripts/bump-deps.sh
     - name: Create Pull Request


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Our bump dependency workflow was failing due to a [bug](https://github.com/golang/go/issues/56494) in `go get`. A [fix](https://go-review.googlesource.com/c/go/+/471595) has been available since go1.21, so we should upgrade our go version used in our bump dependency workflow.

**Testing performed:**

Upgraded to go 1.21.3 in the bump dependency workflow in my fork and ensured that it passed.

https://github.com/turan18/soci-snapshotter/actions/runs/6552120409

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
