### PR TITLE
Add manual arch option in artifact verification

### DIFF
--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -22,12 +22,18 @@ cur_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 soci_snapshotter_project_root="$(cd -- "$cur_dir"/.. && pwd)"
 release_dir="${soci_snapshotter_project_root}/release"
 
-arch=""
-case $(uname -m) in
-    x86_64) arch="amd64" ;;
-    aarch64) arch="arm64" ;;
-    *) echo "Error: unsupported arch"; exit 1 ;;
-esac
+arch="$2"
+if [ "${arch}" == "" ]; then
+    case $(uname -m) in
+        x86_64) arch="amd64" ;;
+        aarch64) arch="arm64" ;;
+    esac
+fi
+
+if [ "${arch}" != "amd64" ] && [ "${arch}" != "amd64" ] ; then
+    echo "Error: unsupported arch"
+    exit 1
+fi
 
 function usage {
     echo "Usage: $0 <release_tag>"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Allows us to check AMD64 artifacts on ARM64 and vice versa via an optional second parameter.

Even after getting ARM runners, this would be a good manual verification step in ensuring the binaries are built properly.

**Testing performed:**
`scripts/verify-release-artifacts.sh v0.6.0 arm64` on an AMD64 machine and ensured it worked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
