### PR TITLE
Free zTOC from memory

### DIFF
--- a/ztoc/ztoc_marshaler.go
+++ b/ztoc/ztoc_marshaler.go
@@ -97,7 +97,10 @@ func flatbufToZtoc(flatbuffer []byte) (z *Ztoc, err error) {
 		dgst, _ := digest.Parse(string(compressionInfo.SpanDigests(i)))
 		ztoc.SpanDigests[i] = dgst
 	}
-	ztoc.Checkpoints = compressionInfo.CheckpointsBytes()
+	// Since compressionInfo.CheckpointsBytes() returns a slice,
+	// we need to give it its own array so the GC can free compressionInfo.
+	ztoc.Checkpoints = make([]byte, len(compressionInfo.CheckpointsBytes()))
+	copy(ztoc.Checkpoints, compressionInfo.CheckpointsBytes())
 	ztoc.CompressionAlgorithm = strings.ToLower(compressionInfo.CompressionAlgorithm().String())
 	return ztoc, nil
 }


### PR DESCRIPTION
**Issue #, if available:**
#967 

**Description of changes:**
Before this change, the uncompressed zTOC would stay in memory. This was because when converting the full uncompressed bytes into a struct, we erreneously retained a reference to the original byte array in `ztoc.Checkpoints`, because `compressionInfo.CheckpointsBytes()` returns a slice of the uncompressed bytes. This change copies the bytes into a dedicated buffer to free up the full uncompressed byte array.

**Testing performed:**
`make test`. Also redid the steps in #967 and confirmed that `io.ReadAll` was no longer in the FlameGraph, and that it is smaller than before (73MB -> 65MB).

Using Tensorflow image:

Before:
![before_flamegraph](https://github.com/awslabs/soci-snapshotter/assets/55555210/cfe06d54-b6fe-4a77-9eb0-eccef45bda4e)

After:
![after_flamegraph](https://github.com/awslabs/soci-snapshotter/assets/55555210/8e12d04e-eede-446e-98e9-2882d832c17e)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
