### PR TITLE
Revert changes to bump-deps script and ignore SC2046

### DIFF
--- a/scripts/bump-deps.sh
+++ b/scripts/bump-deps.sh
@@ -24,19 +24,21 @@ pushd "${SOCI_SNAPSHOTTER_PROJECT_ROOT}"
 # skip k8s deps since they use the latest go version/features that may not be in the go version soci uses
 # skip grpc because it's not compatible with containerd 1.7
 # Also ignored in /dependabot.yml
-go get "$(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
+# shellcheck disable=SC2046
+go get $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
     grep -v "^google.golang.org/grpc" | \
-    grep -v "^k8s.io/")"
+    grep -v "^k8s.io/")
 make tidy
 
 pushd ./cmd
 # skip k8s deps and soci-snapshotter itself
 # skip grpc because it's not compatible with containerd 1.7
 # Also ignored in /dependabot.yml
-go get "$(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
+# shellcheck disable=SC2046
+go get $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
     grep -v "^github.com/awslabs/soci-snapshotter" | \
     grep -v "^google.golang.org/grpc" | \
-    grep -v "^k8s.io/")"
+    grep -v "^k8s.io/")
 popd
 make tidy
 


### PR DESCRIPTION
**Issue #, if available:**
Dependency update automation is failing for:
```
oras.land/oras-go/v2: malformed module path "github.com/containerd/containerd\ngithub.com/containerd/continuity\ngithub.com/containerd/log\ngithub.com/docker/cli\ngithub.com/docker/go-metrics\ngithub.com/golang/groupcache\ngithub.com/google/flatbuffers\ngithub.com/google/go-cmp\ngithub.com/google/uuid\ngithub.com/hanwen/go-fuse/v2\ngithub.com/hashicorp/go-retryablehttp\ngithub.com/klauspost/compress\ngithub.com/moby/sys/mountinfo\ngithub.com/montanaflynn/stats\ngithub.com/opencontainers/go-digest\ngithub.com/opencontainers/image-spec\ngithub.com/opencontainers/runtime-spec\ngithub.com/pelletier/go-toml\ngithub.com/prometheus/client_golang\ngithub.com/rs/xid\ngithub.com/sirupsen/logrus\ngo.etcd.io/bbolt\ngolang.org/x/crypto\ngolang.org/x/sync\ngolang.org/x/sys\ngolang.org/x/time\noras.land/oras-go/v2": invalid char '\n'
```

(See https://github.com/awslabs/soci-snapshotter/actions/runs/8434120283)

I am unable to reproduce the error locally, but have confirmed by reverting the changes and running automation in a fork the issue is caused by the double quotes around go list command.

**Description of changes:**
This change reverts the changes to quote the output of go list in bump-deps script to prevent word splitting. This has caused a regression in the dependency update automation.

**Testing performed:**
Ran dependency update automation in fork.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
