### PR TITLE
Change LogMonitor to look for correct string

### DIFF
--- a/util/testutil/shell.go
+++ b/util/testutil/shell.go
@@ -216,7 +216,8 @@ func monitorStartup(errs chan error) func(string) {
 				errs <- errors.New("fatal snapshotter log entry encountered, snapshotter failed to start")
 				return
 			}
-			if strings.Contains(logline.Msg, "background") {
+			// Looking for "soci-snapshotter-grpc successfully started"
+			if strings.Contains(logline.Msg, "successfully") {
 				errs <- nil
 				return
 			}


### PR DESCRIPTION
**Issue #, if available:**
Related #515

**Description of changes:**
Per the comment in #515, after our changes in #1001, we should modify `monitorStartup` to look for this instead of just the background fetcher.

**Testing performed:**
`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
