### PR TITLE
Add timeouts to testing in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -34,6 +35,7 @@ jobs:
       - run: make test
   integration:
     runs-on: ubuntu-20.04
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Issue #, if available:**
When making the test container to be Alpine based, the GitHub Action workflow ran for 6+ hours due to tests getting stuck.
https://github.com/awslabs/soci-snapshotter/actions/runs/8671778098

**Description of changes:**
This change adds a 15 and 30 minute timeout to unit and integration tests respectively to prevent wasting compute resources.

**Testing performed:**
CI is successful

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
