### PR TITLE
Disable TestNetworkRetry on ARM machines

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -41,6 +41,7 @@ import (
 	"math"
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -220,7 +221,14 @@ type retryConfig struct {
 // TestNetworkRetry runs a container, disables network access to the remote image, asks the container
 // to do something requiring the remote image, waits for some/all requests to fail, enables the network,
 // confirms retries and success/failure
+
+// TODO: Refactor test
 func TestNetworkRetry(t *testing.T) {
+	// This test makes the testing suite hang on ARM.
+	// Disabling for now till we can refactor this.
+	if runtime.GOARCH == "arm64" {
+		return
+	}
 
 	const containerImage = alpineImage
 


### PR DESCRIPTION
This test currently hangs on ARM machines, so disabling till we can fix this.

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
