### PR TITLE
[release/0.4] Enable build workflow for release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,13 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: ['main', 'release/**']
     paths:
       - '**'
       - '!docs/**' # ignore docs changes
       - '!**.md' # ignore markdown changes
   pull_request:
-    branches: [ main ]
+    branches: ['main', 'release/**']
     paths:
       - '**.go'
       - 'go.*'


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Backports #957 

Enables build workflow on release branches

(cherry picked from commit 21ec5445ea5e0908861e60e92cbdcd70d3251c93)

**Testing performed:**
Ran yamllint on workflow definition

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
