### PR TITLE
Disable release note generation in release automation

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           draft: true
           prerelease: false
-          generate_release_notes: true
+          generate_release_notes: false
           files: |
             ${{ needs.generate-artifacts.outputs.dynamic_binary_name }}
             ${{ needs.generate-artifacts.outputs.dynamic_binary_name }}.sha256sum


### PR DESCRIPTION
**Issue #, if available:**
Related to #1041 

**Description of changes:**
As part of the v0.5.0 release, automation generated release notes which included every commit in history. Instead the desired effect was to only include the diff since the last release. Disabling for now until another solution is found.

**Testing performed:**
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
