### PR TITLE
Replace "soci image rpull" with common base command

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -131,7 +131,7 @@ func TestOverlayFallbackMetric(t *testing.T) {
 				sh.X("nerdctl", "pull", "-q", imgInfo.ref)
 				indexDigest := tc.indexDigestFn(sh, contentStoreType, imgInfo)
 
-				sh.X("soci", "--content-store", string(contentStoreType), "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
+				sh.X(append(imagePullSociCmd, "--content-store", string(contentStoreType), "--soci-index-digest", indexDigest, imgInfo.ref)...)
 				curlOutput := string(sh.O("curl", tcpMetricsAddress+metricsPath))
 
 				if err := checkOverlayFallbackCount(curlOutput, tc.expectedFallbackCount); err != nil {
@@ -216,7 +216,7 @@ log_fuse_operations = true
 			sh.X("nerdctl", "pull", "-q", imgInfo.ref)
 			indexDigest := tc.indexDigestFn(t, sh, imgInfo)
 
-			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
+			sh.X(append(imagePullSociCmd, "--soci-index-digest", indexDigest, imgInfo.ref)...)
 			// this command may fail due to fuse operation failure, use XLog to avoid crashing shell
 			sh.XLog(append(runSociCmd, "--name", "test", "--rm", imgInfo.ref, "echo", "hi")...)
 
@@ -252,7 +252,7 @@ fuse_metrics_emit_wait_duration_sec = 10
 			sh.X("nerdctl", "pull", "-q", imgInfo.ref)
 			indexDigest := buildIndex(sh, imgInfo)
 
-			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
+			sh.X(append(imagePullSociCmd, "--soci-index-digest", indexDigest, imgInfo.ref)...)
 			sh.XLog(append(runSociCmd, "--name", "test", "-d", imgInfo.ref, "echo", "hi")...)
 
 			curlOutput := string(sh.O("curl", tcpMetricsAddress+metricsPath))
@@ -309,7 +309,7 @@ emit_metric_period_sec = 2
 			sh.X("nerdctl", "pull", "-q", imgInfo.ref)
 			indexDigest := buildIndex(sh, imgInfo)
 
-			sh.X("soci", "image", "rpull", "--soci-index-digest", indexDigest, imgInfo.ref)
+			sh.X(append(imagePullSociCmd, "--soci-index-digest", indexDigest, imgInfo.ref)...)
 			sh.XLog(append(runSociCmd, "--name", "test", "-d", imgInfo.ref, "echo", "hi")...)
 
 			time.Sleep(5 * time.Second)

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -178,7 +178,7 @@ func TestLazyPullWithSparseIndex(t *testing.T) {
 		}
 	}
 	export := func(sh *shell.Shell, image string, tarExportArgs []string) {
-		sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, image)
+		sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", indexDigest, image)...)
 		sh.Pipe(nil, shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...), tarExportArgs)
 	}
 
@@ -285,7 +285,7 @@ func TestLazyPull(t *testing.T) {
 		}
 	}
 	export := func(sh *shell.Shell, image string, tarExportArgs []string) {
-		sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest1, image)
+		sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", indexDigest1, image)...)
 		sh.Pipe(nil, shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...), tarExportArgs)
 	}
 
@@ -327,7 +327,7 @@ func TestLazyPull(t *testing.T) {
 				rsm, done := testutil.NewRemoteSnapshotMonitor(m)
 				defer done()
 				buildIndex(sh, regConfig.mirror(optimizedImageName2), withMinLayerSize(0))
-				sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest2, regConfig.mirror(optimizedImageName2).ref)
+				sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", indexDigest2, regConfig.mirror(optimizedImageName2).ref)...)
 				buildIndex(sh, regConfig.mirror(optimizedImageName1), withMinLayerSize(0))
 				sh.X("ctr", "i", "rm", optimizedImageName1)
 				export(sh, image, tarExportArgs)
@@ -368,7 +368,7 @@ func TestLazyPullNoIndexDigest(t *testing.T) {
 		}
 	}
 	export := func(sh *shell.Shell, image string, tarExportArgs []string) {
-		sh.X("soci", "image", "rpull", "--user", regConfig.creds(), image)
+		sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), image)...)
 		sh.Pipe(nil, shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...), tarExportArgs)
 	}
 
@@ -438,7 +438,7 @@ func TestPullWithAribtraryBlobInvalidZtocFormat(t *testing.T) {
 	}
 
 	export := func(sh *shell.Shell, image, sociIndexDigest string, tarExportArgs []string) {
-		sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", sociIndexDigest, image)
+		sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", sociIndexDigest, image)...)
 		sh.Pipe(nil, shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...), tarExportArgs)
 	}
 
@@ -550,7 +550,7 @@ disable = true
 		}
 	}
 	export := func(sh *shell.Shell, image string, tarExportArgs []string) {
-		sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest1, image)
+		sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", indexDigest1, image)...)
 		sh.Pipe(nil, shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...), tarExportArgs)
 	}
 
