### PR TITLE
Switch release workflow to on.push

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  create:
+  push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 env:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Before this change, the release workflow was running when creating a branch. It seems that tag filtering doesn't work on `create` events.

https://github.com/awslabs/soci-snapshotter/actions/workflows/releases.yml

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
