### PR TITLE
Remove unparsed references from zTOC

### DIFF
--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -91,6 +91,7 @@ var infoCommand = cli.Command{
 			return err
 		}
 		defer gzInfo.Close()
+		ztoc.Checkpoints = nil
 
 		multiSpanFiles := 0
 		zinfo := Info{

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -90,6 +90,7 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
+		defer gzInfo.Close()
 
 		multiSpanFiles := 0
 		zinfo := Info{

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -327,6 +327,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, ref
 	if err != nil {
 		return nil, err
 	}
+	ztoc.TOC.FileMetadata = nil
 	log.G(ctx).Debugf("[Resolver.Resolve]Initialized metadata store for layer sha=%v", desc.Digest)
 
 	spanManager := spanmanager.New(ztoc, sr, spanCache, r.config.BlobConfig.MaxSpanVerificationRetries, cache.Direct())

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -93,6 +93,7 @@ func New(ztoc *ztoc.Ztoc, r *io.SectionReader, cache cache.BlobCache, retries in
 	if err != nil {
 		return nil
 	}
+	ztoc.Checkpoints = nil
 	spans := make([]*span, ztoc.MaxSpanID+1)
 	m := &SpanManager{
 		cache:                             cache,

--- a/ztoc/ztoc.go
+++ b/ztoc/ztoc.go
@@ -180,6 +180,7 @@ func (zt Ztoc) ExtractFile(r *io.SectionReader, filename string) ([]byte, error)
 		return nil, nil
 	}
 	defer zinfo.Close()
+	zt.Checkpoints = nil
 
 	spanStart := zinfo.UncompressedOffsetToSpanID(entry.UncompressedOffset)
 	spanEnd := zinfo.UncompressedOffsetToSpanID(entry.UncompressedOffset + entry.UncompressedSize)
@@ -244,6 +245,7 @@ func (zt Ztoc) ExtractFromTarGz(gz string, filename string) (string, error) {
 		return "", err
 	}
 	defer zinfo.Close()
+	zt.Checkpoints = nil
 
 	bytes, err := zinfo.ExtractDataFromFile(gz, entry.UncompressedSize, entry.UncompressedOffset)
 	if err != nil {


### PR DESCRIPTION
**Issue #, if available:**
Fixes #968 

**Description of changes:**
Our current zTOC structure uses more memory than needed. Specifically, the Checkpoints and FileMetadata arrays only get called once, yet they cannot be freed because the SpanManager retains a reference to them, despite never needing either past their initial calls. This is an inherent design flaw with our zTOC APIs, and this fix is a temporary workaround to increase performance. Once we can flesh out the zTOC API, this solution can be much more elegant, or even unneeded.

**Testing performed:**
`make test && make integration`

I additionally ran a Prometheus server to show memory usage on heap over time. On my branch, I started the snapshotter, pulled the tensorflow image, then waited for it to stabilize. Then I did the same with main. The first metrics are with my change, the second ones are without.

![image](https://github.com/awslabs/soci-snapshotter/assets/55555210/2398df89-1d5a-4d97-abbd-a574d6409872)

We can see that we now have a baseline of roughly 18-30MB being used, instead of the 50-95MB previously used. The initial pulls remain unchanged (and can be somewhat volatile), but now while the snapshotter is running, it holds onto much less memory than before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
