### PR TITLE
Keep directories when SIGINT sent to daemon

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -556,18 +556,21 @@ func (o *snapshotter) getCleanupDirectories(ctx context.Context, t storage.Trans
 }
 
 func (o *snapshotter) cleanupSnapshotDirectory(ctx context.Context, dir string) error {
-
-	// On a remote snapshot, the layer is mounted on the "fs" directory.
-	// We use Filesystem's Unmount API so that it can do necessary finalization
-	// before/after the unmount.
-	mp := filepath.Join(dir, "fs")
-	if err := o.fs.Unmount(ctx, mp); err != nil {
-		log.G(ctx).WithError(err).WithField("dir", mp).Debug("failed to unmount")
+	if err := o.unmountSnapshotDirectory(ctx, dir); err != nil {
+		return fmt.Errorf("failed to unmount directory %q: %w", dir, err)
 	}
 	if err := os.RemoveAll(dir); err != nil {
 		return fmt.Errorf("failed to remove directory %q: %w", dir, err)
 	}
 	return nil
+}
+
+func (o *snapshotter) unmountSnapshotDirectory(ctx context.Context, dir string) error {
+	// On a remote snapshot, the layer is mounted on the "fs" directory.
+	// We use Filesystem's Unmount API so that it can do necessary finalization
+	// before/after the unmount.
+	mp := filepath.Join(dir, "fs")
+	return o.fs.Unmount(ctx, mp)
 }
 
 func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, key, parent string, opts []snapshots.Opt) (_ storage.Snapshot, err error) {
@@ -743,10 +746,26 @@ func (o *snapshotter) Close() error {
 	// unmount all mounts including Committed
 	const cleanupCommitted = true
 	ctx := context.Background()
-	if err := o.cleanup(ctx, cleanupCommitted); err != nil {
-		log.G(ctx).WithError(err).Warn("failed to cleanup")
+	if err := o.unmountAllSnapshots(ctx, cleanupCommitted); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to unmount snapshots on close")
 	}
 	return o.ms.Close()
+}
+
+func (o *snapshotter) unmountAllSnapshots(ctx context.Context, cleanupCommitted bool) error {
+	cleanup, err := o.cleanupDirectories(ctx, cleanupCommitted)
+	if err != nil {
+		return err
+	}
+
+	log.G(ctx).Debugf("unmount: dirs=%v", cleanup)
+	for _, dir := range cleanup {
+		if err := o.unmountSnapshotDirectory(ctx, dir); err != nil {
+			log.G(ctx).WithError(err).WithField("path", dir).Warn("failed to unmount directory")
+		}
+	}
+
+	return nil
 }
 
 // prepareLocalSnapshot tries to prepare the snapshot as a local snapshot.


### PR DESCRIPTION
**Issue #, if available:**
#275, #832

**Description of changes:**
On SIGINT, the daemon will perform some cleanup functions, including removing the directories for each of the snapshot layers. However, the metadata does not reflect this change. This meant that, upon restarting the snapshot, the snapshot would not start unless `allow_invalid_mounts_on_restart=true` was set in the config. Even with the variable set, one had to manually remove the snapshot to get the daemon in a working state.

This was pretty frustrating behavior. What should be a graceful kill ends up being more work than using a non-graceful kill (i.e. SIGKILL/SIGTERM, which allow the snapshots to instantly start working again, no questions asked). Additionally, it was unintuitive (to me) that killing the daemon also wipes all the snapshotter data, forcing one to re-pull an image every time the daemon is killed.

This change removes the cleanup step of wiping the snapshot directories. It will still unmount the FUSE mounts, but the snapshotter [already tries to restore snapshots](https://github.com/awslabs/soci-snapshotter/blob/1e0057135d22a2bd91567200be8a73ead99bb63e/snapshot/snapshot.go#L199) on startup, which just unmounts any mounts leftover and remounts existing mounts in the metadata, so it ties in very well to snapshot startup

**Testing performed:**
I performed some basic testing, largely including pulling an image + running a container with it after a SIGINT and confirmed normal behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
