### PR TITLE
Fix file descriptor leak

### DIFF
--- a/fs/unpacker.go
+++ b/fs/unpacker.go
@@ -77,18 +77,19 @@ func (lu *layerUnpacker) Unpack(ctx context.Context, desc ocispec.Descriptor, mo
 	if err != nil {
 		return fmt.Errorf("cannot fetch layer: %w", err)
 	}
-	defer rc.Close()
 
 	if !local {
-		if err = lu.fetcher.Store(ctx, desc, rc); err != nil {
+		err := lu.fetcher.Store(ctx, desc, rc)
+		rc.Close()
+		if err != nil {
 			return fmt.Errorf("cannot store layer: %w", err)
 		}
-		rc.Close()
 		rc, _, err = lu.fetcher.Fetch(ctx, desc)
 		if err != nil {
 			return fmt.Errorf("cannot fetch layer: %w", err)
 		}
 	}
+	defer rc.Close()
 	parents, err := getLayerParents(mounts[0].Options)
 	if err != nil {
 		return fmt.Errorf("cannot get layer parents: %w", err)


### PR DESCRIPTION
**Issue #, if available:**
#901 

**Description of changes:**
Moved `defer rc.Close()` outside of the local check, so that it will always close the correct file descriptor

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
