### PR TITLE
Support re-authentication on 403

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -255,8 +255,7 @@ func (tr *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	// TODO: support more status codes and retries
-	if resp.StatusCode == http.StatusUnauthorized {
+	if socihttp.ShouldAuthenticate(resp) {
 		log.G(ctx).Infof("Received status code: %v. Refreshing creds...", resp.Status)
 
 		// Prepare authorization for the target host using docker.Authorizer.
@@ -283,6 +282,7 @@ func (tr *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			return nil, err
 		}
 
+		socihttp.Drain(resp.Body)
 		// re-authorize and send the request
 		return roundTrip(req.Clone(ctx))
 	}

--- a/util/http/errors.go
+++ b/util/http/errors.go
@@ -1,0 +1,19 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package http
+
+const ECRTokenExpiredResponse = "Your authorization token has expired. Reauthenticate and try again."


### PR DESCRIPTION
**Issue #, if available:**

Resolves: #920 

**Description of changes:**
Although in most cases 403 responses represent authorization issues that generally cannot be resolved by re-authentication, some registries like ECR, will return a 403 on credential expiration. We will attempt to re-authenticate only if the response body indicates credential expiration.

Ref: https://docs.aws.amazon.com/AmazonECR/latest/userguide/common-errors-docker.html#error-403

**Testing performed:**

`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
