### PR TITLE
Remove "soci run" from CLI

### DIFF
--- a/cmd/soci/main.go
+++ b/cmd/soci/main.go
@@ -42,7 +42,6 @@ import (
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/ztoc"
 	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/version"
-	"github.com/containerd/containerd/cmd/ctr/commands/run"
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/namespaces"
 
@@ -95,7 +94,6 @@ func main() {
 		ztoc.Command,
 		commands.CreateCommand,
 		commands.PushCommand,
-		run.Command,
 		commands.RebuildDBCommand,
 	}
 

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -218,7 +218,7 @@ log_fuse_operations = true
 
 			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
 			// this command may fail due to fuse operation failure, use XLog to avoid crashing shell
-			sh.XLog("ctr", "run", "--rm", "--snapshotter=soci", imgInfo.ref, "test", "echo", "hi")
+			sh.XLog(append(runSociCmd, "--name", "test", "--rm", imgInfo.ref, "echo", "hi")...)
 
 			curlOutput := string(sh.O("curl", tcpMetricsAddress+metricsPath))
 			checkFuseOperationFailureMetrics(t, curlOutput, tc.metricToCheck, tc.expectFuseOperationFailure, tc.expectedCount)
@@ -253,7 +253,7 @@ fuse_metrics_emit_wait_duration_sec = 10
 			indexDigest := buildIndex(sh, imgInfo)
 
 			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
-			sh.XLog("ctr", "run", "-d", "--snapshotter=soci", imgInfo.ref, "test", "echo", "hi")
+			sh.XLog(append(runSociCmd, "--name", "test", "-d", imgInfo.ref, "echo", "hi")...)
 
 			curlOutput := string(sh.O("curl", tcpMetricsAddress+metricsPath))
 
@@ -310,7 +310,7 @@ emit_metric_period_sec = 2
 			indexDigest := buildIndex(sh, imgInfo)
 
 			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
-			sh.XLog("ctr", "run", "-d", "--snapshotter=soci", imgInfo.ref, "test", "echo", "hi")
+			sh.XLog(append(runSociCmd, "--name", "test", "-d", imgInfo.ref, "echo", "hi")...)
 
 			time.Sleep(5 * time.Second)
 			curlOutput := string(sh.O("curl", tcpMetricsAddress+metricsPath))

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -174,12 +174,12 @@ func TestLazyPullWithSparseIndex(t *testing.T) {
 		return func(t *testing.T, tarExportArgs ...string) {
 			rebootContainerd(t, sh, "", "")
 			sh.X("nerdctl", "pull", "-q", image)
-			sh.Pipe(nil, shell.C("ctr", "run", "--rm", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
+			sh.Pipe(nil, shell.C("nerdctl", "run", "--name", "test", "--pull", "never", "--net", "none", "--rm", image, "tar", "-zc", "/usr"), tarExportArgs)
 		}
 	}
 	export := func(sh *shell.Shell, image string, tarExportArgs []string) {
 		sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, image)
-		sh.Pipe(nil, shell.C("soci", "run", "--rm", "--snapshotter=soci", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
+		sh.Pipe(nil, shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...), tarExportArgs)
 	}
 
 	imageManifestDigest, err := getManifestDigest(sh, dockerhub(imageName).ref, dockerhub(imageName).platform)
@@ -281,12 +281,12 @@ func TestLazyPull(t *testing.T) {
 		return func(t *testing.T, tarExportArgs ...string) {
 			rebootContainerd(t, sh, "", "")
 			sh.X("nerdctl", "pull", "-q", image)
-			sh.Pipe(nil, shell.C("ctr", "run", "--rm", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
+			sh.Pipe(nil, shell.C("nerdctl", "run", "--name", "test", "--pull", "never", "--net", "none", "--rm", image, "tar", "-zc", "/usr"), tarExportArgs)
 		}
 	}
 	export := func(sh *shell.Shell, image string, tarExportArgs []string) {
 		sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest1, image)
-		sh.Pipe(nil, shell.C("soci", "run", "--rm", "--snapshotter=soci", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
+		sh.Pipe(nil, shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...), tarExportArgs)
 	}
 
 	// NOTE: these tests must be executed sequentially.
@@ -364,12 +364,12 @@ func TestLazyPullNoIndexDigest(t *testing.T) {
 		return func(t *testing.T, tarExportArgs ...string) {
 			rebootContainerd(t, sh, "", "")
 			sh.X("nerdctl", "pull", "-q", image)
-			sh.Pipe(nil, shell.C("ctr", "run", "--rm", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
+			sh.Pipe(nil, shell.C("nerdctl", "run", "--name", "test", "--pull", "never", "--net", "none", "--rm", image, "tar", "-zc", "/usr"), tarExportArgs)
 		}
 	}
 	export := func(sh *shell.Shell, image string, tarExportArgs []string) {
 		sh.X("soci", "image", "rpull", "--user", regConfig.creds(), image)
-		sh.Pipe(nil, shell.C("soci", "run", "--rm", "--snapshotter=soci", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
+		sh.Pipe(nil, shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...), tarExportArgs)
 	}
 
 	// NOTE: these tests must be executed sequentially.
@@ -433,13 +433,13 @@ func TestPullWithAribtraryBlobInvalidZtocFormat(t *testing.T) {
 		return func(t *testing.T, tarExportArgs ...string) {
 			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
 			sh.X("nerdctl", "pull", "-q", image)
-			sh.Pipe(nil, shell.C("ctr", "run", "--rm", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
+			sh.Pipe(nil, shell.C("nerdctl", "run", "--name", "test", "--pull", "never", "--net", "none", "--rm", image, "tar", "-zc", "/usr"), tarExportArgs)
 		}
 	}
 
 	export := func(sh *shell.Shell, image, sociIndexDigest string, tarExportArgs []string) {
 		sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", sociIndexDigest, image)
-		sh.Pipe(nil, shell.C("soci", "run", "--rm", "--snapshotter=soci", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
+		sh.Pipe(nil, shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...), tarExportArgs)
 	}
 
 	buildMaliciousIndex := func(sh *shell.Shell, imgDigest string) ([]byte, []ocispec.Descriptor, error) {
@@ -546,12 +546,12 @@ disable = true
 		return func(t *testing.T, tarExportArgs ...string) {
 			rebootContainerd(t, sh, "", "")
 			sh.X("nerdctl", "pull", "-q", image)
-			sh.Pipe(nil, shell.C("ctr", "run", "--rm", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
+			sh.Pipe(nil, shell.C("nerdctl", "run", "--name", "test", "--pull", "never", "--net", "none", "--rm", image, "tar", "-zc", "/usr"), tarExportArgs)
 		}
 	}
 	export := func(sh *shell.Shell, image string, tarExportArgs []string) {
 		sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest1, image)
-		sh.Pipe(nil, shell.C("soci", "run", "--rm", "--snapshotter=soci", image, "test", "tar", "-zc", "/usr"), tarExportArgs)
+		sh.Pipe(nil, shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...), tarExportArgs)
 	}
 
 	// NOTE: these tests must be executed sequentially.
@@ -721,10 +721,10 @@ insecure = true
 	sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(imageName).ref)
 	registryHostIP, registryAltHostIP := getIP(t, sh, regConfig.host), getIP(t, sh, regAltConfig.host)
 	export := func(image string) []string {
-		return shell.C("soci", "run", "--rm", "--snapshotter=soci", image, "test", "tar", "-zc", "/usr")
+		return shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...)
 	}
 	sample := func(t *testing.T, tarExportArgs ...string) {
-		sh.Pipe(nil, shell.C("ctr", "run", "--rm", regConfig.mirror(imageName).ref, "test", "tar", "-zc", "/usr"), tarExportArgs)
+		sh.Pipe(nil, shell.C("nerdctl", "run", "--name", "test", "--pull", "never", "--net", "none", "--rm", regConfig.mirror(imageName).ref, "tar", "-zc", "/usr"), tarExportArgs)
 	}
 
 	// test if mirroring is working (switching to registryAltHost)

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -78,6 +78,11 @@ const (
 	oci11RegistryImage = "ghcr.io/project-zot/zot-linux-" + runtime.GOARCH + ":v2.0.0-rc6"
 )
 
+// Commonly used CLI commands
+var (
+	runSociCmd = []string{"nerdctl", "run", "--pull", "never", "--net", "none", "--snapshotter", "soci"}
+)
+
 // These are images that we use in our integration tests
 const (
 	helloImage    = "hello-world:latest"


### PR DESCRIPTION
With the effort to remove ctr code from CLI, we removed `soci run`, as it ran `ctr run` under the hood with no additional functionality.

In the testing suite, `soci run` has been replaced in favor of `nerdctl run` for similar reasons to above. `nerdctl run`, while it attempts to mimic ctr, does not function exactly the same as ctr out of the box. In particular default behavior in `nerdctl run` deviates from `ctr run` in the following ways:

- Auto generates an ID. `ctr run` requires the container have an ID after the image ref. Circumvented with `--name [id]` (not exactly the same, but good enough for tasks to find the container.
- Uses the [bridge CNI plugin](https://www.cni.dev/plugins/current/main/bridge/) for networking, which would add an unnecessary dependency. Circumvented this with `--net none` (maybe `--net host` might be more suitable for some tests? Unsure though)
-  Automatically pulls an image if the name is not found, which would cause some of our tests to unexpectedly succeed. Circumvented this with `--pull never`.
- Automatically closes after a task is finished, which would cause some of our tests to fail, as a container would start without a task but would need to stay running for later tasks. Circumvented this with `sleep infinity` for those tasks.

These are behaviors that I noticed but did not fully understand.
- `cannot remove containerd task: Device or resource busy` in `TestRunInNamespace`. Maybe resources between namespaces are shared strangely? In any case, adding `--rm` seemed to fix this
- `stdout` would output an empty string on task failure. This was noted in `TestNetworkRetry`, which is why the additional test condition was given. Really not sure as to why that works this way, since the tests should only return an error and thus stdout should be empty. Maybe because it actually prints an error message instead of nothing like ctr does?

It should also be noted that I had to replace `ctr task exec` with `nerdctl exec` because otherwise ctr could not find the containers to run the tasks in.

A lot of the replacement was done automatically via a custom shell script (which I can share if it helps) but proofread manually, I tried to be extremely thorough to ensure no funny replacements slipped through the cracks but do bear that in mind.

**Issue #, if available:**
#841

**Description of changes:**

**Testing performed:**
`make test` and `make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
