### PR TITLE
Add ztoc generation benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ CMD=soci-snapshotter-grpc soci
 
 CMD_BINARIES=$(addprefix $(OUTDIR)/,$(CMD))
 
+GO_BENCHMARK_TESTS?=.
+
 .PHONY: all build check add-ltag install uninstall clean test integration release benchmarks build-benchmarks benchmarks-perf-test benchmarks-comparison-test
 
 all: build
@@ -87,6 +89,7 @@ test:
 	@echo "$@"
 	@GO111MODULE=$(GO111MODULE_VALUE) go test $(GO_TEST_FLAGS) $(GO_LD_FLAGS) -race ./...
 
+
 integration: build
 	@echo "$@"
 	@echo "SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT)"
@@ -95,6 +98,10 @@ integration: build
 release:
 	@echo "$@"
 	@$(SOCI_SNAPSHOTTER_PROJECT_ROOT)/scripts/create-releases.sh $(RELEASE_TAG)
+
+go-benchmarks:
+    # -run matches TestXXX type functions. Setting it to ^$ ensures non-benchmark tests are not run
+	go test -run=^$$ -bench=$(GO_BENCHMARK_TESTS) -benchmem $(GO_BENCHMARK_FLAGS) ./...
 
 benchmarks: benchmarks-perf-test benchmarks-comparison-test
 


### PR DESCRIPTION
**Issue #, if available:**
Related to #76. I'd like to see how a go rewrite affects build times.

**Description of changes:**
We have benchmarks for pulling and running images with OverlayFS vs SOCI, but we don't have any benchmarking for how long it takes to build ztocs. This adds a benchmark for building ztocs to give us directional information about how the changes we make affect build times.

This also adds a make target: `make go-benchmarks` to run the handful of benchmarks that we have.

**Testing performed:**
`make go-benchmarks`

Output:
```
goos: linux
goarch: amd64
pkg: github.com/awslabs/soci-snapshotter/ztoc
cpu: Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
BenchmarkZtocGeneration/gzip/one_small_file-8         	    6885	    158749 ns/op	  122082 B/op	      52 allocs/op
BenchmarkZtocGeneration/gzip/one_large_file-8         	      14	  77734864 ns/op	 1382596 B/op	     239 allocs/op
BenchmarkZtocGeneration/gzip/many_small_files-8       	       3	 362723048 ns/op	 7474165 B/op	   67718 allocs/op
BenchmarkZtocGeneration/gzip/several_large_files-8    	       2	 544046376 ns/op	 8852608 B/op	    1366 allocs/op
BenchmarkZtocGeneration/uncompressed/one_small_file-8 	   25680	     46456 ns/op	   35669 B/op	      51 allocs/op
BenchmarkZtocGeneration/uncompressed/one_large_file-8 	      20	  55605206 ns/op	  669178 B/op	     229 allocs/op
BenchmarkZtocGeneration/uncompressed/many_small_files-8         	      12	  91597917 ns/op	 6608970 B/op	   65270 allocs/op
BenchmarkZtocGeneration/uncompressed/several_large_files-8      	       3	 390447901 ns/op	 4473634 B/op	    1359 allocs/op
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
