### PR TITLE
[release/0.4] Fix integration test failures on non-x86

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,3 @@ RUN curl -sSL --output /tmp/nerdctl.tgz https://github.com/containerd/nerdctl/re
     rm -f /tmp/nerdctl.tgz
 
 FROM registry:2 AS registry2
-
-FROM ghcr.io/oci-playground/registry:v3.0.0-alpha.1 AS registry3alpha1

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -107,10 +107,9 @@ func TestMain(m *testing.M) {
 // setup can be used to initialize things before integration tests start (as of now it only builds the services used by the integration tests so they can be referenced)
 func setup() ([]func() error, error) {
 	var (
-		serviceName          = "testing"
-		targetStage          = "containerd-snapshotter-base"
-		registry2Stage       = "registry2"
-		registry3alpha1Stage = "registry3alpha1"
+		serviceName    = "testing"
+		targetStage    = "containerd-snapshotter-base"
+		registry2Stage = "registry2"
 	)
 	pRoot, err := testutil.GetProjectRoot()
 	if err != nil {
@@ -122,11 +121,10 @@ func setup() ([]func() error, error) {
 	}
 
 	composeYaml, err := testutil.ApplyTextTemplate(composeBuildTemplate, dockerComposeYaml{
-		ServiceName:          serviceName,
-		ImageContextDir:      pRoot,
-		TargetStage:          targetStage,
-		Registry2Stage:       registry2Stage,
-		Registry3Alpha1Stage: registry3alpha1Stage,
+		ServiceName:     serviceName,
+		ImageContextDir: pRoot,
+		TargetStage:     targetStage,
+		Registry2Stage:  registry2Stage,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Issue #, if available:**
Backports #806

**Description of changes:**
There were several issues that caused integration tests to fail on non-x86. The first one was our dependency GHCR registry image which is only supported on amd64. The GHCR registry was needed when we supported artifact manifests, but those have been seemingly removed from the OCI 1.1 spec proposal, so we no longer need it. We also had 2 tests that relied on a pinned amd64 variant of rabbitmq. Those have been replaced with a pinned multi-arch index.

(cherry picked from commit 7cc04aff01bce06f3b1759cf1eecf4cebdeeb2cb)

**Testing performed:**
Successfully ran integration tests on a EC2 ARM instance using the release/0.4 branch + cherry-picked commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
