### PR TITLE
Allow benchmarks config as json

### DIFF
--- a/benchmark/comparisonTest/main.go
+++ b/benchmark/comparisonTest/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	var (
 		numberOfTests int
-		configCsv     string
+		configFile    string
 		showCom       bool
 		imageList     []benchmark.ImageDescriptor
 		err           error
@@ -43,7 +43,7 @@ func main() {
 
 	flag.BoolVar(&showCom, "show-commit", false, "tag the commit hash to the benchmark results")
 	flag.IntVar(&numberOfTests, "count", 5, "Describes the number of runs a benchmarker should run. Default: 5")
-	flag.StringVar(&configCsv, "f", "default", "Path to a csv file describing image details in this order ['Name','Image ref', 'Ready line', 'manifest ref'].")
+	flag.StringVar(&configFile, "f", "default", "Path to a file describing image details as a json file or csv in this order ['Name','Image ref', 'Ready line', 'manifest ref'].")
 
 	flag.Parse()
 
@@ -53,12 +53,12 @@ func main() {
 		commit = "N/A"
 	}
 
-	if configCsv == "default" {
+	if configFile == "default" {
 		imageList = benchmark.GetDefaultWorkloads()
 	} else {
-		imageList, err = benchmark.GetImageListFromCsv(configCsv)
+		imageList, err = benchmark.GetImageList(configFile)
 		if err != nil {
-			errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
+			errMsg := fmt.Sprintf("Failed to read file %s with error:%v\n", configFile, err)
 			panic(errMsg)
 		}
 	}

--- a/benchmark/performanceTest/main.go
+++ b/benchmark/performanceTest/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	var (
 		numberOfTests           int
-		configCsv               string
+		configFile              string
 		showCom                 bool
 		parseFileAccessPatterns bool
 		commit                  string
@@ -46,7 +46,7 @@ func main() {
 	flag.BoolVar(&parseFileAccessPatterns, "parse-file-access", false, "Parse fuse file access patterns.")
 	flag.BoolVar(&showCom, "show-commit", false, "tag the commit hash to the benchmark results")
 	flag.IntVar(&numberOfTests, "count", 5, "Describes the number of runs a benchmarker should run. Default: 5")
-	flag.StringVar(&configCsv, "f", "default", "Path to a csv file describing image details in this order ['Name','Image ref', 'Ready line', 'manifest ref'].")
+	flag.StringVar(&configFile, "f", "default", "Path to a file describing image details as a json file or csv in this order ['Name','Image ref', 'Ready line', 'manifest ref'].")
 
 	flag.Parse()
 
@@ -68,12 +68,12 @@ func main() {
 		}
 	}
 
-	if configCsv == "default" {
+	if configFile == "default" {
 		imageList = benchmark.GetDefaultWorkloads()
 	} else {
-		imageList, err = benchmark.GetImageListFromCsv(configCsv)
+		imageList, err = benchmark.GetImageList(configFile)
 		if err != nil {
-			errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
+			errMsg := fmt.Sprintf("Failed to read file %s with error:%v\n", configFile, err)
 			panic(errMsg)
 		}
 	}

--- a/benchmark/stargzTest/main.go
+++ b/benchmark/stargzTest/main.go
@@ -32,16 +32,16 @@ var (
 
 func main() {
 	commit := os.Args[1]
-	configCsv := os.Args[2]
+	configFile := os.Args[2]
 	numberOfTests, err := strconv.Atoi(os.Args[3])
 	stargzBinary := os.Args[4]
 	if err != nil {
 		errMsg := fmt.Sprintf("Failed to parse number of test %s with error:%v\n", os.Args[3], err)
 		panic(errMsg)
 	}
-	imageList, err := benchmark.GetImageListFromCsv(configCsv)
+	imageList, err := benchmark.GetImageList(configFile)
 	if err != nil {
-		errMsg := fmt.Sprintf("Failed to read csv file %s with error:%v\n", configCsv, err)
+		errMsg := fmt.Sprintf("Failed to read file %s with error:%v\n", configFile, err)
 		panic(errMsg)
 	}
 


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Benchmarks can currently be passed as a csv file. This additionally adds json as an option to make it not order dependent and to allow us to add more complex options in the future (e.g. mounts).

**Testing performed:**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
