### PR TITLE
Fallback to containerd if we are unable to fetch SOCI artifacts

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -409,7 +409,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	client := src[0].Hosts[0].Client
 	c, err := fs.getSociContext(ctx, imageRef, sociIndexDigest, imgDigest, client)
 	if err != nil {
-		return fmt.Errorf("unable to fetch SOCI artifacts: %w", err)
+		return fmt.Errorf("%w: unable to fetch SOCI artifacts for image %q: %w", snapshot.ErrUnableToLazyLoadImage, imageRef, err)
 	}
 
 	// Resolve the target layer


### PR DESCRIPTION
If we know that we cannot lazy load an image (eg: SOCI index does not exist for an image), we should fallback to the underlying runtime to do the fetching/unpacking of all layers.

**Issue #, if available:**

Fixes: #1034 

**Description of changes:**

**Testing performed:**

`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
