### PR TITLE
Remove testing from release workflow

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,33 +12,7 @@ permissions:
   deployments: write
 
 jobs:
-  test:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - run: make
-      - run: make test
-      
-  integration:
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        containerd: ["1.6.26", "1.7.11"]
-    env:
-      DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-      - run: make integration
-
   generate-artifacts:
-    needs: [test, integration]
     runs-on: ubuntu-20.04
     env:
       # Set during setup.


### PR DESCRIPTION
Testing on tag push is somewhat redundant since we will not be pushing out new versions unless the previous commit has passing tests, and manual testing on ARM must be done before the release tag is pushed, so this just saves us some time.

**Issue #, if available:**

**Description of changes:**
Removed unit and integration tests from release workflow.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
