### PR TITLE
Fix max concurrent uploads on SOCI push

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -51,7 +51,7 @@ Soci artifacts will be pushed only
 
 Flags:
 
-- ```--max-concurrent-uploads```: Max concurrent uploads. Default is 10
+- ```--max-concurrent-uploads```: Max concurrent uploads. Default is 3.
 - ```--quiet```, ```-q```: Enable quiet mode
 
 **Example:** 


### PR DESCRIPTION
**Issue #, if available:**
Fixes #1118 

**Description of changes:**
This change fixes the SOCI push command to set the maximum number of concurrent copy tasks to the value passed via the CLI flag. Before this change, the push command would not use the concurrency limit value set via CLI and default to 3 copy tasks. [Ref](https://github.com/oras-project/oras-go/blob/8d139f0be9190ee4e48fe00cda08e0185ccd2494/copy.go#L93)

**Testing performed:**

Added some logs to validate concurrency is now being set by the flag.
```
$ mysudo soci push docker.io/library/hello-world:latest
The concurrent limits are 3
soci: could not find any soci indices to push
$ 
```

```
$ mysudo soci push --max-concurrent-uploads=20 docker.io/library/hello-world:latest
The concurrent limits are 20
soci: could not find any soci indices to push
$ 
```

Before the change:
```
$ mysudo soci push docker.io/library/hello-world:latest
The concurrent limits are 0
soci: could not find any soci indices to push
$
```

```
$ mysudo soci push --max-concurrent-uploads=20 docker.io/library/hello-world:latest
The concurrent limits are 0
soci: could not find any soci indices to push
$ 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
