### PR TITLE
Add concurrency limits

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -74,6 +74,9 @@ const (
 	// defaultFuseMetricsEmitWaitDurationSec is the amount of time the snapshotter will wait before emitting the metrics for FUSE operation.
 	defaultFuseMetricsEmitWaitDurationSec = 60
 
+	// defaultMaxConcurrency is the maximum number of layers allowed to be pulled at once
+	defaultMaxConcurrency = 100
+
 	defaultValidIntervalSec = 60
 
 	defaultFetchTimeoutSec = 300

--- a/config/fs.go
+++ b/config/fs.go
@@ -187,6 +187,13 @@ func parseFSConfig(cfg *Config) {
 	if cfg.FuseMetricsEmitWaitDurationSec == 0 {
 		cfg.FuseMetricsEmitWaitDurationSec = defaultFuseMetricsEmitWaitDurationSec
 	}
+	if cfg.MaxConcurrency == 0 {
+		cfg.MaxConcurrency = defaultMaxConcurrency
+	}
+	// If MaxConcurrency is negative, disable concurrency limits entirely.
+	if cfg.MaxConcurrency < 0 {
+		cfg.MaxConcurrency = 0
+	}
 	// Parse nested fs configs
 	parsers := []configParser{parseFuseConfig, parseBackgroundFetchConfig, parseRetryableHTTPClientConfig, parseBlobConfig, parseContentStoreConfig}
 	for _, p := range parsers {

--- a/service/service.go
+++ b/service/service.go
@@ -102,6 +102,9 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	fsOpts := append(sOpts.fsOpts, socifs.WithGetSources(
 		source.FromDefaultLabels(source.RegistryHosts(hosts)), // provides source info based on default labels
 	), socifs.WithOverlayOpaqueType(opq))
+	if serviceCfg.FSConfig.MaxConcurrency != 0 {
+		fsOpts = append(fsOpts, socifs.WithMaxConcurrency(serviceCfg.FSConfig.MaxConcurrency))
+	}
 	fs, err := socifs.NewFilesystem(ctx, fsRoot(root), serviceCfg.FSConfig, fsOpts...)
 	if err != nil {
 		log.G(ctx).WithError(err).Fatalf("failed to configure filesystem")


### PR DESCRIPTION
**Issue #, if available:**
Fixes #970 

**Description of changes:**
Implemented a limit on number of layers that can be pulled at once, reusing an old variable in the TOML for FSConfig, `max_concurrency`. This ended up slightly refactoring our pre-resolve calls to be slightly more efficient on larger images.

With the changes, instead of spawning a bunch of goroutines in order and having many layers compete with each other, every layer to be preresolved is instead sent to the queue. From there, the main queue function will first ensure that the amount of Goroutines running do not exceed the max concurrency limit, and if not, it will read from the channel and resolve the layers in the order they came in.

We initially wanted this to only make unique calls, but this PR doesn't have it yet. I feel like the queue system already does a lot to ensure that the most important work is done first. Keeping track of what layers it has already resolved has two caveats:
1. This requires new data structure besides a channel to store all of what is being queued, which will probably be less efficient than a channel. But, it's possible.
2. If a layer is pulled and then for some reason content is removed from the filesystem, it will never add the layer to the queue again until the service is restarted. This can be circumvented by having another data structure (e.g. a hashset) and just removing from the hashset after the layer has been resolved.

I don't think either of the two caveats are a huge deal, and thus I'll probably end up implementing # 2, but figured I'd write them down in case we feel it's unnecessary/unneeded. Also just want to make sure the PR is going in the right direction :p

**Testing performed:**
`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
