### PR TITLE
Check connection only when image isn't fully cached

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -641,10 +641,13 @@ func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[s
 		return fmt.Errorf("layer not registered")
 	}
 
-	// Check the blob connectivity and try to refresh the connection on failure
-	if err := fs.check(ctx, l, labels); err != nil {
-		log.G(ctx).WithError(err).Warn("check failed")
-		return err
+	if l.Info().FetchedSize < l.Info().Size {
+		// Image contents hasn't fully cached yet.
+		// Check the blob connectivity and try to refresh the connection on failure
+		if err := fs.check(ctx, l, labels); err != nil {
+			log.G(ctx).WithError(err).Warn("check failed")
+			return err
+		}
 	}
 
 	return nil

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -78,13 +78,19 @@ type breakableLayer struct {
 	success bool
 }
 
-func (l *breakableLayer) Info() layer.Info                                    { return layer.Info{} }
-func (l *breakableLayer) DisableXAttrs() bool                                 { return false }
-func (l *breakableLayer) RootNode(uint32) (fusefs.InodeEmbedder, error)       { return nil, nil }
-func (l *breakableLayer) Verify(tocDigest digest.Digest) error                { return nil }
-func (l *breakableLayer) SkipVerify()                                         {}
-func (l *breakableLayer) ReadAt([]byte, int64, ...remote.Option) (int, error) { return 0, nil }
-func (l *breakableLayer) BackgroundFetch() error                              { return fmt.Errorf("fail") }
+func (l *breakableLayer) Info() layer.Info {
+	return layer.Info{
+		Size: 1,
+	}
+}
+func (l *breakableLayer) DisableXAttrs() bool                           { return false }
+func (l *breakableLayer) RootNode(uint32) (fusefs.InodeEmbedder, error) { return nil, nil }
+func (l *breakableLayer) Verify(tocDigest digest.Digest) error          { return nil }
+func (l *breakableLayer) SkipVerify()                                   {}
+func (l *breakableLayer) ReadAt([]byte, int64, ...remote.Option) (int, error) {
+	return 0, fmt.Errorf("fail")
+}
+func (l *breakableLayer) BackgroundFetch() error { return fmt.Errorf("fail") }
 func (l *breakableLayer) Check() error {
 	if !l.success {
 		return fmt.Errorf("failed")


### PR DESCRIPTION
Taken from stargz:
https://github.com/containerd/stargz-snapshotter/pull/1584/files

**Issue #, if available:**
Related to #1084
Fixes #1116

**Description of changes:**
SOCI does not use any form of credential rotation. Thus, it can refuse to run on pods with stale credentials unless a new image is pulled. This fix should mitigate a pain point where a user will want to use a cached image on a pod with expired credentials.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
