### PR TITLE
fs/source: drop indirect dependency on k8s.io/cri-api

### DIFF
--- a/fs/source/source.go
+++ b/fs/source/source.go
@@ -38,7 +38,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/awslabs/soci-snapshotter/service/resolver"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/labels"
 	ctdsnapshotters "github.com/containerd/containerd/pkg/snapshotters"
@@ -87,9 +86,13 @@ const (
 	TargetSociIndexDigestLabel = "containerd.io/snapshot/remote/soci.index.digest"
 )
 
+// RegistryHosts is copied from [github.com/awslabs/soci-snapshotter/service/resolver.RegistryHosts]
+// to reduce package dependency
+type RegistryHosts func(imgRefSpec reference.Spec) ([]docker.RegistryHost, error)
+
 // FromDefaultLabels returns a function for converting snapshot labels to
 // source information based on labels.
-func FromDefaultLabels(hosts resolver.RegistryHosts) GetSources {
+func FromDefaultLabels(hosts RegistryHosts) GetSources {
 	return func(labels map[string]string) ([]Source, error) {
 		refStr, ok := labels[ctdsnapshotters.TargetRefLabel]
 		if !ok {

--- a/service/service.go
+++ b/service/service.go
@@ -100,7 +100,7 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	}
 	// Configure filesystem and snapshotter
 	fsOpts := append(sOpts.fsOpts, socifs.WithGetSources(
-		source.FromDefaultLabels(hosts), // provides source info based on default labels
+		source.FromDefaultLabels(source.RegistryHosts(hosts)), // provides source info based on default labels
 	), socifs.WithOverlayOpaqueType(opq))
 	fs, err := socifs.NewFilesystem(ctx, fsRoot(root), serviceCfg.FSConfig, fsOpts...)
 	if err != nil {


### PR DESCRIPTION

**Issue #, if available:**
nerdctl imports `soci-snapshotter/fs/source` but does not want to import k8s.io/cri-api

- https://github.com/containerd/nerdctl/pull/2761#discussion_r1458338720

**Description of changes:**
fs/source: drop indirect dependency on k8s.io/cri-api

**Testing performed:**
`go list -f '{{join .Deps "\n"}}' ./fs/source | grep cri-api`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
