### PR TITLE
Check first header in each layer

### DIFF
--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -60,6 +60,7 @@ func TestSpanManager(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var err error
 			defer func() {

--- a/ztoc/compression/gzip_zinfo.go
+++ b/ztoc/compression/gzip_zinfo.go
@@ -24,7 +24,9 @@ package compression
 import "C"
 
 import (
+	"compress/gzip"
 	"fmt"
+	"io"
 	"unsafe"
 )
 
@@ -179,6 +181,15 @@ func (i *GzipZinfo) EndUncompressedOffset(spanID SpanID, fileSize Offset) Offset
 		return fileSize
 	}
 	return i.getUncompressedOffset(spanID + 1)
+}
+
+// VerifyHeader checks if the given zinfo has a proper header
+func (i *GzipZinfo) VerifyHeader(r io.Reader) error {
+	gz, err := gzip.NewReader(r)
+	if gz != nil {
+		gz.Close()
+	}
+	return err
 }
 
 // getCompressedOffset wraps `C.get_comp_off` and returns the offset for the span in the compressed stream.

--- a/ztoc/compression/tar_zinfo.go
+++ b/ztoc/compression/tar_zinfo.go
@@ -18,6 +18,7 @@ package compression
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	zinfo_flatbuffers "github.com/awslabs/soci-snapshotter/ztoc/compression/fbs/zinfo"
@@ -184,6 +185,14 @@ func (i *TarZinfo) EndUncompressedOffset(spanID SpanID, fileSize Offset) Offset 
 		return fileSize
 	}
 	return i.spanIDToOffset(spanID + 1)
+}
+
+// VerifyHeader checks if the given zinfo has a proper header
+func (i *TarZinfo) VerifyHeader(r io.Reader) error {
+	// As this is a catch-all for all compression algorithms,
+	// there's not really a way to verify the header,
+	// so blindly assume it's correct.
+	return nil
 }
 
 func (i *TarZinfo) spanIDToOffset(spanID SpanID) Offset {

--- a/ztoc/compression/zinfo.go
+++ b/ztoc/compression/zinfo.go
@@ -18,6 +18,7 @@ package compression
 
 import (
 	"fmt"
+	"io"
 )
 
 // Zinfo is the interface for dealing with compressed data efficiently. It chunks
@@ -75,6 +76,8 @@ type Zinfo interface {
 	// EndUncompressedOffset returns the offset (in uncompressed stream)
 	// of the last byte belonging to `spanID`. If it's the last span, `fileSize` is returned.
 	EndUncompressedOffset(spanID SpanID, fileSize Offset) Offset
+	// VerifyHeader checks if the given zinfo has a proper header
+	VerifyHeader(r io.Reader) error
 }
 
 // NewZinfo deseralizes given zinfo bytes into a zinfo struct.


### PR DESCRIPTION
**Issue #, if available:**
Follow-up to #1147

**Description of changes:**
In #1147, we cherry-picked a commit from stargz where we don't make registry calls if layers are fully pulled. This works fine for stargz, but for SOCI, we skip reading the first header for each layer, as we don't need it. This caused a bug where our fetched size never matched our expected size, so this condition was never met.

This commit fixes this by reading the initially skipped header. It also checks this header to ensure that it is not malformed for any reason. It also adds an integration test to ensure the header is read on image pull.

**Testing performed:**
`make test` and `make integration`.

Additionally, I ran `GO_TEST_FLAGS='-run TestFullLayerRead' make integration` before and after my chance and ensured that it did not pass before the changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
