### PR TITLE
Pull container images from ECR Public instead of Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ ARG CONTAINERD_VERSION=1.6.30
 ARG RUNC_VERSION=1.1.12
 ARG NERDCTL_VERSION=1.7.1
 ARG GO_VERSION=1.21.8
+ARG REGISTRY_VERSION=3.0.0-alpha.1
 
-FROM golang:${GO_VERSION}-bookworm AS golang-base
+FROM public.ecr.aws/docker/library/golang:${GO_VERSION}-bookworm AS golang-base
 
 FROM golang-base AS containerd-snapshotter-base
 ARG CONTAINERD_VERSION
@@ -46,4 +47,4 @@ RUN curl -sSL --output /tmp/nerdctl.tgz https://github.com/containerd/nerdctl/re
     tar zxvf /tmp/nerdctl.tgz -C /usr/local/bin/ && \
     rm -f /tmp/nerdctl.tgz
 
-FROM registry:3.0.0-alpha.1 AS registry
+FROM public.ecr.aws/docker/library/registry:${REGISTRY_VERSION} AS registry


### PR DESCRIPTION
**Issue #, if available:**
As an Amazon best practice, CI should pull container images from ECR Public instead of Docker Hub.

**Description of changes:**
This change pulls the base container images from ECR Public.

**Testing performed:**
CI is successful

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
