### PR TITLE
Add git secrets scanning to CI

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,6 @@
+# Ignore items listed in .gitallowed
+# Workaround for https://github.com/awslabs/git-secrets/issues/198
+.gitallowed
+
+# Ignore false positive in docs/getting-started.md
+docs/getting-started.md:[0-9]+:export AWS_ACCOUNT=000000000000

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -30,6 +30,25 @@ jobs:
       - run: ./scripts/check-ltag.sh
       - run: ./scripts/check-dco.sh
       - run: PATH=$PATH:$(pwd) ./scripts/check-flatc.sh
+
+  git-secrets:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Pull latest awslabs/git-secrets repo
+        uses: actions/checkout@v4
+        with:
+           repository: awslabs/git-secrets
+           ref: 1.3.0
+           fetch-tags: true
+           path: git-secrets
+      - name: Install git secrets from source
+        run: sudo make install
+        working-directory: git-secrets
+      - uses: actions/checkout@v4
+      - name: Scan repository for git secrets
+        run: |
+          git secrets --register-aws
+          git secrets --scan-history
   
   lint:
     strategy:


### PR DESCRIPTION
**Issue #, if available:**
Contributors can accidentally submit git secrets to version control.

**Description of changes:**
This change adds a GitHub Actions job to validate git secrets are not submitted to version control.

**Testing performed:**
CI is successful

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
