### PR TITLE
Update Go version in CI to v1.20.12

### DIFF
--- a/.github/workflows/benchmark_visualization.yml
+++ b/.github/workflows/benchmark_visualization.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: write
   deployments: write
+
+env:
+  GO_VERSION: '1.20.12'
       
 jobs:
   benchmark:
@@ -23,7 +26,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20.6'
+          go-version: ${{ env.GO_VERSION }}
       - run: make
       - name: Run benchmark
         run: make benchmarks-perf-test 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ on:
       - 'integration/**'
       - 'scripts/**'
 
+env:
+  GO_VERSION: '1.20.12'
+
 jobs:
   test:
     runs-on: ubuntu-20.04
@@ -25,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20.6'
+          go-version: ${{ env.GO_VERSION }}
       - run: make
       - run: make test
   integration:
@@ -40,5 +43,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20.6'
+          go-version: ${{ env.GO_VERSION }}
       - run: make integration

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 0 */2 * *" # every 2 days
 
+env:
+  GO_VERSION: '1.20.12'
+
 jobs:
   check:
     runs-on: ubuntu-20.04
@@ -11,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20.6'
+          go-version: ${{ env.GO_VERSION }}
       - run: make
       - run: make benchmarks
       - run: cd benchmark/comparisonTest && cat output/results.json

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  GO_VERSION: '1.20.12'
+
 jobs:
   check:
     runs-on: ubuntu-20.04
@@ -19,7 +22,7 @@ jobs:
           fetch-depth: 21
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20.6'
+          go-version: ${{ env.GO_VERSION }}
       - run: wget https://github.com/google/flatbuffers/releases/download/v22.9.29/Linux.flatc.binary.g++-10.zip
       - run: unzip Linux.flatc.binary.g++-10.zip
       - run: ./scripts/install-check-tools.sh

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 env:
-  GO_VERSION: '1.20.6'
+  GO_VERSION: '1.20.12'
 
 permissions:
   contents: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG CONTAINERD_VERSION=1.6.17
 ARG RUNC_VERSION=1.1.5
 ARG NERDCTL_VERSION=1.3.0
 
-FROM golang:1.20.6-bookworm AS golang-base
+FROM golang:1.20.12-bookworm AS golang-base
 
 FROM golang-base AS containerd-snapshotter-base
 ARG CONTAINERD_VERSION


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This PR updates the Go compiler version in CI to 1.20.12 to pickup builtin Go runtime bug fixes and security patches.

**Testing performed:**

Ran `make test` and `make integration` on EC2 ARM instance with Go 1.20.12 compiler installed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
