### PR TITLE
Update image-spec and distribution-spec links in documentation to v1.1.0

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -206,8 +206,8 @@ Once the snapshotter is running we can call the `pull` command from nerdctl.
 This command reads the manifest from the registry and mounts a FUSE filesystem
 for each layer.
 
-> The snapshotter will use the OCI distribution-spec's [Referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers)
-> (if available, otherwise the spec's [fallback mechanism](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#unavailable-referrers-api)) to fetch a list of available indices.
+> The snapshotter will use the OCI distribution-spec's [Referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers)
+> (if available, otherwise the spec's [fallback mechanism](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#unavailable-referrers-api)) to fetch a list of available indices.
 
 ```shell
 sudo nerdctl pull --snapshotter soci $REGISTRY/rabbitmq:latest

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -3,7 +3,7 @@ The SOCI project introduces several new terms that sometimes have subtle differe
 ## Terminology 
 
 * __SOCI__: Seekable OCI (pronounced so-CHEE). SOCI combines an unmodified
-  [OCI Image](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc4/spec.md) (or Docker v2
+  [OCI Image](https://github.com/opencontainers/image-spec/blob/v1.1.0/spec.md) (or Docker v2
   image) with a SOCI index to enable the SOCI snapshotter to lazily pull the image at runtime.
 
 * __SOCI index__: An OCI artifact consisting of a SOCI index manifest and a set of zTOCs
@@ -12,7 +12,7 @@ The SOCI project introduces several new terms that sometimes have subtle differe
   layers.
 
 * __SOCI index manifest__: An
-  [OCI Image manifest](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc4/manifest.md)
+  [OCI Image manifest](https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md)
   containing the list of zTOCs in the SOCI Index with a Subject reference to the image for
   which the manifest was generated.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,11 +28,11 @@ content of the SOCI Index.
 
 The SOCI index manifest contains a subject reference to the image and a list of zTOCs.
 
-* `Subject` _[descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/descriptor.md)_
+* `Subject` _[descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0/descriptor.md)_
 
     Reference to the image from which the index was generated.
 
-* `zTOCs` _array of [descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/descriptor.md)_
+* `zTOCs` _array of [descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0/descriptor.md)_
 
 ![manifest-concept](images/soci-index-manifest-conceptual-data-model.drawio.svg)
 
@@ -75,10 +75,10 @@ The following figure builds a data model for a layer TAR and its zTOC:
 ## Physical Data Model
 
 The SOCI index is packaged as an
-[OCI image manifest](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/manifest.md).
+[OCI image manifest](https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md).
 This enables the SOCI index to be stored and distributed alongside its OCI image.
 
-See [guidelines for artifact usage](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/manifest.md#guidelines-for-artifact-usage)
+See [guidelines for artifact usage](https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md#guidelines-for-artifact-usage)
 for more information on packaging content using OCI image manifest.
 
 ### SOCI Index Property Descriptions
@@ -91,10 +91,10 @@ for more information on packaging content using OCI image manifest.
 
     This value MUST contain the media type `application/vnd.oci.image.manifest.v1+json`.
 
-* `config` _[descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/descriptor.md)_
+* `config` _[descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0/descriptor.md)_
 
     A REQUIRED property for OCI image manifests to maintain portability. See
-    [guidance for an empty descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/manifest.md#guidance-for-an-empty-descriptor)
+    [guidance for an empty descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md#guidance-for-an-empty-descriptor)
     for more information.
 
     * `mediaType` _string_
@@ -109,18 +109,18 @@ for more information on packaging content using OCI image manifest.
 
         This REQUIRED descriptor property specifies the size, in bytes, of the empty JSON payload (`size` of 2).
 
-* `subject` _[descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/descriptor.md)_
+* `subject` _[descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0/descriptor.md)_
 
     A REQUIRED property which is used to specify the descriptor of the
     image manifest from which the index was generated. This value is used by the
-    [referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc3/spec.md#listing-referrers)
+    [referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers)
     and associates a SOCI index with an OCI image.
 
     * `mediaType` _string_
 
         This REQUIRED property specifies the media type of the OCI image
         manifest from which the SOCI index was generated. The media type MUST
-        [be compatible](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/media-types.md#compatibility-matrix)
+        [be compatible](https://github.com/opencontainers/image-spec/blob/v1.1.0/media-types.md#compatibility-matrix)
         with OCI image manifest.
 
     * `digest` _string_
@@ -133,7 +133,7 @@ for more information on packaging content using OCI image manifest.
         This REQUIRED property specifies the size, in bytes, of the OCI image
         manifest from which the SOCI index was generated.
 
-* `layers` _array of [descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/descriptor.md)_
+* `layers` _array of [descriptor](https://github.com/opencontainers/image-spec/blob/v1.1.0/descriptor.md)_
 
     An ordered array where each item in the array is a serialized representation
     of a zTOC. See [zTOC](#ztoc) section.

--- a/docs/pull-modes.md
+++ b/docs/pull-modes.md
@@ -32,9 +32,9 @@ The CLI accepts an optional flag `--soci-index-digest`, which is the sha256 of t
 SOCI index manifest and will be passed to the snapshotter.
 
 If not provided, the snapshotter will use the OCI distribution-spec's
-[Referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers)
+[Referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers)
 (if available, otherwise the spec's
-[fallback mechanism](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#unavailable-referrers-api))
+[fallback mechanism](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#unavailable-referrers-api))
 to fetch a list of available indices. An index will be chosen from the list of available indices,
 but the selection process is undefined and it may not choose the same index every time.
 

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -21,25 +21,25 @@ For most use-cases, compatibility is the only concern. However, there is a diffe
 
 In order for a registry to be compatible SOCI it must support the following features of the OCI distribution and image specs:
 
-1) Accept [OCI Image Manifests](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/manifest.md) with [subject fields](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/manifest.md#image-manifest-property-descriptions) and arbitrary config media types.
+1) Accept [OCI Image Manifests](https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md) with [subject fields](https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md#image-manifest-property-descriptions) and arbitrary config media types.
 This allows the registry to store SOCI indices and is supported by most registries.
 
-2) (optional) Support the [OCI referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers).
-This adds convenience around retrieving SOCI indices from the registry. If it is not supported, there is a [fallback mechanism](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#unavailable-referrers-api) that works with all registries, but it has a few issues noted in the next section.
+2) (optional) Support the [OCI referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers).
+This adds convenience around retrieving SOCI indices from the registry. If it is not supported, there is a [fallback mechanism](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#unavailable-referrers-api) that works with all registries, but it has a few issues noted in the next section.
 
 ## Referrers API vs Fallback
 
-The SOCI snapshotter can retrieve SOCI indices and ztocs either through the [OCI referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers) or a [Fallback mechanism](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#unavailable-referrers-api). The referrers API is part of the not-yet-released [OCI Distribution Spec v1.1](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md) so registry support is limited. The Fallback is supported by all registries, but has notable edge cases.
+The SOCI snapshotter can retrieve SOCI indices and ztocs either through the [OCI referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers) or a [Fallback mechanism](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#unavailable-referrers-api). The referrers API is part of the not-yet-released [OCI Distribution Spec v1.1](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md) so registry support is limited. The Fallback is supported by all registries, but has notable edge cases.
 
 The SOCI CLI and the SOCI snapshotter automatically uses the referrers API if the registry supports it or the fallback mechanism otherwise.
 
 ### Referrers API
 
-The [referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers) is a registry endpoint where an agent can query for all artifacts that reference a given image digest, optionally filtering by artifact type. The registry indexes artifacts for the referrers API when the artifact is pushed. When a container is launched, the SOCI snapshotter can query this API to find SOCI indices that reference the digest of the image.
+The [referrers API](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers) is a registry endpoint where an agent can query for all artifacts that reference a given image digest, optionally filtering by artifact type. The registry indexes artifacts for the referrers API when the artifact is pushed. When a container is launched, the SOCI snapshotter can query this API to find SOCI indices that reference the digest of the image.
 
 ### Fallback
 
-If the referrers API is not available, the OCI distribution spec defines a [fallback mechanism that works with existing registries](https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#unavailable-referrers-api). In this mechanism, the contents that would normally be returned by the referrers API are instead put into an [OCI Image Index](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/image-index.md) which is tagged in the registry with the digest of the manifest to which it refers.
+If the referrers API is not available, the OCI distribution spec defines a [fallback mechanism that works with existing registries](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#unavailable-referrers-api). In this mechanism, the contents that would normally be returned by the referrers API are instead put into an [OCI Image Index](https://github.com/opencontainers/image-spec/blob/v1.1.0/image-index.md) which is tagged in the registry with the digest of the manifest to which it refers.
 
 For example, imagine you had an image `myregistry.com/image:latest` with digest `sha:123`. If you created and pushed a SOCI index for that image, there would also be a new image index `myregistry.com/image:sha-123` which contains the SOCI index' descriptor. At runtime, the SOCI snapshotter will pull the `myregistry.com/image:sha-123` index and apply client side filtering to discover the SOCI index.
 


### PR DESCRIPTION
**Issue #, if available:**
Documentation is inconsistent in the image-specification and distribution-specification documentation it references.

**Description of changes:**
This change updates documentation links to opencontainers/image-spec@v1.1.0 and opencontainers/distribution-spec@v1.1.0.

**Testing performed:**
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
