### PR TITLE
Fix tar archive generation

### DIFF
--- a/scripts/create-releases.sh
+++ b/scripts/create-releases.sh
@@ -60,15 +60,19 @@ static_binary_name=soci-snapshotter-${release_version}-linux-${ARCH}-static.tar.
 
 make build
 cp "$NOTICE_FILE" "$LICENSE_FILE" "${OUT_DIR}"
-tar -czvf "$RELEASE_DIR"/"$dynamic_binary_name" -C "$OUT_DIR" .
+pushd "$OUT_DIR"
+tar -czvf "$RELEASE_DIR"/"$dynamic_binary_name" -- *
+popd
 rm -rf "{$OUT_DIR:?}"/*
 
 STATIC=1 make build
 cp "$NOTICE_FILE" "$LICENSE_FILE" "$OUT_DIR"
-tar -czvf "$RELEASE_DIR"/"$static_binary_name" -C "$OUT_DIR" .
+pushd "$OUT_DIR"
+tar -czvf "$RELEASE_DIR"/"$static_binary_name" -- *
+popd
 rm -rf "{$OUT_DIR:?}"/*
 
-pushd $RELEASE_DIR
+pushd "$RELEASE_DIR"
 sha256sum "$dynamic_binary_name" > "$RELEASE_DIR"/"$dynamic_binary_name".sha256sum
 sha256sum "$static_binary_name" > "$RELEASE_DIR"/"$static_binary_name".sha256sum
 popd


### PR DESCRIPTION
**Issue #, if available:**
Fixes #1094

**Description of changes:**
Since v0.5.0, our TAR archive generation erreneously leaves the `./` prefix.

In previous versions, the command
```bash
wget https://github.com/awslabs/soci-snapshotter/releases/download/v0.4.1/soci-snapshotter-0.4.1-linux-amd64.tar.gz
sudo tar -tvf soci-snapshotter-0.4.1-linux-amd64.tar.gz
```
produces the following:
```
-rw-rw-r-- ubuntu/ubuntu  5204 2024-01-05 18:40 NOTICE.md
-rw-rw-r-- ubuntu/ubuntu 140970 2024-01-05 18:40 THIRD_PARTY_LICENSES
-rwxrwxr-x ubuntu/ubuntu 26708152 2024-01-05 18:40 soci
-rwxrwxr-x ubuntu/ubuntu 58114872 2024-01-05 18:40 soci-snapshotter-grpc
```

However,
```bash
wget https://github.com/awslabs/soci-snapshotter/releases/download/v0.5.0/soci-snapshotter-0.5.0-linux-amd64.tar.gz
sudo tar -tvf soci-snapshotter-0.5.0-linux-amd64.tar.gz
```
produces the following:
```bash
drwxr-xr-x runner/docker     0 2024-01-18 20:20 ./
-rw-r--r-- runner/docker 142532 2024-01-18 20:20 ./THIRD_PARTY_LICENSES
-rw-r--r-- runner/docker   5204 2024-01-18 20:20 ./NOTICE.md
-rwxr-xr-x runner/docker 60860632 2024-01-18 20:20 ./soci-snapshotter-grpc
-rwxr-xr-x runner/docker 26278808 2024-01-18 20:20 ./soci
```

This means that the extraction command in our Getting Started guide no longer works.

```bash
sudo tar -C /usr/local/bin -tvf soci-snapshotter-0.5.0-linux-amd64.tar.gz soci soci-snapshotter-grpc
```
```
tar: soci: Not found in archive
tar: soci-snapshotter-grpc: Not found in archive
tar: Exiting with failure status due to previous errors
```

This worked previously in v0.4.1.

```bash
sudo tar -C /usr/local/bin -tvf soci-snapshotter-0.4.1-linux-amd64.tar.gz soci soci-snapshotter-grpc
```
```
-rwxrwxr-x ubuntu/ubuntu 26708152 2024-01-05 18:40 soci
-rwxrwxr-x ubuntu/ubuntu 58114872 2024-01-05 18:40 soci-snapshotter-grpc
```

This change fixes the command to cd to the out directory before creating the tar. Additionally fixed a quick complaint from ShellCheck.

**Testing performed:**
`make release RELEASE_TAG=v9.9.9` and confirmed contents of the tar archive were similar to the ones of v0.4.1, not v0.5.0.

```bash
scripts/build-third-party-licenses.sh
make release RELEASE_TAG=v9.9.9
sudo tar -tvf release/soci-snapshotter-9.9.9-linux-amd64.tar.gz
```
```
-rw-r--r-- ubuntu/ubuntu 5204 2024-02-29 22:22 NOTICE.md
-rwxr-xr-x ubuntu/ubuntu 25940784 2024-02-29 22:22 soci
-rwxr-xr-x ubuntu/ubuntu 59920688 2024-02-29 22:22 soci-snapshotter-grpc
-rw-r--r-- ubuntu/ubuntu   142528 2024-02-29 22:22 THIRD_PARTY_LICENSES
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
