### PR TITLE
fix: strip path in release tar

### DIFF
--- a/scripts/create-releases.sh
+++ b/scripts/create-releases.sh
@@ -60,13 +60,15 @@ static_binary_name=soci-snapshotter-${release_version}-linux-${ARCH}-static.tar.
 
 make build
 cp "$NOTICE_FILE" "$LICENSE_FILE" "${OUT_DIR}"
-tar -czvf "$RELEASE_DIR"/"$dynamic_binary_name" "$OUT_DIR"
+tar -czvf "$RELEASE_DIR"/"$dynamic_binary_name" -C "$OUT_DIR" .
 rm -rf "{$OUT_DIR:?}"/*
 
 STATIC=1 make build
 cp "$NOTICE_FILE" "$LICENSE_FILE" "$OUT_DIR"
-tar -czvf "$RELEASE_DIR"/"$static_binary_name" "$OUT_DIR"
+tar -czvf "$RELEASE_DIR"/"$static_binary_name" -C "$OUT_DIR" .
 rm -rf "{$OUT_DIR:?}"/*
 
-sha256sum "$RELEASE_DIR"/"$dynamic_binary_name" > "$RELEASE_DIR"/"$dynamic_binary_name".sha256sum
-sha256sum "$RELEASE_DIR"/"$static_binary_name" > "$RELEASE_DIR"/"$static_binary_name".sha256sum
+pushd $RELEASE_DIR
+sha256sum "$dynamic_binary_name" > "$RELEASE_DIR"/"$dynamic_binary_name".sha256sum
+sha256sum "$static_binary_name" > "$RELEASE_DIR"/"$static_binary_name".sha256sum
+popd


### PR DESCRIPTION
**Issue #, if available:**

Fixes: #1007 #1010 

Update the create tar release from

```
tar -czvf "$RELEASE_DIR"/"$dynamic_binary_name" "$OUT_DIR"
```

to

```sh
tar -czvf "$RELEASE_DIR"/"$dynamic_binary_name" -C "$OUT_DIR" .
```

after the change, when I tried to do `make RELEASE_TAG=v0.4.1 release`, I will get the following

![image](https://github.com/awslabs/soci-snapshotter/assets/627278/0037d20b-3762-4dad-9feb-e898d3e960cc)




**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
