### PR TITLE
Disable xattrs if layer has no xattrs or opaque directories

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -31,6 +31,7 @@ const (
 	buildToolIdentifier = "AWS SOCI CLI v0.1"
 	spanSizeFlag        = "span-size"
 	minLayerSizeFlag    = "min-layer-size"
+	xattrFlag           = "xattr-optimization"
 )
 
 // CreateCommand creates SOCI index for an image
@@ -53,6 +54,10 @@ var CreateCommand = cli.Command{
 			Usage: "Minimum layer size to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10 MiB.",
 			Value: 10 << 20,
 		},
+		cli.BoolFlag{
+			Name:  xattrFlag,
+			Usage: "If set to true layers without xattr will have xattr disabled, yielding a performance benefit. Does not effect layers where is xattrs are present. Default is False.",
+		},
 	),
 	Action: func(cliContext *cli.Context) error {
 		srcRef := cliContext.Args().Get(0)
@@ -74,6 +79,7 @@ var CreateCommand = cli.Command{
 		}
 		spanSize := cliContext.Int64(spanSizeFlag)
 		minLayerSize := cliContext.Int64(minLayerSizeFlag)
+		xattr := cliContext.Bool(xattrFlag)
 		// Creating the snapshotter's root path first if it does not exist, since this ensures, that
 		// it has the limited permission set as drwx--x--x.
 		// The subsequent oci.New creates a root path dir with too broad permission set.
@@ -104,6 +110,7 @@ var CreateCommand = cli.Command{
 			soci.WithMinLayerSize(minLayerSize),
 			soci.WithSpanSize(spanSize),
 			soci.WithBuildToolIdentifier(buildToolIdentifier),
+			soci.WithXAttrOptimization(xattr),
 		}
 
 		for _, plat := range ps {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -508,7 +508,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		FsName:        "soci", // name this filesystem as "soci"
 		Debug:         fs.debug,
 		Logger:        golog.New(logger, "", 0),
-		DisableXAttrs: l.NoXAttr(),
+		DisableXAttrs: l.DisableXAttrs(),
 	}
 	if _, err := exec.LookPath(fusermountBin); err == nil {
 		mountOpts.Options = []string{"suid"} // option for fusermount; allow setuid inside container

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -504,10 +504,11 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		WithField("layerDigest", labels[ctdsnapshotters.TargetLayerDigestLabel]).
 		WriterLevel(logrus.TraceLevel)
 	mountOpts := &fuse.MountOptions{
-		AllowOther: true,   // allow users other than root&mounter to access fs
-		FsName:     "soci", // name this filesystem as "soci"
-		Debug:      fs.debug,
-		Logger:     golog.New(logger, "", 0),
+		AllowOther:    true,   // allow users other than root&mounter to access fs
+		FsName:        "soci", // name this filesystem as "soci"
+		Debug:         fs.debug,
+		Logger:        golog.New(logger, "", 0),
+		DisableXAttrs: l.NoXAttr(),
 	}
 	if _, err := exec.LookPath(fusermountBin); err == nil {
 		mountOpts.Options = []string{"suid"} // option for fusermount; allow setuid inside container

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -79,6 +79,7 @@ type breakableLayer struct {
 }
 
 func (l *breakableLayer) Info() layer.Info                                    { return layer.Info{} }
+func (l *breakableLayer) NoXAttr() bool                                       { return false }
 func (l *breakableLayer) RootNode(uint32) (fusefs.InodeEmbedder, error)       { return nil, nil }
 func (l *breakableLayer) Verify(tocDigest digest.Digest) error                { return nil }
 func (l *breakableLayer) SkipVerify()                                         {}

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -79,7 +79,7 @@ type breakableLayer struct {
 }
 
 func (l *breakableLayer) Info() layer.Info                                    { return layer.Info{} }
-func (l *breakableLayer) NoXAttr() bool                                       { return false }
+func (l *breakableLayer) DisableXAttrs() bool                                 { return false }
 func (l *breakableLayer) RootNode(uint32) (fusefs.InodeEmbedder, error)       { return nil, nil }
 func (l *breakableLayer) Verify(tocDigest digest.Digest) error                { return nil }
 func (l *breakableLayer) SkipVerify()                                         {}

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -45,6 +45,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -58,6 +59,7 @@ import (
 
 	spanmanager "github.com/awslabs/soci-snapshotter/fs/span-manager"
 	"github.com/awslabs/soci-snapshotter/metadata"
+	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/util/lrucache"
 	"github.com/awslabs/soci-snapshotter/util/namedmutex"
 	"github.com/awslabs/soci-snapshotter/ztoc"
@@ -103,6 +105,9 @@ type Layer interface {
 
 	// ReadAt reads this layer.
 	ReadAt([]byte, int64, ...remote.Option) (int, error)
+
+	//True if none of the files in the layer has an xattr
+	NoXAttr() bool
 
 	// Done releases the reference to this layer. The resources related to this layer will be
 	// discarded sooner or later. Queries after calling this function won't be serviced.
@@ -339,9 +344,9 @@ func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, ref
 	if err != nil {
 		return nil, fmt.Errorf("failed to read layer: %w", err)
 	}
-
+	xattr := getXAttrAnnotation(sociDesc)
 	// Combine layer information together and cache it.
-	l := newLayer(r, desc, blobR, vr, bgLayerResolver, opCounter)
+	l := newLayer(r, desc, blobR, vr, bgLayerResolver, opCounter, xattr)
 	r.layerCacheMu.Lock()
 	cachedL, done2, added := r.layerCache.Add(name, l)
 	r.layerCacheMu.Unlock()
@@ -403,6 +408,7 @@ func newLayer(
 	vr *reader.VerifiableReader,
 	bgResolver backgroundfetcher.Resolver,
 	opCounter *FuseOperationCounter,
+	hasXAttr bool,
 ) *layer {
 	return &layer{
 		resolver:             resolver,
@@ -411,6 +417,7 @@ func newLayer(
 		verifiableReader:     vr,
 		bgResolver:           bgResolver,
 		fuseOperationCounter: opCounter,
+		hasXAttr:             hasXAttr,
 	}
 }
 
@@ -425,6 +432,7 @@ type layer struct {
 	r reader.Reader
 
 	fuseOperationCounter *FuseOperationCounter
+	hasXAttr             bool
 
 	closed   bool
 	closedMu sync.Mutex
@@ -494,6 +502,10 @@ func (l *layer) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, erro
 	return l.blob.ReadAt(p, offset, opts...)
 }
 
+func (l *layer) NoXAttr() bool {
+	return !l.hasXAttr
+}
+
 func (l *layer) close() error {
 	l.closedMu.Lock()
 	defer l.closedMu.Unlock()
@@ -517,6 +529,19 @@ func (l *layer) isClosed() bool {
 	closed := l.closed
 	l.closedMu.Unlock()
 	return closed
+}
+
+func getXAttrAnnotation(desc ocispec.Descriptor) bool {
+	stringVal, present := desc.Annotations[soci.IndexAnnotationXattrPresent]
+	if !present {
+		return false
+	}
+	val, err := strconv.ParseBool(stringVal)
+	if err != nil {
+		return false
+	}
+
+	return val
 }
 
 // blobRef is a reference to the blob in the cache. Calling `done` decreases the reference counter

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -106,8 +106,8 @@ type Layer interface {
 	// ReadAt reads this layer.
 	ReadAt([]byte, int64, ...remote.Option) (int, error)
 
-	//True if none of the files in the layer has an xattr
-	NoXAttr() bool
+	// DisableXAttrs determines whether this layer should have xattrs disabled
+	DisableXAttrs() bool
 
 	// Done releases the reference to this layer. The resources related to this layer will be
 	// discarded sooner or later. Queries after calling this function won't be serviced.
@@ -344,9 +344,9 @@ func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, ref
 	if err != nil {
 		return nil, fmt.Errorf("failed to read layer: %w", err)
 	}
-	xattr := getXAttrAnnotation(sociDesc)
+	disableXattrs := getDisableXAttrAnnotation(sociDesc)
 	// Combine layer information together and cache it.
-	l := newLayer(r, desc, blobR, vr, bgLayerResolver, opCounter, xattr)
+	l := newLayer(r, desc, blobR, vr, bgLayerResolver, opCounter, disableXattrs)
 	r.layerCacheMu.Lock()
 	cachedL, done2, added := r.layerCache.Add(name, l)
 	r.layerCacheMu.Unlock()
@@ -408,7 +408,7 @@ func newLayer(
 	vr *reader.VerifiableReader,
 	bgResolver backgroundfetcher.Resolver,
 	opCounter *FuseOperationCounter,
-	hasXAttr bool,
+	disableXAttrs bool,
 ) *layer {
 	return &layer{
 		resolver:             resolver,
@@ -417,7 +417,7 @@ func newLayer(
 		verifiableReader:     vr,
 		bgResolver:           bgResolver,
 		fuseOperationCounter: opCounter,
-		hasXAttr:             hasXAttr,
+		disableXAttrs:        disableXAttrs,
 	}
 }
 
@@ -432,7 +432,7 @@ type layer struct {
 	r reader.Reader
 
 	fuseOperationCounter *FuseOperationCounter
-	hasXAttr             bool
+	disableXAttrs        bool
 
 	closed   bool
 	closedMu sync.Mutex
@@ -502,8 +502,8 @@ func (l *layer) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, erro
 	return l.blob.ReadAt(p, offset, opts...)
 }
 
-func (l *layer) NoXAttr() bool {
-	return !l.hasXAttr
+func (l *layer) DisableXAttrs() bool {
+	return l.disableXAttrs
 }
 
 func (l *layer) close() error {
@@ -531,8 +531,8 @@ func (l *layer) isClosed() bool {
 	return closed
 }
 
-func getXAttrAnnotation(desc ocispec.Descriptor) bool {
-	stringVal, present := desc.Annotations[soci.IndexAnnotationXattrPresent]
+func getDisableXAttrAnnotation(desc ocispec.Descriptor) bool {
+	stringVal, present := desc.Annotations[soci.IndexAnnotationDisableXAttrs]
 	if !present {
 		return false
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This is a rebase + update to #718 

## Original change
The original insight is that GetXAttr and ListXAttr are the most expensive FUSE operations, accounting for significant SOCI overhead in some use cases, but most layers don't actually contain any xattrs. If we can disable xattrs in these cases, then we can get better runtime performance with SOCI. 

Since image layers are immutable, if the layer tarball doesn't contain any xattrs, then we can disable xattrs for the FUSE mount and the kernel will stop issuing the calls to the snapshotter. 

## Updates

### Fix for opaque directories
The original insight is mostly correct, but it doesn't handle OveralyFS opaque directories. To delete a file in OverlayFS, you can either create a whiteout file in a high layer (`.wh.$ORIGINAL_FILE_NAME`) or you can implicitly delete all files in a directory by returning an opaque xattr (`trusted.overlay.opaque=y`). The image spec encodes opaque xattrs into the layer as a special file (`$DIR/.wh..wh..opq`) instead of directly putting the xattr into the tarball, and the snapshotter translates that back into an xattr at runtime. With the original change xattrs would be disabled so the opaque file wouldn't be converted back into an xattr which means that the files would be visible.

This change updates the logic for determining whether to disable xattrs to include checking  for opaque directories

### `--xattr-optimization` -> `--optimizations xattr`

Following a suggestion on the original PR, I renamed the flag to `--optimizations` so that we can experiment with optimizations in the future. I'm on the fence on whether there should be a concept of "experimental optimizations" and "stable optimizations". I can also imagine that this xattrs optimization eventually just becomes on-by-default and disappears from the CLI entirely. Thoughts on this are welcome.

### Everything is now "Disable Xattrs"
In the original PR, the discussions were back and forth on whether we should use variations of "Has xattrs", "No xattrs", or "Disable Xattrs". Since now it also includes whether the layer has whiteouts, I opted to stick to "Disable Xattrs" everywhere since it's not directly related to whether xattrs exist in the layer, but whether xattrs should be enabled for OverlayFS. This also has the nice property that the default false ignores the optimization as pointed out in the original PR.

**Testing performed:**
```
make check && make test && make integration
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
