### PR TITLE
Add global FUSE failure metric

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -184,6 +184,9 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 	if ns != nil {
 		metrics.Register(ns) // Register layer metrics.
 	}
+
+	go commonmetrics.ListenForFuseFailure(ctx)
+
 	return &filesystem{
 		// it's generally considered bad practice to store a context in a struct,
 		// however `filesystem` has it's own lifecycle as well as a per-request lifecycle.


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Add a FUSE failure metric at a global/process level. 
Added telemetry helper functions around FUSE operations.

**Testing performed:**

`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