@@ -592,7 +592,7 @@ disable = true
 				rsm, done := testutil.NewRemoteSnapshotMonitor(m)
 				defer done()
 				buildIndex(sh, regConfig.mirror(optimizedImageName2), withMinLayerSize(0))
-				sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest2, regConfig.mirror(optimizedImageName2).ref)
+				sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", indexDigest2, regConfig.mirror(optimizedImageName2).ref)...)
 				buildIndex(sh, regConfig.mirror(optimizedImageName1), withMinLayerSize(0))
 				sh.X("ctr", "i", "rm", optimizedImageName1)
 				export(sh, image, tarExportArgs)
@@ -718,7 +718,7 @@ insecure = true
 	rebootContainerd(t, sh, "", "")
 	sh.X("nerdctl", "pull", "-q", regConfig.mirror(imageName).ref)
 	sh.X("soci", "create", regConfig.mirror(imageName).ref)
-	sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(imageName).ref)
+	sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(imageName).ref)...)
 	registryHostIP, registryAltHostIP := getIP(t, sh, regConfig.host), getIP(t, sh, regAltConfig.host)
 	export := func(image string) []string {
 		return shell.C(append(runSociCmd, "--name", "test", "--rm", image, "tar", "-zc", "/usr")...)
@@ -797,7 +797,7 @@ func TestRpullImageThenRemove(t *testing.T) {
 		t.Fatalf("soci index %s contains 0 blobs, invalidating this test", indexDigest)
 	}
 
-	sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(containerImage).ref)
+	sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(containerImage).ref)...)
 
 	checkFuseMounts(t, sh, len(sociIndex.Blobs))
 
@@ -830,7 +830,7 @@ min_layer_size=` + strconv.FormatInt(middleSize, 10) + `
 	copyImage(sh, dockerhub(containerImage), regConfig.mirror(containerImage))
 	indexDigest := buildIndex(sh, regConfig.mirror(containerImage), withMinLayerSize(0))
 
-	sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(containerImage).ref)
+	sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(containerImage).ref)...)
 
 	checkFuseMounts(t, sh, layerCount-middleIndex)
 }

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -67,7 +67,7 @@ func TestSociArtifactsPushAndPull(t *testing.T) {
 
 			sh.X("soci", "push", "--user", regConfig.creds(), "--platform", tt.Platform, regConfig.mirror(imageName).ref)
 			sh.X("rm", "-rf", filepath.Join(store.DefaultSociContentStorePath, "blobs", "sha256"))
-			sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, "--platform", tt.Platform, regConfig.mirror(imageName).ref)
+			sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", indexDigest, "--platform", tt.Platform, regConfig.mirror(imageName).ref)...)
 
 			artifactsStoreContentDigestAfterRPull, err := getSociLocalStoreContentDigest(sh, config.DefaultContentStoreType)
 			if err != nil {
@@ -180,7 +180,7 @@ func TestLegacyOCI(t *testing.T) {
 			}
 			sh.X("rm", "-rf", filepath.Join(store.DefaultSociContentStorePath, "blobs", "sha256"))
 
-			sh.X("soci", "image", "rpull", "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(imageName).ref)
+			sh.X(append(imagePullSociCmd, "--user", regConfig.creds(), "--soci-index-digest", indexDigest, regConfig.mirror(imageName).ref)...)
 			if err := sh.Err(); err != nil {
 				t.Fatalf("failed to rpull: %v", err)
 			}

--- a/integration/rebuild-db_test.go
+++ b/integration/rebuild-db_test.go
@@ -76,8 +76,8 @@ func TestRebuildArtifactsDB(t *testing.T) {
 			name: "Rpull and rebuild %s content store",
 			setup: func(sh *dockershell.Shell, contentStoreType store.ContentStoreType) {
 				sh.X(
-					"soci", "image", "rpull", "--user", regConfig.creds(),
-					regConfig.mirror(img).ref)
+					append(imagePullSociCmd, "--user", regConfig.creds(),
+						regConfig.mirror(img).ref)...)
 			},
 			afterContent:       true,
 			expectedIndexCount: 1,

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -80,7 +80,8 @@ const (
 
 // Commonly used CLI commands
 var (
-	runSociCmd = []string{"nerdctl", "run", "--pull", "never", "--net", "none", "--snapshotter", "soci"}
+	runSociCmd       = []string{"nerdctl", "run", "--pull", "never", "--net", "none", "--snapshotter", "soci"}
+	imagePullSociCmd = []string{"soci", "image", "rpull"}
 )
 
 // These are images that we use in our integration tests


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Similar to #912's change making "nerdctl run" consolidated into one common command, this has the same function.

**Testing performed:**
go fmt passed. Should be no functional changes so as long as the replacement was done properly it should be alright.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
