### PR TITLE
Fix containerd socket address when using containerd as content store

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -85,7 +85,7 @@ var CreateCommand = cli.Command{
 			return err
 		}
 
-		ctx, blobStore, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
+		ctx, blobStore, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -55,7 +55,7 @@ var infoCommand = cli.Command{
 		if artifactType == soci.ArtifactEntryTypeLayer {
 			return fmt.Errorf("the provided digest is of ztoc not SOCI index. Use \"soci ztoc info\" command to get detailed info of ztoc")
 		}
-		ctx, store, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
+		ctx, store, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/rm.go
+++ b/cmd/soci/commands/index/rm.go
@@ -47,7 +47,7 @@ var rmCommand = cli.Command{
 		}
 
 		ctx := context.Background()
-		ctx, contentStore, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
+		ctx, contentStore, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return fmt.Errorf("cannot create local content store: %w", err)
 		}

--- a/cmd/soci/commands/internal/store.go
+++ b/cmd/soci/commands/internal/store.go
@@ -1,0 +1,33 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import (
+	"strings"
+
+	"github.com/awslabs/soci-snapshotter/soci/store"
+	"github.com/urfave/cli"
+)
+
+// ContentStoreOptions builds a list of content store options from a CLI context.
+func ContentStoreOptions(context *cli.Context) []store.Option {
+	return []store.Option{
+		store.WithType(store.ContentStoreType(context.GlobalString("content-store"))),
+		store.WithContainerdAddress(strings.TrimPrefix(context.GlobalString("address"), "unix://")),
+		store.WithNamespace(context.GlobalString("namespace")),
+	}
+}

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -130,7 +130,7 @@ if they are available in the snapshotter's local content store.
 			}, nil
 		}
 
-		ctx, src, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
+		ctx, src, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return fmt.Errorf("cannot create local content store: %w", err)
 		}

--- a/cmd/soci/commands/rebuild_db.go
+++ b/cmd/soci/commands/rebuild_db.go
@@ -39,7 +39,7 @@ var RebuildDBCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		ctx, blobStore, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
+		ctx, blobStore, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -87,7 +87,7 @@ var getFileCommand = cli.Command{
 }
 
 func getZtoc(ctx context.Context, cliContext *cli.Context, d digest.Digest) (*ztoc.Ztoc, error) {
-	ctx, blobStore, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
+	ctx, blobStore, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/awslabs/soci-snapshotter/ztoc"
@@ -72,7 +73,7 @@ var infoCommand = cli.Command{
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), cliContext.GlobalDuration("timeout"))
 		defer cancel()
-		ctx, store, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cliContext.GlobalString("content-store"))), store.WithNamespace(cliContext.GlobalString("namespace")))
+		ctx, store, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return err
 		}

--- a/config/config.toml
+++ b/config/config.toml
@@ -74,6 +74,9 @@ emit_metric_period_sec=0
 
 [content_store]
 type="" # will set to 'soci' by default
+# Socket address for containerd. Only applicable using containerd content store.
+# Defaults to '/run/containerd/containerd.sock'
+containerd_address=""
 namespace="" # will set to 'default' by default
    
 #

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -142,7 +142,11 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 			return docker.ConfigureDefaultRegistries(docker.WithPlainHTTP(docker.MatchLocalhost))(refspec.Hostname())
 		})
 	}
-	ctx, store, err := store.NewContentStore(ctx, store.WithType(store.ContentStoreType(cfg.ContentStoreConfig.Type)), store.WithNamespace(cfg.ContentStoreConfig.Namespace))
+	ctx, store, err := store.NewContentStore(ctx,
+		store.WithType(cfg.ContentStoreConfig.Type),
+		store.WithContainerdAddress(cfg.ContentStoreConfig.ContainerdAddress),
+		store.WithNamespace(cfg.ContentStoreConfig.Namespace),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create content store: %w", err)
 	}


### PR DESCRIPTION
**Issue #, if available:**
Fixes #982 

**Description of changes:**
Previously the CLI and snapshotter service would use '/run/containerd/containerd.sock' as the containerd socket when using containerd as content store. This resulted in errors for users not using the default install path for containerd. This change allows for pass through of `--address` flag to content store and configuration of contaienrd socket in SOCI config.toml.

**Testing performed:**

```
$ sudo soci --content-store containerd --address="/run/containerd/containerd-other.sock" create public.ecr.aws/datadog/agent:7.50.0-rc.6
layer sha256:d0ed4082888aed967d69278e4056798ed0b24e4eef1c65bbaa67a6148097b602 -> ztoc sha256:863292676e1c021f9e024c626ab4d790313ac5963f04fbace23d389dc171740a
$ sudo soci --content-store containerd index ls
soci: failed to dial "/run/containerd/containerd.sock": context deadline exceeded: connection error: desc = "transport: error while dialing: dial unix:///run/containerd/containerd.sock: timeout"
$ sudo soci --content-store containerd --address="/run/containerd/containerd-other.sock" index ls
DIGEST                                                                     SIZE    IMAGE REF                                   PLATFORM       MEDIA TYPE                                    CREATED         
sha256:2c957ec0f8a239f3f59433aa272e9acaa467b1888e8b724a2944c39b00d0d332    854     public.ecr.aws/datadog/agent:7.50.0-rc.6    linux/amd64    application/vnd.oci.image.manifest.v1+json    7m19s ago       
sha256:8aad6c25d856dabc72284325e14dc5ea2df228c3fd6b5a96ab46854def73ea50    837     public.ecr.aws/ubuntu/ubuntu:22.04          linux/amd64    application/vnd.oci.image.manifest.v1+json    2h13m37s ago    
$ 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
