### PR TITLE
Log successful startup of soci-snapshotter-grpc

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -268,6 +268,8 @@ func serve(ctx context.Context, rpc *grpc.Server, addr string, rs snapshots.Snap
 		}
 	}()
 
+	log.G(ctx).WithField("address", addr).Info("soci-snapshotter-grpc successfully started")
+
 	var s os.Signal
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, unix.SIGINT, unix.SIGTERM)


### PR DESCRIPTION
**Issue #, if available:**
Resolves: #515 

**Description of changes:** Currently, the beginning of the startup process is logged, but no line is logged when startup succeeds.

**Testing performed:**
Before:
```
[ec2-user@ip-10-0-1-240 soci-snapshotter]$ sudo soci-snapshotter-grpc
{"level":"info","msg":"starting soci-snapshotter-grpc","revision":"5d1022b0def534e457fd0f649b99e3874dc38eaa","time":"2023-12-14T22:01:22.686850482Z","version":"5d1022b"}
{"emitMetricPeriod":10000000000,"fetchPeriod":500000000,"level":"info","maxQueueSize":100,"msg":"constructing background fetcher","silencePeriod":30000000000,"time":"2023-12-14T22:01:22.905906907Z"}
^C{"level":"info","msg":"Got interrupt","time":"2023-12-14T22:01:29.001103791Z"}
{"error":"bucket does not exist: not found","level":"warning","msg":"failed to unmount snapshots on close","time":"2023-12-14T22:01:29.001244038Z"}
{"level":"info","msg":"Exiting","time":"2023-12-14T22:01:29.001289768Z"}
```

After:
```
[ec2-user@ip-10-0-1-240 soci-snapshotter]$ sudo soci-snapshotter-grpc
{"level":"info","msg":"starting soci-snapshotter-grpc","revision":"1f95399f909bdd1ba02529255b682165d3007949","time":"2023-12-14T22:01:58.597241960Z","version":"1f95399"}
{"emitMetricPeriod":10000000000,"fetchPeriod":500000000,"level":"info","maxQueueSize":100,"msg":"constructing background fetcher","silencePeriod":30000000000,"time":"2023-12-14T22:01:58.615551090Z"}
{"level":"info","msg":"soci-snapshotter-grpc successfully started, listening on \"/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock\"","time":"2023-12-14T22:01:58.618808388Z"}
^C{"level":"info","msg":"Got interrupt","time":"2023-12-14T22:02:37.162371412Z"}
{"error":"bucket does not exist: not found","level":"warning","msg":"failed to unmount snapshots on close","time":"2023-12-14T22:02:37.162574419Z"}
{"level":"info","msg":"Exiting","time":"2023-12-14T22:02:37.162618239Z"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
