### PR TITLE
remove duplicate logging on integ tests, add info for where log came from

### DIFF
--- a/util/testutil/shell.go
+++ b/util/testutil/shell.go
@@ -44,6 +44,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -70,14 +71,24 @@ func NewTestingReporter(t *testing.T) *TestingReporter {
 
 // Errorf prints the provided message to TestingL and stops the test using testing.T.Fatalf.
 func (r *TestingReporter) Errorf(format string, v ...interface{}) {
-	TestingL.Printf(format, v...)
-	r.t.Fatalf(format, v...)
+	msg := fmt.Sprintf(format, v...)
+	_, file, lineNum, ok := runtime.Caller(2)
+	if ok {
+		r.t.Fatalf("%s:%d: %s", file, lineNum, msg)
+	} else {
+		r.t.Fatalf(format, v...)
+	}
 }
 
 // Logf prints the provided message to TestingL testing.T.
 func (r *TestingReporter) Logf(format string, v ...interface{}) {
-	TestingL.Printf(format, v...)
-	r.t.Logf(format, v...)
+	msg := fmt.Sprintf(format, v...)
+	_, file, lineNum, ok := runtime.Caller(2)
+	if ok {
+		r.t.Logf("%s:%d: %s", file, lineNum, msg)
+	} else {
+		r.t.Logf(format, v...)
+	}
 }
 
 // Stdout returns the writer to TestingL as stdout. This enables to print command logs realtime.


### PR DESCRIPTION
**Issue #, if available:** https://github.com/awslabs/soci-snapshotter/issues/404

**Description of changes:** removed double logging, added in caller info

**Testing performed:** `make integration`
logs now appear like so:

```
    shell.go:88: /home/ec2-user/workplace/soci-snapshotter/integration/ztoc_test.go#385: >>> Getting output of: [cat test.txt]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
