### PR TITLE
[release/0.4] Add test against referrers API

### DIFF
--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -631,7 +631,12 @@ func TestMirror(t *testing.T) {
 		t.Fatalf("failed to generate htpasswd: %v", err)
 	}
 
-	authDir := t.TempDir()
+	hostVolumeMount := t.TempDir()
+	authDir := filepath.Join(hostVolumeMount, "auth")
+	if err := os.Mkdir(authDir, 0777); err != nil {
+		t.Fatalf("failed to create auth folder in tempdir: %v", err)
+	}
+
 	if err := os.WriteFile(filepath.Join(authDir, "domain.key"), key, 0666); err != nil {
 		t.Fatalf("failed to prepare key file")
 	}
@@ -653,7 +658,7 @@ func TestMirror(t *testing.T) {
 		RegistryAltImageRef: oci10RegistryImage,
 		RegistryHost:        regConfig.host,
 		RegistryAltHost:     regAltConfig.host,
-		AuthDir:             authDir,
+		HostVolumeMount:     hostVolumeMount,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -146,6 +146,11 @@ func TestLegacyOCI(t *testing.T) {
 			registryImage: oci10RegistryImage,
 			expectError:   false,
 		},
+		{
+			name:          "OCI 1.0 Artifacts succeed with OCI 1.1 registry",
+			registryImage: oci11RegistryImage,
+			expectError:   false,
+		},
 	}
 	for _, tc := range tests {
 		tc := tc


### PR DESCRIPTION
**Issue #, if available:**
Back-ports #856

**Description of changes:**
#806 removed our test against the referrers API. This test uses a multi-platform image (zot) to reintroduce this test.

(cherry picked from commit 49dc6a77a41175bca0dc74d43389c61edc171803)

**Testing performed:**

Successfully ran integration tests on EC2 ARM instance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
