### PR TITLE
Add make tidy and make vendor targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,9 @@ CMD_BINARIES=$(addprefix $(OUTDIR)/,$(CMD))
 
 GO_BENCHMARK_TESTS?=.
 
-.PHONY: all build check add-ltag install uninstall clean test integration release benchmarks build-benchmarks benchmarks-perf-test benchmarks-comparison-test
+.PHONY: all build check add-ltag install uninstall tidy vendor clean \
+	test integration release benchmarks build-benchmarks \
+	benchmarks-perf-test benchmarks-comparison-test
 
 all: build
 
@@ -81,9 +83,13 @@ uninstall:
 clean:
 	rm -rf $(OUTDIR)
 
-vendor:
+tidy:
 	@GO111MODULE=$(GO111MODULE_VALUE) go mod tidy
 	@cd ./cmd ; GO111MODULE=$(GO111MODULE_VALUE) go mod tidy
+
+vendor:
+	@GO111MODULE=$(GO111MODULE_VALUE) go mod vendor
+	@cd ./cmd ; GO111MODULE=$(GO111MODULE_VALUE) go mod vendor
 
 test:
 	@echo "$@"

--- a/scripts/bump-deps.sh
+++ b/scripts/bump-deps.sh
@@ -27,7 +27,7 @@ pushd ${SOCI_SNAPSHOTTER_PROJECT_ROOT}
 go get $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
     grep -v "^google.golang.org/grpc" | \
     grep -v "^k8s.io/")
-make vendor
+make tidy
 
 pushd ./cmd
 # skip k8s deps and soci-snapshotter itself
@@ -38,6 +38,6 @@ go get $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
     grep -v "^google.golang.org/grpc" | \
     grep -v "^k8s.io/")
 popd
-make vendor
+make tidy
 
 popd


### PR DESCRIPTION
**Issue #, if available:**
Partial to #1085

There was some confusion that `make vendor` was really `go mod tidy` under the hood which installs module dependencies into the Go module cache instead versus `go mod vendor` which creates a `vendor` directory for users needing immutability. Both use cases are valid.

**Description of changes:**
This change reworks the vendor make target to vendor dependencies for users looking for stronger build reproducibility. This change adds a new tidy make target for the previous behavior to install dependencies in the local Go module cache and ensures go.mod file matches the source code in the module.

**Testing performed:**
`make vendor` now creates `<root>/vendor` and `<root>/cmd/vendor`.
`make tidy` installs dependencies into Go module cache and validates go.mod is correct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
