### PR TITLE
Fix index info command with containerd content store

### DIFF
--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -18,12 +18,12 @@ package index
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 
+	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 
@@ -38,6 +38,9 @@ var infoCommand = cli.Command{
 	Description: "get detailed info about an index",
 	ArgsUsage:   "<digest>",
 	Action: func(cliContext *cli.Context) error {
+		ctx, cancel := internal.AppContext(cliContext)
+		defer cancel()
+
 		digest, err := digest.Parse(cliContext.Args().First())
 		if err != nil {
 			return err
@@ -53,8 +56,6 @@ var infoCommand = cli.Command{
 		if artifactType == soci.ArtifactEntryTypeLayer {
 			return fmt.Errorf("the provided digest is of ztoc not SOCI index. Use \"soci ztoc info\" command to get detailed info of ztoc")
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), cliContext.GlobalDuration("timeout"))
-		defer cancel()
 		ctx, store, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
 		if err != nil {
 			return err

--- a/cmd/soci/commands/internal/client.go
+++ b/cmd/soci/commands/internal/client.go
@@ -74,8 +74,7 @@ func AppContext(context *cli.Context) (gocontext.Context, gocontext.CancelFunc) 
 
 // NewClient returns a new containerd client
 func NewClient(context *cli.Context, opts ...containerd.ClientOpt) (*containerd.Client, gocontext.Context, gocontext.CancelFunc, error) {
-	timeoutOpt := containerd.WithTimeout(context.GlobalDuration("connect-timeout"))
-	opts = append(opts, timeoutOpt)
+	opts = append(opts, containerd.WithTimeout(context.GlobalDuration("timeout")))
 	address := strings.TrimPrefix(context.GlobalString("address"), "unix://")
 	client, err := containerd.New(address, opts...)
 	if err != nil {


### PR DESCRIPTION
**Issue #, if available:**
Fixes #983 

**Description of changes:**
Previously SOCI CLI index info command would fail with context deadline exceeded error when the content store was set to containerd. The root cause was the default global duration for the app context is zero if not set. The result was Go context with an immediate deadline thus resulting in the error. The fix is to not set a deadline if no duration is provided.

**Testing performed:**
Before changes:
```
$ mysudo soci --content-store containerd index info sha256:8aad6c25d856dabc72284325e14dc5ea2df228c3fd6b5a96ab46854def73ea50
soci: context deadline exceeded
$ 
```

After changes:
```
$ mysudo soci --content-store containerd index info sha256:8aad6c25d856dabc72284325e14dc5ea2df228c3fd6b5a96ab46854def73ea50
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.amazon.soci.index.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/octet-stream",
      "digest": "sha256:d548f77fc4f9ad31bf390ccaab4c5ffa97f7319f921a3125e5d7daa865c0a8a1",
      "size": 1229704,
      "annotations": {
        "com.amazon.soci.image-layer-digest": "sha256:5e8117c0bd28aecad06f7e76d4d3b64734d59c1a0a44541d18060cd8fba30c50",
        "com.amazon.soci.image-layer-mediaType": "application/vnd.oci.image.layer.v1.tar+gzip"
      }
    }
  ],
  "subject": {
    "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "digest": "sha256:149d67e29f765f4db62aa52161009e99e389544e25a8f43c8c89d4a445a7ca37",
    "size": 424
  },
  "annotations": {
    "com.amazon.soci.build-tool-identifier": "AWS SOCI CLI v0.1"
  }
}$ 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
