### PR TITLE
Add unpack stats to benchmarker

### DIFF
--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -127,6 +127,7 @@ func SociFullRun(
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Stop").Infof("Stop Pull Image")
 	pullDuration := time.Since(pullStart)
 	b.ReportMetric(float64(pullDuration.Milliseconds()), "pullDuration")
+	b.ReportMetric(0, "unpackDuration")
 	if err != nil {
 		fatalf(b, "%s", err)
 	}
@@ -207,8 +208,11 @@ func OverlayFSFullRun(
 		fatalf(b, "%s", err)
 	}
 	log.G(ctx).WithField("benchmark", "Unpack").WithField("event", "Start").Infof("Start Unpack Image")
+	unpackStart := time.Now()
 	err = image.Unpack(ctx, "overlayfs")
+	unpackDuration := time.Since(unpackStart)
 	log.G(ctx).WithField("benchmark", "Unpack").WithField("event", "Stop").Infof("Stop Unpack Image")
+	b.ReportMetric(float64(unpackDuration.Milliseconds()), "unpackDuration")
 	if err != nil {
 		fatalf(b, "%s", err)
 	}

--- a/benchmark/framework/framework.go
+++ b/benchmark/framework/framework.go
@@ -62,6 +62,7 @@ type BenchmarkTestDriver struct {
 	TestsRun       int                `json:"-"`
 	FullRunStats   BenchmarkTestStats `json:"fullRunStats"`
 	PullStats      BenchmarkTestStats `json:"pullStats"`
+	UnpackStats    BenchmarkTestStats `json:"unpackStats"`
 	LazyTaskStats  BenchmarkTestStats `json:"lazyTaskStats"`
 	LocalTaskStats BenchmarkTestStats `json:"localTaskStats"`
 }
@@ -82,6 +83,7 @@ func (frame *BenchmarkFramework) Run(ctx context.Context) {
 			res := testing.Benchmark(testDriver.TestFunction)
 			testDriver.FullRunStats.BenchmarkTimes = append(testDriver.FullRunStats.BenchmarkTimes, res.T.Seconds())
 			testDriver.PullStats.BenchmarkTimes = append(testDriver.PullStats.BenchmarkTimes, res.Extra["pullDuration"]/1000)
+			testDriver.UnpackStats.BenchmarkTimes = append(testDriver.UnpackStats.BenchmarkTimes, res.Extra["unpackDuration"]/1000)
 			testDriver.LazyTaskStats.BenchmarkTimes = append(testDriver.LazyTaskStats.BenchmarkTimes, res.Extra["lazyTaskDuration"]/1000)
 			testDriver.LocalTaskStats.BenchmarkTimes = append(testDriver.LocalTaskStats.BenchmarkTimes, res.Extra["localTaskStats"]/1000)
 		}
@@ -112,6 +114,7 @@ func (frame *BenchmarkFramework) Run(ctx context.Context) {
 func (driver *BenchmarkTestDriver) calculateStats() {
 	driver.FullRunStats.calculateTestStat()
 	driver.PullStats.calculateTestStat()
+	driver.UnpackStats.calculateTestStat()
 	driver.LazyTaskStats.calculateTestStat()
 	driver.LocalTaskStats.calculateTestStat()
 }


### PR DESCRIPTION
**Issue #, if available:**
related to #205

**Description of changes:**
Adds benchmark stats for unpack. This doesn't fully address #205 but whether this is the right way to be measuring unpack or not, it's definitely better to do this than to not measure unpack at all. 

**Testing performed:**
~/benchmark.json:
```
[
  {
    "short_name": "ECR-public-ffmpeg",
    "image_ref": "public.ecr.aws/soci-workshop-examples/ffmpeg:latest",
    "soci_index_manifest_ref": "sha256:ef63578971ebd8fc700c74c96f81dafab4f3875e9117ef3c5eb7446e169d91cb",
    "ready_line": "Hello World"
  }
]
```

```
$ BENCHMARK_FLAGS='-count 1 -f ~/benchmark.json' make benchmarks-comparison-test
$ cat benchmark/comparisonTest/output/results.json 
# removed unnecessary details
"unpackStats": {
    "BenchmarkTimes": [
     11.812
    ],
    "stdDev": 0,
    "mean": 11.812,
    "min": 11.812,
    "pct25": 11.812,
    "pct50": 11.812,
    "pct75": 11.812,
    "pct90": 11.812,
    "max": 11.812
   },
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
