### PR TITLE
Minor clarification to getting started docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,8 +73,10 @@ in directories that a non-root user often does not have access to.
 
 In this document we will use `rabbitmq` from DockerHub `docker.io/library/rabbitmq:latest`.
 We use [AWS ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/getting-started-console.html)
-as the public registry for demonstration. Other OCI 1.0 compatible registries such
-as dockerhub should also work.
+as the public registry for demonstration. Use of other registries is possible but please
+note that not all of the widely used container
+registries are `soci` compatible - please check the
+[registry compatibility list](https://github.com/awslabs/soci-snapshotter/blob/main/docs/registry.md#list-of-registry-compatibility) to ensure that the registry you wish to work with is compatible.
 
 First let's pull the image from docker into containerd's data store, then (tag and)
 push it up to your registry:


### PR DESCRIPTION
**Issue #, if available:**
I opened #1092 as I thought working with dockerhub worked as per the documentation.

**Description of changes:**
Tiny clarification to docs removing comment that dockerhub should work and pointing to the list of compatible registries.

**Testing performed:**
No testing required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
