### PR TITLE
fix: trim unix:// prefix for address flag

### DIFF
--- a/cmd/soci/commands/internal/client.go
+++ b/cmd/soci/commands/internal/client.go
@@ -34,6 +34,7 @@ package internal
 
 import (
 	gocontext "context"
+	"strings"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
@@ -75,7 +76,8 @@ func AppContext(context *cli.Context) (gocontext.Context, gocontext.CancelFunc) 
 func NewClient(context *cli.Context, opts ...containerd.ClientOpt) (*containerd.Client, gocontext.Context, gocontext.CancelFunc, error) {
 	timeoutOpt := containerd.WithTimeout(context.GlobalDuration("connect-timeout"))
 	opts = append(opts, timeoutOpt)
-	client, err := containerd.New(context.GlobalString("address"), opts...)
+	address := strings.TrimPrefix(context.GlobalString("address"), "unix://")
+	client, err := containerd.New(address, opts...)
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
**Issue #, if available:**
Fixes: https://github.com/awslabs/soci-snapshotter/issues/880

**Description of changes:**
Trim the `unix://` prefix in address if presented so this now works

![image](https://github.com/awslabs/soci-snapshotter/assets/627278/9674177a-3377-4c36-bdf4-65a623507f96)

Previously, it would fail with

![image](https://github.com/awslabs/soci-snapshotter/assets/627278/fabd47e1-c02d-4282-b3e5-ed3deadab143)


**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
