### PR TITLE
Eagerly resolve local blobs

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -346,6 +346,20 @@ func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels 
 	}
 	unpacker := NewLayerUnpacker(fetcher, archive)
 	desc := s.Target
+
+	// If no descriptor size is given, resolve the layer
+	// to populate it
+	if desc.Size == 0 {
+		// In remoteStore.Reference, Registry and Target should be correct.
+		// However, we need Reference to point to the current layer.
+		blobRef := remoteStore.Reference
+		blobRef.Reference = s.Target.Digest.String()
+		desc, err = remoteStore.Blobs().Resolve(ctx, blobRef.String())
+		if err != nil {
+			return fmt.Errorf("cannot resolve size of layer (%s): %w", blobRef.String(), err)
+		}
+	}
+
 	err = unpacker.Unpack(ctx, desc, mountpoint, mounts)
 	if err != nil {
 		return fmt.Errorf("cannot unpack the layer: %w", err)


### PR DESCRIPTION
**Issue #, if available:**
Fixes #931

**Description of changes:**
For local snapshots, we previously encountered a bug where the size of a layer was resported as zero in its descriptor. This caused the Fetch function to attempt to resolve it as a manifest, which would then cause the local snapshot to defer to container runtime, causing containerd to fetch all remaining layers ahead of time. This change resolves the local blob earlier to populate the size field, avoiding this issue.

**Testing performed:**
Followed steps in #931 and ensured local snapshots were successfully prepared.

After setting up containerd/crictl configs I ran the following script:

```
# Empty content store beforehand

TOKEN=$(aws ecr get-authorization-token --region us-west-2 | jq -r '.authorizationData[0].authorizationToken' | base64 -d)
sudo crictl \
  --runtime-endpoint "unix:///var/run/containerd/containerd.sock" \
  --image-endpoint "unix:///var/run/containerd/containerd.sock" \
  run \
  --creds $TOKEN \
  container-config.json \
  pod-config.json
```

<details>
  <summary>Output</summary>

``` json
{"level":"info","msg":"starting soci-snapshotter-grpc","revision":"5217c3718d46a675fb964ff06c2399540b03794e","time":"2024-01-09T21:56:31.727674500Z","version":"5217c37"}
{"emitMetricPeriod":10000000000,"fetchPeriod":500000000,"level":"info","maxQueueSize":100,"msg":"constructing background fetcher","silencePeriod":30000000000,"time":"2024-01-09T21:56:31.763298289Z"}
{"address":"/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock","level":"info","msg":"soci-snapshotter-grpc successfully started","time":"2024-01-09T21:56:31.767434398Z"}
{"key":"k8s.io/1/extract-544072554-KtoC sha256:e3e5579ddd43c08e4b5c74dc12941a4ef656fab070b1087a1fd5a8a836b71e7d","level":"info","msg":"preparing filesystem mount at mountpoint=/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs","parent":"","time":"2024-01-09T21:56:32.550227833Z"}
{"key":"k8s.io/1/extract-544072554-KtoC sha256:e3e5579ddd43c08e4b5c74dc12941a4ef656fab070b1087a1fd5a8a836b71e7d","level":"info","mountpoint":"/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs","msg":"index digest not provided, making a Referrers API call to fetch list of indices","parent":"","time":"2024-01-09T21:56:32.550317570Z"}
{"error":"unable to fetch SOCI artifacts: cannot fetch list of referrers: unable to fetch referrers: GET \"https://accounts.google.com/v3/signin/identifier?continue=https%3A%2F%2Fconsole.cloud.google.com%2Fartifacts%2Ftags%2Fv2%2Fus-west1%2Fk8s-artifacts-prod%2Fimages%252Fpause%252Freferrers%252Fsha256%2F8d4106c88ec0bd28001e34c975d65175d994072d65341f62a8ab0754b0fafe10\u0026followup=https%3A%2F%2Fconsole.cloud.google.com%2Fartifacts%2Ftags%2Fv2%2Fus-west1%2Fk8s-artifacts-prod%2Fimages%252Fpause%252Freferrers%252Fsha256%2F8d4106c88ec0bd28001e34c975d65175d994072d65341f62a8ab0754b0fafe10\u0026ifkv=ASKXGp2557sFr8K0acu6KQXE9y8yxDkTNaD4RnM82YUOVq6iCWSnQMBGS4ZPj_NXyXuExnKCWQ10Sw\u0026osid=1\u0026passive=1209600\u0026service=cloudconsole\u0026flowName=WebLiteSignIn\u0026flowEntry=ServiceLogin\u0026dsh=S111108%3A1704837392875678\": failed to decode response: invalid character '\u003c' looking for beginning of value","key":"k8s.io/1/extract-544072554-KtoC sha256:e3e5579ddd43c08e4b5c74dc12941a4ef656fab070b1087a1fd5a8a836b71e7d","level":"warning","msg":"failed to prepare remote snapshot","parent":"","remote-snapshot-prepared":"false","time":"2024-01-09T21:56:33.057822171Z"}
{"layerDigest":"sha256:61fec91190a0bab34406027bbec43d562218df6e80d22d4735029756f23c7007","level":"info","msg":"preparing snapshot as local snapshot","time":"2024-01-09T21:56:33.057880065Z"}
{"key":"k8s.io/1/extract-544072554-KtoC sha256:e3e5579ddd43c08e4b5c74dc12941a4ef656fab070b1087a1fd5a8a836b71e7d","level":"info","msg":"preparing local filesystem at mountpoint=/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs","parent":"","time":"2024-01-09T21:56:33.057905931Z"}
{"digest":"sha256:61fec91190a0bab34406027bbec43d562218df6e80d22d4735029756f23c7007","key":"k8s.io/1/extract-544072554-KtoC sha256:e3e5579ddd43c08e4b5c74dc12941a4ef656fab070b1087a1fd5a8a836b71e7d","level":"info","msg":"fetching artifact from remote","parent":"","time":"2024-01-09T21:56:33.115622050Z"}
{"key":"k8s.io/1/extract-544072554-KtoC sha256:e3e5579ddd43c08e4b5c74dc12941a4ef656fab070b1087a1fd5a8a836b71e7d","level":"info","msg":"local snapshot successfully prepared","parent":"","time":"2024-01-09T21:56:33.170098068Z"}
{"key":"k8s.io/3/extract-634603292-LAsg sha256:8075d045345a93dbac9815a69cdee7f0d10ba82e83f364c794683b31f3a82c86","level":"info","msg":"preparing filesystem mount at mountpoint=/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/3/fs","parent":"","time":"2024-01-09T21:56:33.637428598Z"}
{"key":"k8s.io/3/extract-634603292-LAsg sha256:8075d045345a93dbac9815a69cdee7f0d10ba82e83f364c794683b31f3a82c86","level":"info","mountpoint":"/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/3/fs","msg":"index digest not provided, making a Referrers API call to fetch list of indices","parent":"","time":"2024-01-09T21:56:33.637517943Z"}
{"key":"k8s.io/3/extract-634603292-LAsg sha256:8075d045345a93dbac9815a69cdee7f0d10ba82e83f364c794683b31f3a82c86","level":"info","mountpoint":"/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/3/fs","msg":"Received status code: 401 Unauthorized. Authorizing...","parent":"","time":"2024-01-09T21:56:33.655293258Z"}
{"digest":"sha256:bed193e8a077047e03e0775f8827fca3d9bd5c555e429b95c797ed2ffbb87fbf","key":"k8s.io/3/extract-634603292-LAsg sha256:8075d045345a93dbac9815a69cdee7f0d10ba82e83f364c794683b31f3a82c86","level":"info","mountpoint":"/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/3/fs","msg":"fetching SOCI artifacts using index descriptor","parent":"","time":"2024-01-09T21:56:33.785765708Z"}
{"digest":"sha256:bed193e8a077047e03e0775f8827fca3d9bd5c555e429b95c797ed2ffbb87fbf","level":"info","msg":"fetching SOCI index from remote registry","time":"2024-01-09T21:56:33.785797153Z"}
{"digest":"sha256:bed193e8a077047e03e0775f8827fca3d9bd5c555e429b95c797ed2ffbb87fbf","level":"info","msg":"fetching artifact from remote","time":"2024-01-09T21:56:33.785832098Z"}
{"digest":"sha256:5f931294fa10c999223fb7c19ff241ecb3cdfcb0b61d9289da8d7562d51c7778","level":"info","msg":"fetching artifact from remote","time":"2024-01-09T21:56:33.870896973Z"}
{"digest":"sha256:3baf6beca7e66fd9f202a0e80d22a446927f7f3b8e0bab208758c4ca1258aee9","level":"info","msg":"fetching artifact from remote","time":"2024-01-09T21:56:33.870904590Z"}
{"key":"k8s.io/3/extract-634603292-LAsg sha256:8075d045345a93dbac9815a69cdee7f0d10ba82e83f364c794683b31f3a82c86","level":"info","mountpoint":"/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/3/fs","msg":"Verification forcefully skipped","parent":"","time":"2024-01-09T21:56:34.495312457Z"}
{"key":"k8s.io/3/extract-634603292-LAsg sha256:8075d045345a93dbac9815a69cdee7f0d10ba82e83f364c794683b31f3a82c86","level":"info","msg":"remote snapshot successfully prepared.","parent":"","remote-snapshot-prepared":"true","time":"2024-01-09T21:56:34.499215012Z"}
{"key":"k8s.io/4/extract-504004840-sQgj sha256:fb0172ff7e95acb9f733f1974fde617f9f4194d6ba3e4f9486791fe35553e1b8","level":"info","msg":"preparing filesystem mount at mountpoint=/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/4/fs","parent":"sha256:8075d045345a93dbac9815a69cdee7f0d10ba82e83f364c794683b31f3a82c86","time":"2024-01-09T21:56:34.507123341Z"}
{"key":"k8s.io/4/extract-504004840-sQgj sha256:fb0172ff7e95acb9f733f1974fde617f9f4194d6ba3e4f9486791fe35553e1b8","level":"info","mountpoint":"/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/4/fs","msg":"Verification forcefully skipped","parent":"sha256:8075d045345a93dbac9815a69cdee7f0d10ba82e83f364c794683b31f3a82c86","time":"2024-01-09T21:56:34.787930976Z"}
{"key":"k8s.io/4/extract-504004840-sQgj sha256:fb0172ff7e95acb9f733f1974fde617f9f4194d6ba3e4f9486791fe35553e1b8","level":"info","msg":"remote snapshot successfully prepared.","parent":"sha256:8075d045345a93dbac9815a69cdee7f0d10ba82e83f364c794683b31f3a82c86","remote-snapshot-prepared":"true","time":"2024-01-09T21:56:34.792532731Z"}
{"key":"k8s.io/5/extract-795965430-Z2XQ sha256:ed65b89030c460f72fc00e77fbd1a49514d7db99128cd3f8dd692bad4cd65eaa","level":"info","msg":"preparing filesystem mount at mountpoint=/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/5/fs","parent":"sha256:fb0172ff7e95acb9f733f1974fde617f9f4194d6ba3e4f9486791fe35553e1b8","time":"2024-01-09T21:56:34.799303025Z"}
{"image":"425784566319.dkr.ecr.us-west-2.amazonaws.com/testing:nginx-demo","key":"k8s.io/5/extract-795965430-Z2XQ sha256:ed65b89030c460f72fc00e77fbd1a49514d7db99128cd3f8dd692bad4cd65eaa","layerDigest":"sha256:e95787efecdd4b6afe3e32d9d6ddb1ad8605754b4c73c1a4637135c63c684247","level":"info","mountpoint":"/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/5/fs","msg":"skipping mounting layer as FUSE mount: no ztoc for layer","parent":"sha256:fb0172ff7e95acb9f733f1974fde617f9f4194d6ba3e4f9486791fe35553e1b8","time":"2024-01-09T21:56:34.799375369Z"}
{"error":"skipping mounting layer sha256:e95787efecdd4b6afe3e32d9d6ddb1ad8605754b4c73c1a4637135c63c684247 as FUSE mount: no ztoc for layer","key":"k8s.io/5/extract-795965430-Z2XQ sha256:ed65b89030c460f72fc00e77fbd1a49514d7db99128cd3f8dd692bad4cd65eaa","level":"warning","msg":"failed to prepare remote snapshot","parent":"sha256:fb0172ff7e95acb9f733f1974fde617f9f4194d6ba3e4f9486791fe35553e1b8","remote-snapshot-prepared":"false","time":"2024-01-09T21:56:34.799414383Z"}
{"layerDigest":"sha256:e95787efecdd4b6afe3e32d9d6ddb1ad8605754b4c73c1a4637135c63c684247","level":"info","msg":"preparing snapshot as local snapshot","time":"2024-01-09T21:56:34.799481264Z"}
{"key":"k8s.io/5/extract-795965430-Z2XQ sha256:ed65b89030c460f72fc00e77fbd1a49514d7db99128cd3f8dd692bad4cd65eaa","level":"info","msg":"preparing local filesystem at mountpoint=/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/5/fs","parent":"sha256:fb0172ff7e95acb9f733f1974fde617f9f4194d6ba3e4f9486791fe35553e1b8","time":"2024-01-09T21:56:34.799499214Z"}
{"digest":"sha256:e95787efecdd4b6afe3e32d9d6ddb1ad8605754b4c73c1a4637135c63c684247","key":"k8s.io/5/extract-795965430-Z2XQ sha256:ed65b89030c460f72fc00e77fbd1a49514d7db99128cd3f8dd692bad4cd65eaa","level":"info","msg":"fetching artifact from remote","parent":"sha256:fb0172ff7e95acb9f733f1974fde617f9f4194d6ba3e4f9486791fe35553e1b8","time":"2024-01-09T21:56:34.848547041Z"}
{"key":"k8s.io/5/extract-795965430-Z2XQ sha256:ed65b89030c460f72fc00e77fbd1a49514d7db99128cd3f8dd692bad4cd65eaa","level":"info","msg":"local snapshot successfully prepared","parent":"sha256:fb0172ff7e95acb9f733f1974fde617f9f4194d6ba3e4f9486791fe35553e1b8","time":"2024-01-09T21:56:34.922153837Z"}
```
</details>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
