### PR TITLE
Add release automation on tag push

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  create:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+env:
+  GO_VERSION: '1.20.6'
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  # Any way we can just call build.yml?
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - run: make
+      - run: make test
+      
+  integration:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        containerd: ["1.6.19", "1.7.0"]
+    env:
+      DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - run: make integration
+
+  generate-artifacts:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup and export variables
+      run: |
+        export release_tag=${GITHUB_REF#refs/*/} # Strip down to raw tag name
+        export release_version=${release_tag/v/} # Remove v from tag name
+
+        echo "release_tag=${release_tag}">> $GITHUB_ENV
+        echo "dynamic_binary_name=soci-snapshotter-${release_version}-linux-amd64.tar.gz" >> $GITHUB_ENV
+        echo "static_binary_name=soci-snapshotter-${release_version}-linux-amd64-static.tar.gz" >> $GITHUB_ENV
+        
+        mkdir release
+    - name: Create release binaries
+      run: make RELEASE_TAG=${{ env.release_tag }} release
+    - uses: actions/upload-artifact@v3
+      with:
+        name: artifacts
+        path: release/
+        if-no-files-found: error
+
+    outputs:
+      dynamic_binary_name: ${{ env.dynamic_binary_name }}
+      static_binary_name: ${{ env.static_binary_name }}
+
+  create-release:
+    needs: generate-artifacts
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+      - uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            ${{ needs.generate-artifacts.outputs.dynamic_binary_name }}
+            ${{ needs.generate-artifacts.outputs.dynamic_binary_name }}.sha256sum
+            ${{ needs.generate-artifacts.outputs.static_binary_name }}
+            ${{ needs.generate-artifacts.outputs.static_binary_name }}.sha256sum

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ CMD=soci-snapshotter-grpc soci
 
 CMD_BINARIES=$(addprefix $(OUTDIR)/,$(CMD))
 
-.PHONY: all build check add-ltag install uninstall clean test integration benchmarks build-benchmarks benchmarks-perf-test benchmarks-comparison-test
+.PHONY: all build check add-ltag install uninstall clean test integration release benchmarks build-benchmarks benchmarks-perf-test benchmarks-comparison-test
 
 all: build
 
@@ -91,6 +91,10 @@ integration: build
 	@echo "$@"
 	@echo "SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT)"
 	@GO111MODULE=$(GO111MODULE_VALUE) SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT) ENABLE_INTEGRATION_TEST=true go test $(GO_TEST_FLAGS) -v -timeout=0 ./integration
+
+release:
+	@echo "$@"
+	@$(SOCI_SNAPSHOTTER_PROJECT_ROOT)/scripts/create-releases.sh $(RELEASE_TAG)
 
 benchmarks: benchmarks-perf-test benchmarks-comparison-test
 

--- a/scripts/create-releases.sh
+++ b/scripts/create-releases.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+#   Copyright The Soci Snapshotter Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# A script to generate release artifacts.
+# This will create a folder in your project root called release.
+# This will contain the dynamic + static binaries
+# as well as their respective sha256 checksums.
+# NOTE: this will mutate your $SOCI_SNAPSHOTTER_PROJECT_ROOT/out folder.
+
+set -eux -o pipefail
+
+CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOCI_SNAPSHOTTER_PROJECT_ROOT="$(cd -- "$CUR_DIR"/.. && pwd)"
+OUT_DIR="${SOCI_SNAPSHOTTER_PROJECT_ROOT}/out"
+RELEASE_DIR="${SOCI_SNAPSHOTTER_PROJECT_ROOT}/release"
+LICENSE_FILE=${SOCI_SNAPSHOTTER_PROJECT_ROOT}/THIRD_PARTY_LICENSES
+NOTICE_FILE=${SOCI_SNAPSHOTTER_PROJECT_ROOT}/NOTICE.md
+TAG_REGEX="v[0-9]+.[0-9]+.[0-9]+"
+
+ARCH=""
+case $(uname -m) in
+    x86_64) ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    *) echo "Error: Unsupported arch"; exit 1 ;;
+esac
+
+if [ "$#" -ne 1 ]; then
+    echo "Expected 1 parameter, got $#."
+    echo "Usage: $0 [release_tag]"
+    exit 1
+fi
+
+if ! [[ "$1" =~ $TAG_REGEX ]]; then
+    echo "Improper tag format. Format should match regex $TAG_REGEX"
+    exit 1
+fi
+
+if [ -d "$RELEASE_DIR" ]; then
+    rm -rf "${RELEASE_DIR:?}"/*
+else
+    mkdir "$RELEASE_DIR"
+fi
+
+release_version=${1/v/} # Remove v from tag name
+dynamic_binary_name=soci-snapshotter-${release_version}-linux-${ARCH}.tar.gz
+static_binary_name=soci-snapshotter-${release_version}-linux-${ARCH}-static.tar.gz
+
+make build
+cp "$NOTICE_FILE" "$LICENSE_FILE" "${OUT_DIR}"
+tar -czvf "$RELEASE_DIR"/"$dynamic_binary_name" "$OUT_DIR"
+rm -rf "{$OUT_DIR:?}"/*
+
+STATIC=1 make build
+cp "$NOTICE_FILE" "$LICENSE_FILE" "$OUT_DIR"
+tar -czvf "$RELEASE_DIR"/"$static_binary_name" "$OUT_DIR"
+rm -rf "{$OUT_DIR:?}"/*
+
+sha256sum "$RELEASE_DIR"/"$dynamic_binary_name" > "$RELEASE_DIR"/"$dynamic_binary_name".sha256sum
+sha256sum "$RELEASE_DIR"/"$static_binary_name" > "$RELEASE_DIR"/"$static_binary_name".sha256sum


### PR DESCRIPTION
**Issue #, if available:**
#447

**Description of changes:**
Created a new workflow for automating part of the release process. On tag push, it will test the build on AMD64, create the binaries + sha256 checksums, and create a draft release with a changelog. Note that testing and building are run in parallel, which was an intentional design choice, but if we feel that the tests should pass before building the binaries, that can be changed.

ARM64 releases must still be created manually. Technically we could build the binaries with ARM64 here anyway but it would be considered poor practice to test and build in separate environments. (Still waiting for GH Actions to natively support ARM64 :v)

**Testing performed:**
I pushed a tag and ensured the workflow passed. You can see it running successfully [here](https://github.com/sondavidb/soci-snapshotter/actions/runs/6657291217/job/18091686729). The workflow was modified to include a THIRD_PARTY_LICENSES file, but otherwise is identical to the one in this PR. The workflow was triggered with the following:

```
git tag -s -a v999.999.999 -m "Release v999.999.999"
git push origin v999.999.999
```

The created release can be seen [here](https://github.com/sondavidb/soci-snapshotter/releases/tag/v999.999.999) (release will be deleted after PR is merged). Note that the changelog is empty. My guess is that this is due to previous testing with other tags making GitHub erroneously believe the last release was the tag previously pushed and deleted. This should not be an issue for official releases, but if a release needs to be modified for whatever reason, please bear in mind it may generate an empty changelog, so we should ensure we keep the original generated changelog.

To be explicit, this is not an official v999.999.999 release :P

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
