### PR TITLE
Add verification step to release automation

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,7 +12,6 @@ permissions:
   deployments: write
 
 jobs:
-  # Any way we can just call build.yml?
   test:
     runs-on: ubuntu-20.04
     steps:
@@ -39,7 +38,13 @@ jobs:
       - run: make integration
 
   generate-artifacts:
+    needs: [test, integration]
     runs-on: ubuntu-20.04
+    env:
+      # Set during setup.
+      RELEASE_TAG: ''
+      DYNAMIC_BINARY_NAME: ''
+      STATIC_BINARY_NAME: ''
     steps:
     - uses: actions/checkout@v4
     - name: Setup and export variables
@@ -47,13 +52,13 @@ jobs:
         export release_tag=${GITHUB_REF#refs/*/} # Strip down to raw tag name
         export release_version=${release_tag/v/} # Remove v from tag name
 
-        echo "release_tag=${release_tag}">> $GITHUB_ENV
-        echo "dynamic_binary_name=soci-snapshotter-${release_version}-linux-amd64.tar.gz" >> $GITHUB_ENV
-        echo "static_binary_name=soci-snapshotter-${release_version}-linux-amd64-static.tar.gz" >> $GITHUB_ENV
+        echo "RELEASE_TAG=${release_tag}" >> $GITHUB_ENV
+        echo "DYNAMIC_BINARY_NAME=soci-snapshotter-${release_version}-linux-amd64.tar.gz" >> $GITHUB_ENV
+        echo "STATIC_BINARY_NAME=soci-snapshotter-${release_version}-linux-amd64-static.tar.gz" >> $GITHUB_ENV
         
         mkdir release
     - name: Create release binaries
-      run: make RELEASE_TAG=${{ env.release_tag }} release
+      run: make RELEASE_TAG=${{ env.RELEASE_TAG }} release
     - uses: actions/upload-artifact@v4
       with:
         name: artifacts
@@ -61,11 +66,22 @@ jobs:
         if-no-files-found: error
 
     outputs:
-      dynamic_binary_name: ${{ env.dynamic_binary_name }}
-      static_binary_name: ${{ env.static_binary_name }}
+      release_tag: ${{ env.RELEASE_TAG }}
+      dynamic_binary_name: ${{ env.DYNAMIC_BINARY_NAME }}
+      static_binary_name: ${{ env.STATIC_BINARY_NAME }}
+  
+  validate-artifacts:
+    needs: generate-artifacts
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: artifacts
+      - run: bash scripts/verify-release-artifacts.sh ${{ needs.generate-artifacts.outputs.release_tag }}
 
   create-release:
-    needs: generate-artifacts
+    needs: [generate-artifacts, validate-artifacts]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /out
+/release
 *.db
 .vscode/
 go.work

--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+#   Copyright The Soci Snapshotter Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# A script to verify artifacts from release automation.
+
+set -o pipefail
+
+arch=""
+case $(uname -m) in
+    x86_64) arch="amd64" ;;
+    aarch64) arch="arm64" ;;
+    *) echo "Error: unsupported arch"; exit 1 ;;
+esac
+
+function usage {
+    echo "Usage: $0 <release_tag>"
+}
+
+if [ $# -eq 0 ]; then
+    echo "$0: Missing required argument"
+    usage
+    exit 1
+fi
+
+release_tag=$1
+# Strip 'v' from release tag.
+release_version=${release_tag/v/} 
+
+tarballs=("soci-snapshotter-${release_version}-linux-${arch}.tar.gz" "soci-snapshotter-${release_version}-linux-${arch}-static.tar.gz")
+expected_contents=("soci-snapshotter-grpc" "soci" "THIRD_PARTY_LICENSES" "NOTICE.md")
+release_is_valid=true
+
+for t in "${tarballs[@]}"; do
+    # Verify each expected tarball was generated.
+    if [[ ! -e $t ]]; then
+        echo "$t: MISSING"
+        release_is_valid=false
+        continue
+    fi
+
+    # Verify the tarball's checksum is present and valid.
+    if [[ ! -e "$t.sha256sum" ]] ; then
+        echo "$t.sha256sum: MISSING"
+        release_is_valid=false
+        continue
+    elif ( ! sha256sum -c "$t.sha256sum" &>/dev/null); then
+        echo "$t.sha256sum: INVALID"
+        release_is_valid=false
+        continue
+    fi
+
+    # Read file names from tarball and strip './' if found.
+    mapfile -t found_contents < <(tar -tf "$t" | sed -r 's/^.\///')
+
+    content_matches=true
+
+    # Verify the tarball only contains the expected contents.
+    for file in "${found_contents[@]}"; do
+        if [[ ! ${expected_contents[*]} =~ $file ]]; then
+            echo "$file: UNEXPECTED"
+            release_is_valid=false
+            content_matches=false
+        fi
+    done
+
+    # Verify the tarball is not missing any content.
+    for file in "${expected_contents[@]}"; do
+        if [[ ! ${found_contents[*]} =~ $file ]]; then
+            echo "$file: MISSING"
+            release_is_valid=false
+            content_matches=false
+        fi
+    done
+
+    if ${content_matches}; then
+        echo "$t: OK"
+    else
+        echo "$t: INVALID"
+    fi
+done
+
+if ( ! ${release_is_valid} ); then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
**Issue #, if available:**
Related to #1007 

**Description of changes:**
This change includes enhancements to the release automation workflow. The primary focus is adding a release artifact verification script to the automation to validate release artifact contents and checksums.

Other minor changes include reordering of release automation workflow jobs and declaration of job environment variables to resolve warnings.

**Testing performed:**
Manually test verification script locally using the following steps:
```
make RELEASE_TAG=v0.4.2 release
cd release
bash ../scripts/verify-release-artifacts.sh v0.4.2
```

The script will validate release artifacts are present, checksums are validate, and contents are expected.
```
$ bash ../scripts/verify-release-artifacts.sh v0.4.2
soci-snapshotter-0.4.2-linux-amd64.tar.gz: OK
soci-snapshotter-0.4.2-linux-amd64-static.tar.gz: OK
```

Example output when checksum does not match.
```
$ bash ../scripts/verify-release-artifacts.sh v0.4.2
soci-snapshotter-0.4.2-linux-amd64.tar.gz.sha256sum: INVALID
soci-snapshotter-0.4.2-linux-amd64-static.tar.gz: OK
```

Example output when contents does not match expected.
```
$ bash ../scripts/verify-release-artifacts.sh v0.4.2
soci-snapshotter-0.4.2-linux-amd64.tar.gz: INVALID
extra.txt: UNEXPECTED
THIRD_PARTY_LICENSES: MISSING
soci-snapshotter-0.4.2-linux-amd64-static.tar.gz: OK
```

Ran release automation in fork by making the following changes:
In `workflows/releases.yml`:
```
on:
  push:
    branches:
        - <branch_name>
...
       # export release_tag=${GITHUB_REF#refs/*/}
       export release_tag=v0.4.2 
```

https://github.com/austinvazquez/soci-snapshotter/actions/runs/7424371225

Ran ShellCheck on script locally using the following command:
```
docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable scripts/verify-release-artifacts.sh
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
