### PR TITLE
Update zot image tag to v2.0.1

### DIFF
--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -75,7 +75,7 @@ const (
 	// Registry images to use in the test infrastructure. These are not intended to be used
 	// as images in the test itself, but just when we're setting up docker compose.
 	oci10RegistryImage = "registry2:soci_test"
-	oci11RegistryImage = "ghcr.io/project-zot/zot-linux-" + runtime.GOARCH + ":v2.0.0-rc6"
+	oci11RegistryImage = "ghcr.io/project-zot/zot-linux-" + runtime.GOARCH + ":v2.0.1"
 )
 
 // Commonly used CLI commands


### PR DESCRIPTION
The v2.0.0-rc6 tag got removed, so using the latest stable version as of the time of this commit.

**Issue #, if available:**

**Description of changes:**

**Testing performed:**
`make integration`. Confirmed v2.0.1 uses OCI spec v1.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
