### PR TITLE
Run shellcheck from container

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -30,3 +30,10 @@ jobs:
       - run: ./scripts/check-dco.sh
       - run: ./scripts/check-lint.sh
       - run: PATH=$PATH:$(pwd) ./scripts/check-flatc.sh
+
+  shellcheck:
+    runs-on: ubuntu-20.04
+    container: koalaman/shellcheck-alpine:v0.10.0
+    steps:
+      - uses: actions/checkout@v4
+      - run: shellcheck ./**/*.sh

--- a/scripts/check-lint.sh
+++ b/scripts/check-lint.sh
@@ -27,7 +27,3 @@ pushd ./cmd
 GO111MODULE=${GO111MODULE_VALUE} "$(go env GOPATH)/bin/golangci-lint" run
 popd
 popd
-
-pushd "${SOCI_SNAPSHOTTER_PROJECT_ROOT}"
-"$(go env GOPATH)/bin/shellcheck" ./**/*.sh
-popd

--- a/scripts/install-check-tools.sh
+++ b/scripts/install-check-tools.sh
@@ -20,8 +20,3 @@ set -eux -o pipefail
 curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.56.2
 go install github.com/kunalkushwaha/ltag@v0.2.4
 go install github.com/vbatts/git-validation@v1.2.0
-
-scversion="v0.10.0"
-arch=$(uname -m)
-wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.${arch}.tar.xz" | tar -xJv
-cp "shellcheck-${scversion}/shellcheck" "$(go env GOPATH)"/bin/


### PR DESCRIPTION
**Issue #, if available:**
Spin-off to #1141 

ShellCheck does not currently publish checksums which makes binary installation verification troublesome.

**Description of changes:**
This change runs ShellCheck from the official Docker container published by maintainers to avoid installing the binaries into developers local development environment.

**Testing performed:**
Ran CI in fork.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
