### PR TITLE
Store file name as is in metadata DB

### DIFF
--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -295,7 +295,7 @@ func (sf *file) Verify() (retErr error) {
 	if !attrMatchesTarHeader(attr, tarHeader) {
 		return errors.New("file attributes do not match tar header")
 	}
-	if sf.fr.Name() != tarHeader.Name {
+	if sf.fr.TarName() != tarHeader.Name {
 		return errors.New("file name does not match tar header")
 	}
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -91,9 +91,9 @@ type Reader interface {
 }
 
 type File interface {
-	Name() string
 	GetUncompressedFileSize() compression.Offset
 	GetUncompressedOffset() compression.Offset
+	TarName() string
 	TarHeaderOffset() compression.Offset
 	TarHeaderSize() compression.Offset
 }


### PR DESCRIPTION
Right now, when converting the TOC to metadata entries, we call `path.Clean` on every file name before writing it to metadata DB. Calling `path.Clean` on a directory path removes the trailing separator. This isn't directly a problem since we only ever perform TAR header file name validation on file reads, not directories, since the kernel VFS disallows reads on directories (`EISDIR`). Cleaning the path, however, also removes the current working directory token (`./`) from a path. This means that if a path in a TAR file were prefixed with `./`, we would clean the path, removing the `./`, in turn causing our TAR header file name validation check to fail when we attempt to read from the file. To avoid TAR edge cases like this one, we should store TAR names as is in our metadata DB.

_Note_: I've also switched to use `filepath` instead of `path`, since `filepath` supports path separators across OS's.

**Issue #, if available:**

**Testing performed:**

`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
