### PR TITLE
Change containerd-snapshotter-base to alpine based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,21 +15,25 @@
 ARG CONTAINERD_VERSION=1.6.30
 ARG RUNC_VERSION=1.1.12
 ARG NERDCTL_VERSION=1.7.1
-ARG GO_VERSION=1.21.9
-ARG REGISTRY_VERSION=3.0.0-alpha.1
 
-FROM public.ecr.aws/docker/library/golang:${GO_VERSION}-bookworm AS golang-base
+FROM public.ecr.aws/docker/library/golang:1.21.9-alpine AS containerd-snapshotter-base
 
-FROM golang-base AS containerd-snapshotter-base
 ARG CONTAINERD_VERSION
 ARG RUNC_VERSION
 ARG NERDCTL_VERSION
-ARG GO_VERSION
 ARG TARGETARCH
 COPY ./integ_entrypoint.sh /integ_entrypoint.sh
 COPY . $GOPATH/src/github.com/awslabs/soci-snapshotter
 ENV GOPROXY direct
-RUN apt-get update -y && apt-get install -y libbtrfs-dev libseccomp-dev libz-dev gcc fuse pigz
+RUN apk add --no-cache \
+    btrfs-progs-libs \
+    curl \
+    fuse \
+    gcc \
+    libc6-compat \
+    libseccomp-dev \
+    pigz \
+    zlib-dev
 RUN cp $GOPATH/src/github.com/awslabs/soci-snapshotter/out/soci /usr/local/bin/ && \
     cp $GOPATH/src/github.com/awslabs/soci-snapshotter/out/soci-snapshotter-grpc /usr/local/bin/ && \
     mkdir /etc/soci-snapshotter-grpc && \
@@ -47,4 +51,4 @@ RUN curl -sSL --output /tmp/nerdctl.tgz https://github.com/containerd/nerdctl/re
     tar zxvf /tmp/nerdctl.tgz -C /usr/local/bin/ && \
     rm -f /tmp/nerdctl.tgz
 
-FROM public.ecr.aws/docker/library/registry:${REGISTRY_VERSION} AS registry
+FROM public.ecr.aws/docker/library/registry:3.0.0-alpha.1 AS registry

--- a/integ_entrypoint.sh
+++ b/integ_entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #   Copyright The Soci Snapshotter Authors.
 

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -739,7 +739,7 @@ insecure = true
 		t.Fatalf("failed to write %v: %v", caCertDir, err)
 	}
 	sh.
-		X("apt-get", "--no-install-recommends", "install", "-y", "iptables").
+		X("apk", "add", "--no-cache", "iptables").
 		X("update-ca-certificates").
 		Retry(100, "nerdctl", "login", "-u", regConfig.user, "-p", regConfig.pass, regConfig.host)
 

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -307,7 +307,7 @@ disable = true
 			image := regConfig.mirror(containerImage).ref
 			sh.X(append(runSociCmd, "--name", "test-container", "-d", image, "sleep", "infinity")...)
 
-			sh.X("apt-get", "--no-install-recommends", "install", "-qy", "iptables")
+			sh.X("apk", "add", "--no-cache", "--quiet", "iptables")
 
 			// TODO: Wait for the container to be up and running
 


### PR DESCRIPTION
**Issue #, if available:**
#1179 

**Description of changes:**
This change swaps to an Alpine base image to reduce the size of the containers spun up for integration testing and simplify maintenance.

**Testing performed:**
Ran CI in fork

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
