### PR TITLE
Allow make clean to be called from anywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ uninstall:
 clean:
 	@echo "🧹 ... 🗑️"
 	@rm -rf $(OUTDIR)
-	@rm -rf release/
+	@rm -rf $(CURDIR)/release/
 	@echo "All clean!"
 
 tidy:


### PR DESCRIPTION
**Issue #, if available:**
Followup to #1138

**Description of changes:**
Added $(CURDIR) prefix to `rm -rf release` so that this works properly no matter where the Makefile is invoked from.

This should've been a review comment on #1138 but I missed it on my first round, sorry about that :v 

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
