### PR TITLE
Fix binary download directory in release workflow

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: artifacts
+          path: release/
       - run: bash scripts/verify-release-artifacts.sh ${{ needs.generate-artifacts.outputs.release_tag }}
 
   create-release:


### PR DESCRIPTION
**Issue #, if available:**
Followup to release v0.6.0

**Description of changes:**
During the release of v0.6.0, `scipts/verify-release-artifacts.sh` failed. This was because we did not download it to the expected `release/` folder. This change fixes this.

**Testing performed:**
Pushed a tag to a local repo with a dummy `THIRD_PARTY_LICENSES` file and ensured the workflow passed.
https://github.com/sondavidb/soci-snapshotter/actions/runs/8666227363

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
