### PR TITLE
Update registry test dependency to registry:3.0.0-alpha.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ RUN curl -sSL --output /tmp/nerdctl.tgz https://github.com/containerd/nerdctl/re
     tar zxvf /tmp/nerdctl.tgz -C /usr/local/bin/ && \
     rm -f /tmp/nerdctl.tgz
 
-FROM registry:2 AS registry2
+FROM registry:3.0.0-alpha.1 AS registry

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -107,9 +107,9 @@ func TestMain(m *testing.M) {
 // setup can be used to initialize things before integration tests start (as of now it only builds the services used by the integration tests so they can be referenced)
 func setup() ([]func() error, error) {
 	var (
-		serviceName    = "testing"
-		targetStage    = "containerd-snapshotter-base"
-		registry2Stage = "registry2"
+		serviceName   = "testing"
+		targetStage   = "containerd-snapshotter-base"
+		registryStage = "registry"
 	)
 	pRoot, err := testutil.GetProjectRoot()
 	if err != nil {
@@ -124,7 +124,7 @@ func setup() ([]func() error, error) {
 		ServiceName:     serviceName,
 		ImageContextDir: pRoot,
 		TargetStage:     targetStage,
-		Registry2Stage:  registry2Stage,
+		RegistryStage:   registryStage,
 	})
 	if err != nil {
 		return nil, err

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -74,7 +74,7 @@ const (
 	dockerLibrary                = "public.ecr.aws/docker/library/"
 	// Registry images to use in the test infrastructure. These are not intended to be used
 	// as images in the test itself, but just when we're setting up docker compose.
-	oci10RegistryImage = "registry2:soci_test"
+	oci10RegistryImage = "registry:soci_test"
 	oci11RegistryImage = "ghcr.io/project-zot/zot-linux-" + runtime.GOARCH + ":v2.0.1"
 )
 
@@ -232,10 +232,10 @@ services:
    args:
     - SNAPSHOTTER_BUILD_FLAGS="-race"
  registry:
-  image: registry2:soci_test
+  image: registry:soci_test
   build:
    context: {{.ImageContextDir}}
-   target: {{.Registry2Stage}}
+   target: {{.RegistryStage}}
 `
 
 const zotConfigTemplate = `
@@ -264,7 +264,7 @@ type dockerComposeYaml struct {
 	ServiceName         string
 	ImageContextDir     string
 	TargetStage         string
-	Registry2Stage      string
+	RegistryStage       string
 	RegistryImageRef    string
 	RegistryAltImageRef string
 	RegistryHost        string


### PR DESCRIPTION
**Issue #, if available:**
For SOCI, [registry](https://hub.docker.com/_/registry) is a test dependency used in CI during integration tests to validate pulling container images lazily against a local container registry implementation. [registry:2](https://hub.docker.com/layers/library/registry/2/images/sha256-33c69a810cc314b55c9e1e218ab9eb1b39034b28b023234854f093a207a87154?context=explore) is showing a high vulnerability due to the last release happening in October 2023 using Go 1.20.8 toolchain. In February 2024, Go 1.22 was released meaning Go 1.20 would no longer receive updates. Since registry is just a test dependency, it is okay for SOCI to become an early adopter and migrate to v3.0.0-alpha.1 in CI which is more up-to-date.

**Description of changes:**
This change updates the test registry version to v3.0.0-alpha.1 for registry CVE updates.

**Testing performed:**
Ran CI in fork.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
