### PR TITLE
Revert Credential function signature

### DIFF
--- a/service/keychain/cri/v1/cri.go
+++ b/service/keychain/cri/v1/cri.go
@@ -81,8 +81,7 @@ type instrumentedService struct {
 	configMu sync.Mutex
 }
 
-func (in *instrumentedService) credentials(imgRefSpec reference.Spec) (string, string, error) {
-	host := imgRefSpec.Hostname()
+func (in *instrumentedService) credentials(imgRefSpec reference.Spec, host string) (string, string, error) {
 	if host == "docker.io" || host == "registry-1.docker.io" {
 		// Creds of "docker.io" is stored keyed by "https://index.docker.io/v1/".
 		host = "index.docker.io"

--- a/service/keychain/cri/v1alpha/cri.go
+++ b/service/keychain/cri/v1alpha/cri.go
@@ -81,8 +81,7 @@ type instrumentedAlphaService struct {
 	configMu sync.Mutex
 }
 
-func (in *instrumentedAlphaService) credentials(imgRefSpec reference.Spec) (string, string, error) {
-	host := imgRefSpec.Hostname()
+func (in *instrumentedAlphaService) credentials(imgRefSpec reference.Spec, host string) (string, string, error) {
 	if host == "docker.io" || host == "registry-1.docker.io" {
 		// Creds of "docker.io" is stored keyed by "https://index.docker.io/v1/".
 		host = "index.docker.io"

--- a/service/keychain/dockerconfig/dockerconfig.go
+++ b/service/keychain/dockerconfig/dockerconfig.go
@@ -40,8 +40,7 @@ import (
 	"github.com/docker/cli/cli/config"
 )
 
-func DockerCreds(imgRefSpec reference.Spec) (string, string, error) {
-	host := imgRefSpec.Hostname()
+func DockerCreds(host string) (string, string, error) {
 	cf, err := config.Load("")
 	if err != nil {
 		return "", "", nil
@@ -62,7 +61,10 @@ func DockerCreds(imgRefSpec reference.Spec) (string, string, error) {
 }
 
 func NewDockerConfigKeychain(ctx context.Context) resolver.Credential {
-	return func(imgRefSpec reference.Spec) (string, string, error) {
-		return DockerCreds(imgRefSpec)
+	// We do not index by image reference because the docker config only
+	// supports indexing credentials by root URL/hostname.
+	// eg: host.io and not host.io/namespace
+	return func(_ reference.Spec, host string) (string, string, error) {
+		return DockerCreds(host)
 	}
 }

--- a/service/keychain/kubeconfig/kubeconfig.go
+++ b/service/keychain/kubeconfig/kubeconfig.go
@@ -151,8 +151,7 @@ type keychain struct {
 	informer cache.SharedIndexInformer
 }
 
-func (kc *keychain) credentials(imgRefSpec reference.Spec) (string, string, error) {
-	host := imgRefSpec.Hostname()
+func (kc *keychain) credentials(imgRefSpec reference.Spec, host string) (string, string, error) {
 	if host == "docker.io" || host == "registry-1.docker.io" {
 		// Creds of "docker.io" is stored keyed by "https://index.docker.io/v1/".
 		host = "https://index.docker.io/v1/"

--- a/service/resolver/client.go
+++ b/service/resolver/client.go
@@ -32,7 +32,6 @@ import (
 	"github.com/awslabs/soci-snapshotter/config"
 	socihttp "github.com/awslabs/soci-snapshotter/internal/http"
 	"github.com/awslabs/soci-snapshotter/version"
-	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/log"
 	rhttp "github.com/hashicorp/go-retryablehttp"
@@ -219,7 +218,6 @@ func shouldAuthenticate(resp *http.Response) bool {
 	case http.StatusUnauthorized:
 		return true
 	case http.StatusForbidden:
-
 		/*
 			Although in most cases 403 responses represent authorization issues that generally
 			cannot be resolved by re-authentication, some registries like ECR, will return a 403 on
@@ -257,7 +255,6 @@ func shouldAuthenticate(resp *http.Response) bool {
 			}
 		}
 	case http.StatusBadRequest:
-
 		/*
 			S3 returns a 400 on token expiry with an XML encoded response body.
 			See: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList
@@ -304,23 +301,4 @@ func shouldAuthenticate(resp *http.Response) bool {
 func newContextWithScope(origReqCtx context.Context) context.Context {
 	scope := docker.GetTokenScopes(origReqCtx, []string{})
 	return docker.WithScope(context.Background(), strings.Join(scope, ""))
-}
-
-// newRefSpecWithHost take a reference spec and returns a new one with the host portion
-// replaced with a given host.
-//
-// Partially copied over from https://github.com/containerd/containerd/blob/e5e7f613cf8bf481430dcf4e79c00c80e9d2683c/reference/reference.go
-// Original Copyright the containerd Authors. Licensed under the Apache License, Version 2.0 (the "License").
-func newRefSpecWithHost(imgRefSpec reference.Spec, host string) (reference.Spec, error) {
-	i := strings.Index(imgRefSpec.Locator, "/")
-	path := imgRefSpec.Locator[i+1:]
-	tag := imgRefSpec.Object
-	if tag[:1] != "@" {
-		tag = fmt.Sprintf(":%s", tag)
-	}
-	newRefSpec, err := reference.Parse(fmt.Sprintf("%s/%s%s", host, path, tag))
-	if err != nil {
-		return reference.Spec{}, err
-	}
-	return newRefSpec, nil
 }

--- a/service/resolver/cri.go
+++ b/service/resolver/cri.go
@@ -127,8 +127,7 @@ func RegistryHostsFromCRIConfig(ctx context.Context, config Registry, credsFuncs
 		return func(imgRefSpec reference.Spec) ([]docker.RegistryHost, error) {
 			host := imgRefSpec.Hostname()
 			hostOptions := dconfig.HostOptions{}
-			hostOptions.Credentials = multiCredsFuncs(imgRefSpec, append(credsFuncs, func(imgRefSpec reference.Spec) (string, string, error) {
-				host := imgRefSpec.Hostname()
+			hostOptions.Credentials = multiCredsFuncs(imgRefSpec, append(credsFuncs, func(imgRefSpec reference.Spec, host string) (string, string, error) {
 				config := config.Configs[host]
 				if config.Auth != nil {
 					return ParseAuth(toRuntimeAuthConfig(*config.Auth), host)


### PR DESCRIPTION
Commit 666ef04 introduced the notion of an `AuthClient`. We create new `AuthClient`'s for every unique image reference since credentials can be scoped to specific images/repositories. This also included mirrors, meaning mirror credentials are completely independent of the host credentials. For the most part this is correct, but the CRI implementation in `containerd` does not do this, instead they [try to use the same CRI/kubelet credentials for every endpoint](https://github.com/containerd/containerd/blob/ced9b18c231a28990617bc0a4b8ce2e81ee2ffa1/pkg/cri/server/images/image_pull.go#L408-L444) (host and mirrors), unless there are host credentials directly provided in the config. We should adopt this same policy as-well. This means we'll have to re-introduce the `host` argument in our `Credential` type, so that when we attempt to get credentials through our CRI implementation for a mirror, we try to use the credentials for the base host first. If that fails, we can try other credential providers using the `host` argument as our index.

This also prevents us from blindly sending the credentials we have cached in our CRI implementation for a specific image reference when the authorizer asks for a set of credentials for a host.

eg: If we make a request for image ref `host.io/namespace/repo:latest` and we somehow get a 401 response from some other host `differenthost.io`, we shouldn't send the credentials for `host.io/namespace/repo:latest`.

**Issue #, if available:**

**Description of changes:**

> For the most part this is correct, but the CRI implementation in containerd does not do this, instead they [try to use the same CRI/kubelet credentials for every endpoint](https://github.com/containerd/containerd/blob/ced9b18c231a28990617bc0a4b8ce2e81ee2ffa1/pkg/cri/server/images/image_pull.go#L408-L444) (host and mirrors)

For some more context, the `RegistryHosts` implementation in containerd CRI attempts to use the original `AuthConfig` for all hosts including mirrors. The actual [`ParseAuth`](https://github.com/containerd/containerd/blob/b7b808c36fccd73ae01f9c67c9ca4a7db238a9ef/pkg/cri/server/images/image_pull.go#L251-L259) function reads the `ServerAdress` field and compares it against the host passed by the `docker.Authorizer`. If they match (or if the kubelet does not specify a `ServerAdress`) then it returns the set of credentials. In most cases, they won't match as the `kubelet` fetches credentials for the reference provided.


**Testing performed:**

`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
