### PR TITLE
Benchmark options

### DIFF
--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -103,10 +103,8 @@ func SociRPullPullImage(
 func SociFullRun(
 	ctx context.Context,
 	b *testing.B,
-	imageRef string,
-	indexDigest string,
-	readyLine string,
-	testName string) {
+	testName string,
+	imageDescriptor ImageDescriptor) {
 	testUUID := uuid.New().String()
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("test_name", testName))
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("uuid", testUUID))
@@ -125,7 +123,7 @@ func SociFullRun(
 	pullStart := time.Now()
 	log.G(ctx).WithField("benchmark", "Test").WithField("event", "Start").Infof("Start Test")
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Start").Infof("Start Pull Image")
-	image, err := sociContainerdProc.SociRPullImageFromRegistry(ctx, imageRef, indexDigest)
+	image, err := sociContainerdProc.SociRPullImageFromRegistry(ctx, imageDescriptor.ImageRef, imageDescriptor.ImageRef)
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Stop").Infof("Stop Pull Image")
 	pullDuration := time.Since(pullStart)
 	b.ReportMetric(float64(pullDuration.Milliseconds()), "pullDuration")
@@ -148,7 +146,7 @@ func SociFullRun(
 	defer cleanupTask()
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Start").Infof("Start Run Task")
 	runLazyTaskStart := time.Now()
-	cleanupRun, err := sociContainerdProc.RunContainerTaskForReadyLine(ctx, taskDetails, readyLine)
+	cleanupRun, err := sociContainerdProc.RunContainerTaskForReadyLine(ctx, taskDetails, imageDescriptor.ReadyLine)
 	lazyTaskDuration := time.Since(runLazyTaskStart)
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Stop").Infof("Stop Run Task")
 	b.ReportMetric(float64(lazyTaskDuration.Milliseconds()), "lazyTaskDuration")
@@ -168,7 +166,7 @@ func SociFullRun(
 	defer cleanupTaskSecondRun()
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Start").Infof("Start Run Task Twice")
 	runLocalStart := time.Now()
-	cleanupRunSecond, err := sociContainerdProc.RunContainerTaskForReadyLine(ctx, taskDetailsSecondRun, readyLine)
+	cleanupRunSecond, err := sociContainerdProc.RunContainerTaskForReadyLine(ctx, taskDetailsSecondRun, imageDescriptor.ReadyLine)
 	localTaskStats := time.Since(runLocalStart)
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Stop").Infof("Stop Run Task Twice")
 	b.ReportMetric(float64(localTaskStats.Milliseconds()), "localTaskStats")
@@ -183,9 +181,8 @@ func SociFullRun(
 func OverlayFSFullRun(
 	ctx context.Context,
 	b *testing.B,
-	imageRef string,
-	readyLine string,
-	testName string) {
+	testName string,
+	imageDescriptor ImageDescriptor) {
 	testUUID := uuid.New().String()
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("test_name", testName))
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("uuid", testUUID))
@@ -198,7 +195,7 @@ func OverlayFSFullRun(
 	log.G(ctx).WithField("benchmark", "Test").WithField("event", "Start").Infof("Start Test")
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Start").Infof("Start Pull Image")
 	pullStart := time.Now()
-	image, err := containerdProcess.PullImageFromRegistry(ctx, imageRef, platform)
+	image, err := containerdProcess.PullImageFromRegistry(ctx, imageDescriptor.ImageRef, platform)
 	pullDuration := time.Since(pullStart)
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Stop").Infof("Stop Pull Image")
 	b.ReportMetric(float64(pullDuration.Milliseconds()), "pullDuration")
@@ -227,7 +224,7 @@ func OverlayFSFullRun(
 	defer cleanupTask()
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Start").Infof("Start Run Task")
 	runLazyTaskStart := time.Now()
-	cleanupRun, err := containerdProcess.RunContainerTaskForReadyLine(ctx, taskDetails, readyLine)
+	cleanupRun, err := containerdProcess.RunContainerTaskForReadyLine(ctx, taskDetails, imageDescriptor.ReadyLine)
 	lazyTaskDuration := time.Since(runLazyTaskStart)
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Stop").Infof("Stop Run Task")
 	b.ReportMetric(float64(lazyTaskDuration.Milliseconds()), "lazyTaskDuration")
@@ -247,7 +244,7 @@ func OverlayFSFullRun(
 	defer cleanupTaskSecondRun()
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Start").Infof("Start Run Task Twice")
 	runLocalStart := time.Now()
-	cleanupRunSecond, err := containerdProcess.RunContainerTaskForReadyLine(ctx, taskDetailsSecondRun, readyLine)
+	cleanupRunSecond, err := containerdProcess.RunContainerTaskForReadyLine(ctx, taskDetailsSecondRun, imageDescriptor.ReadyLine)
 	localTaskStats := time.Since(runLocalStart)
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Stop").Infof("Stop Run Task Twice")
 	b.ReportMetric(float64(localTaskStats.Milliseconds()), "localTaskStats")

--- a/benchmark/comparisonTest/main.go
+++ b/benchmark/comparisonTest/main.go
@@ -78,22 +78,20 @@ func main() {
 
 	var drivers []framework.BenchmarkTestDriver
 	for _, image := range imageList {
+		image := image
 		shortName := image.ShortName
-		imageRef := image.ImageRef
-		sociIndexManifestRef := image.SociIndexManifestRef
-		readyLine := image.ReadyLine
 		drivers = append(drivers, framework.BenchmarkTestDriver{
 			TestName:      "OverlayFSFull" + shortName,
 			NumberOfTests: numberOfTests,
 			TestFunction: func(b *testing.B) {
-				benchmark.OverlayFSFullRun(ctx, b, imageRef, readyLine, "OverlayFSFull"+shortName)
+				benchmark.OverlayFSFullRun(ctx, b, "OverlayFSFull"+shortName, image)
 			},
 		})
 		drivers = append(drivers, framework.BenchmarkTestDriver{
 			TestName:      "SociFull" + shortName,
 			NumberOfTests: numberOfTests,
 			TestFunction: func(b *testing.B) {
-				benchmark.SociFullRun(ctx, b, imageRef, sociIndexManifestRef, readyLine, "SociFull"+shortName)
+				benchmark.SociFullRun(ctx, b, "SociFull"+shortName, image)
 			},
 		})
 	}

--- a/benchmark/performanceTest/main.go
+++ b/benchmark/performanceTest/main.go
@@ -94,15 +94,12 @@ func main() {
 	var drivers []framework.BenchmarkTestDriver
 	for _, image := range imageList {
 		shortName := image.ShortName
-		imageRef := image.ImageRef
-		sociIndexManifestRef := image.SociIndexManifestRef
-		readyLine := image.ReadyLine
 		testName := "SociFull" + shortName
 		driver := framework.BenchmarkTestDriver{
 			TestName:      testName,
 			NumberOfTests: numberOfTests,
 			TestFunction: func(b *testing.B) {
-				benchmark.SociFullRun(ctx, b, imageRef, sociIndexManifestRef, readyLine, testName)
+				benchmark.SociFullRun(ctx, b, testName, image)
 			},
 		}
 		if parseFileAccessPatterns {

--- a/benchmark/performanceTest/main.go
+++ b/benchmark/performanceTest/main.go
@@ -93,6 +93,7 @@ func main() {
 
 	var drivers []framework.BenchmarkTestDriver
 	for _, image := range imageList {
+		image := image
 		shortName := image.ShortName
 		testName := "SociFull" + shortName
 		driver := framework.BenchmarkTestDriver{

--- a/benchmark/soci_utils.go
+++ b/benchmark/soci_utils.go
@@ -156,6 +156,7 @@ func (proc *SociContainerdProcess) SociRPullImageFromRegistry(
 
 func (proc *SociContainerdProcess) CreateSociContainer(
 	ctx context.Context,
-	image containerd.Image) (containerd.Container, func(), error) {
-	return proc.CreateContainer(ctx, image, containerd.WithSnapshotter("soci"))
+	image containerd.Image,
+	imageDescriptor ImageDescriptor) (containerd.Container, func(), error) {
+	return proc.CreateContainer(ctx, imageDescriptor.ContainerOpts(image, containerd.WithSnapshotter("soci"))...)
 }

--- a/benchmark/stargzTest/main.go
+++ b/benchmark/stargzTest/main.go
@@ -60,14 +60,13 @@ func main() {
 
 	var drivers []framework.BenchmarkTestDriver
 	for _, image := range imageList {
+		image := image
 		shortName := image.ShortName
-		imageRef := image.ImageRef
-		readyLine := image.ReadyLine
 		drivers = append(drivers, framework.BenchmarkTestDriver{
 			TestName:      "StargzFullRun" + shortName,
 			NumberOfTests: numberOfTests,
 			TestFunction: func(b *testing.B) {
-				benchmark.StargzFullRun(ctx, b, imageRef, readyLine, stargzBinary)
+				benchmark.StargzFullRun(ctx, b, image, stargzBinary)
 			},
 		})
 	}

--- a/benchmark/utils.go
+++ b/benchmark/utils.go
@@ -20,16 +20,87 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/contrib/nvidia"
+	"github.com/containerd/containerd/oci"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+const testContainerID = "TEST_RUN_CONTAINER"
+
 type ImageDescriptor struct {
-	ShortName            string `json:"short_name"`
-	ImageRef             string `json:"image_ref"`
-	SociIndexManifestRef string `json:"soci_index_manifest_ref"`
-	ReadyLine            string `json:"ready_line"`
+	ShortName       string       `json:"short_name"`
+	ImageRef        string       `json:"image_ref"`
+	SociIndexDigest string       `json:"soci_index_digest"`
+	ReadyLine       string       `json:"ready_line"`
+	TimeoutSec      int64        `json:"timeout_sec"`
+	ImageOptions    ImageOptions `json:"options"`
+}
+
+func (i *ImageDescriptor) Timeout() time.Duration {
+	if i.TimeoutSec <= 0 {
+		return 180 * time.Second
+	}
+	return time.Duration(i.TimeoutSec) * time.Second
+}
+
+// ImageOptions contains image-specific options needed to run the tests
+type ImageOptions struct {
+	// Net indicicates the container's network mode. If set to "host" then the container will have host networking, otherwise no networking.
+	Net string `json:"net"`
+	// Mounts are any mounts needed by the container
+	Mounts []runtimespec.Mount `json:"mounts"`
+	// Gpu is whether the container needs GPUs. If true, all GPUs are mounted in the container
+	Gpu bool `json:"gpu"`
+	// Env is any environment variables needed by the containerd
+	Env []string `json:"env"`
+	// ShmSize is the size of /dev/shm to be used inside the container
+	ShmSize int64 `json:"shm_size"`
+}
+
+// ContainerOpts creates a set of NewContainerOpts from an ImageDescriptor and a containerd.Image
+// The options can be used directly when launching a container
+func (i *ImageDescriptor) ContainerOpts(image containerd.Image, o ...containerd.NewContainerOpts) []containerd.NewContainerOpts {
+	var opts []containerd.NewContainerOpts
+	var ociOpts []oci.SpecOpts
+
+	opts = append(opts, o...)
+	id := fmt.Sprintf("%s-%d", testContainerID, time.Now().UnixNano())
+	opts = append(opts, containerd.WithNewSnapshot(id, image))
+	ociOpts = append(ociOpts, oci.WithImageConfig(image))
+	if len(i.ImageOptions.Mounts) > 0 {
+		ociOpts = append(ociOpts, oci.WithMounts(i.ImageOptions.Mounts))
+	}
+	if i.ImageOptions.Gpu {
+		ociOpts = append(ociOpts, nvidia.WithGPUs(nvidia.WithAllDevices, nvidia.WithAllCapabilities))
+	}
+	if len(i.ImageOptions.Env) > 0 {
+		ociOpts = append(ociOpts, oci.WithEnv(i.ImageOptions.Env))
+	}
+	if i.ImageOptions.ShmSize > 0 {
+		ociOpts = append(ociOpts, oci.WithDevShmSize(i.ImageOptions.ShmSize))
+	}
+	if i.ImageOptions.Net == "host" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			panic(fmt.Errorf("get hostname: %w", err))
+		}
+		ociOpts = append(ociOpts,
+			oci.WithHostNamespace(runtimespec.NetworkNamespace),
+			oci.WithHostHostsFile,
+			oci.WithHostResolvconf,
+			oci.WithEnv([]string{fmt.Sprintf("HOSTNAME=%s", hostname)}),
+		)
+	}
+
+	opts = append(opts, containerd.WithNewSpec(ociOpts...))
+	return opts
 }
 
 func GetImageList(file string) ([]ImageDescriptor, error) {
@@ -74,10 +145,10 @@ func GetImageListFromCsv(r io.Reader) ([]ImageDescriptor, error) {
 			sociIndexManifestRef = image[2]
 		}
 		images = append(images, ImageDescriptor{
-			ShortName:            image[0],
-			ImageRef:             image[1],
-			ReadyLine:            image[3],
-			SociIndexManifestRef: sociIndexManifestRef})
+			ShortName:       image[0],
+			ImageRef:        image[1],
+			ReadyLine:       image[3],
+			SociIndexDigest: sociIndexManifestRef})
 	}
 	return images, nil
 }
@@ -94,52 +165,52 @@ func GetCommitHash() (string, error) {
 func GetDefaultWorkloads() []ImageDescriptor {
 	return []ImageDescriptor{
 		{
-			ShortName:            "ECR-public-ffmpeg",
-			ImageRef:             "public.ecr.aws/soci-workshop-examples/ffmpeg:latest",
-			SociIndexManifestRef: "sha256:ef63578971ebd8fc700c74c96f81dafab4f3875e9117ef3c5eb7446e169d91cb",
-			ReadyLine:            "Hello World",
+			ShortName:       "ECR-public-ffmpeg",
+			ImageRef:        "public.ecr.aws/soci-workshop-examples/ffmpeg:latest",
+			SociIndexDigest: "sha256:ef63578971ebd8fc700c74c96f81dafab4f3875e9117ef3c5eb7446e169d91cb",
+			ReadyLine:       "Hello World",
 		},
 		{
-			ShortName:            "ECR-public-tensorflow",
-			ImageRef:             "public.ecr.aws/soci-workshop-examples/tensorflow:latest",
-			SociIndexManifestRef: "sha256:27546e0267465279e40a8c8ebc8d34836dd5513c6e7019257855c9e0f04a9f34",
-			ReadyLine:            "Hello World with TensorFlow!",
+			ShortName:       "ECR-public-tensorflow",
+			ImageRef:        "public.ecr.aws/soci-workshop-examples/tensorflow:latest",
+			SociIndexDigest: "sha256:27546e0267465279e40a8c8ebc8d34836dd5513c6e7019257855c9e0f04a9f34",
+			ReadyLine:       "Hello World with TensorFlow!",
 		},
 		{
-			ShortName:            "ECR-public-tensorflow_gpu",
-			ImageRef:             "public.ecr.aws/soci-workshop-examples/tensorflow_gpu:latest",
-			SociIndexManifestRef: "sha256:a40b70bc941216cbb29623e98970dfc84e9640666a8b9043564ca79f6d5cc137",
-			ReadyLine:            "Hello World with TensorFlow!",
+			ShortName:       "ECR-public-tensorflow_gpu",
+			ImageRef:        "public.ecr.aws/soci-workshop-examples/tensorflow_gpu:latest",
+			SociIndexDigest: "sha256:a40b70bc941216cbb29623e98970dfc84e9640666a8b9043564ca79f6d5cc137",
+			ReadyLine:       "Hello World with TensorFlow!",
 		},
 		{
-			ShortName:            "ECR-public-node",
-			ImageRef:             "public.ecr.aws/soci-workshop-examples/node:latest",
-			SociIndexManifestRef: "sha256:544d42d3447fe7833c2e798b8a342f5102022188e814de0aa6ce980e76c62894",
-			ReadyLine:            "Server ready",
+			ShortName:       "ECR-public-node",
+			ImageRef:        "public.ecr.aws/soci-workshop-examples/node:latest",
+			SociIndexDigest: "sha256:544d42d3447fe7833c2e798b8a342f5102022188e814de0aa6ce980e76c62894",
+			ReadyLine:       "Server ready",
 		},
 		{
-			ShortName:            "ECR-public-busybox",
-			ImageRef:             "public.ecr.aws/soci-workshop-examples/busybox:latest",
-			SociIndexManifestRef: "sha256:deaaf67bb4baa293dadcfbeb1f511c181f89a05a042ee92dd2e43e7b7295b1c0",
-			ReadyLine:            "Hello World",
+			ShortName:       "ECR-public-busybox",
+			ImageRef:        "public.ecr.aws/soci-workshop-examples/busybox:latest",
+			SociIndexDigest: "sha256:deaaf67bb4baa293dadcfbeb1f511c181f89a05a042ee92dd2e43e7b7295b1c0",
+			ReadyLine:       "Hello World",
 		},
 		{
-			ShortName:            "ECR-public-mongo",
-			ImageRef:             "public.ecr.aws/soci-workshop-examples/mongo:latest",
-			SociIndexManifestRef: "sha256:ecdd6dcc917d09ec7673288e8ba83270542b71959db2ac731fbeb42aa0b038e0",
-			ReadyLine:            "Waiting for connections",
+			ShortName:       "ECR-public-mongo",
+			ImageRef:        "public.ecr.aws/soci-workshop-examples/mongo:latest",
+			SociIndexDigest: "sha256:ecdd6dcc917d09ec7673288e8ba83270542b71959db2ac731fbeb42aa0b038e0",
+			ReadyLine:       "Waiting for connections",
 		},
 		{
-			ShortName:            "ECR-public-rabbitmq",
-			ImageRef:             "public.ecr.aws/soci-workshop-examples/rabbitmq:latest",
-			SociIndexManifestRef: "sha256:3882f9609c0c2da044173710f3905f4bc6c09228f2a5b5a0a5fdce2537677c17",
-			ReadyLine:            "Server startup complete",
+			ShortName:       "ECR-public-rabbitmq",
+			ImageRef:        "public.ecr.aws/soci-workshop-examples/rabbitmq:latest",
+			SociIndexDigest: "sha256:3882f9609c0c2da044173710f3905f4bc6c09228f2a5b5a0a5fdce2537677c17",
+			ReadyLine:       "Server startup complete",
 		},
 		{
-			ShortName:            "ECR-public-redis",
-			ImageRef:             "public.ecr.aws/soci-workshop-examples/redis:latest",
-			SociIndexManifestRef: "sha256:da171fda5f4ccf79f453fc0c5e1414642521c2e189f377809ca592af9458287a",
-			ReadyLine:            "Ready to accept connections",
+			ShortName:       "ECR-public-redis",
+			ImageRef:        "public.ecr.aws/soci-workshop-examples/redis:latest",
+			SociIndexDigest: "sha256:da171fda5f4ccf79f453fc0c5e1414642521c2e189f377809ca592af9458287a",
+			ReadyLine:       "Ready to accept connections",
 		},
 	}
 


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**

All of our existing benchmark images are run with the same set of containerd
options which are only configurable at the test level to control things
like which snapshotter is used.

This is a problem for benchmarking GPU workloads, for example, where we need to
pass additional options to mount the GPU in the container which don't
apply to all images in the test.

Additionally, our benchmarker assumes that the benchmarked images
require no configuration, however this can make experimentation hard in
cases where a single base-image can be used for multiple use cases
depending on environment variables, confiration mounts, etc.

This change adds the ability to configure image-specific options when
loading benchmarks from json. The options are not required and if not
passed, the benchmarker will behave as it did before this change.

The set of options available in this change are those that were
necessary for benchmarking the LLM workloads that I was trying to test.
They are not comprehensive, but can be built upon as use cases arise.

---

I kept 2 commits to separate some refactoring that I needed to make these change from the changes themselves. I'm happy to squash or pull out the refactoring into a separate commit if that's preferred.

**Testing performed:**
~/benchmark.json
```
[{
  "short_name": "djl-serving",
  "image_ref": "<ACCOUNT>.dkr.ecr.us-west-2.amazonaws.com/djl-serving:0.25.0-deepspeed",
  "soci_index_manifest_ref": "<INDEX DIGEST>",
  "ready_line": "ModelServer BOTH API bind to: http://0.0.0.0:8080/",
  "timeout_sec": 1000,
  "options": {
    "net": "host",
    "gpu": true,
    "shm_size": 1000000,
    "mounts": [
      {
        "source": "/home/ubuntu/model",
        "destination": "/opt/ml/model",
        "type": "bind",
        "options": ["rbind", "ro"]
      },
      {
        "source": "/home/ubuntu/model_logs",
        "destination": "/opt/djl/logs",
        "type": "bind",
        "options": ["rbind", "rw"]
      }
    ]
  }
}]
```

```
BENCHMARK_FLAGS="-count 1 -f ~benchmark-tgi.json" make benchmarks-perf-test
BENCHMARK_FLAGS="-count 1 -f ~/benchmark-tgi.json" make benchmarks-perf-test
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
