### PR TITLE
Add Makefile target to cleanup testing artifacts

### DIFF
--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -413,7 +413,7 @@ func withPlainHTTP() registryConfigOpt {
 
 func newRegistryConfig(opts ...registryConfigOpt) registryConfig {
 	rc := registryConfig{
-		host: fmt.Sprintf("registry-%s.test", xid.New().String()),
+		host: fmt.Sprintf("%s-registry-%s.test", compose.TestContainerBaseName, xid.New().String()),
 		user: "dummyuser",
 		pass: "dummypass",
 	}

--- a/util/dockershell/compose/compose.go
+++ b/util/dockershell/compose/compose.go
@@ -35,6 +35,7 @@ package compose
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -43,6 +44,10 @@ import (
 
 	dexec "github.com/awslabs/soci-snapshotter/util/dockershell/exec"
 	"github.com/rs/xid"
+)
+
+const (
+	TestContainerBaseName string = "soci-integration"
 )
 
 // Supported checks if this pkg can run on the current system.
@@ -133,7 +138,7 @@ func Up(dockerComposeYaml string, opts ...Option) (*Compose, error) {
 	for _, o := range opts {
 		o(&cOpts)
 	}
-	tmpContext, err := os.MkdirTemp("", "compose"+xid.New().String())
+	tmpContext, err := os.MkdirTemp("", fmt.Sprintf("%s-compose-%s", TestContainerBaseName, xid.New().String()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Issue #, if available:**
Fixes #1204 

**Description of changes:**
Our integration testing suite can leave artifacts if it is prematurely quit. When run multiple times, this can lead to many artifacts left over, taking up unnecessary disk space, CPU usage, and Docker networks. This change uses a common base container name for all of our testing containers, and allows 

As a compliment to this, I noticed that our Dockerfile, when manually built, would result in an improperly-tagged image. The first commit just moves the registry pull to its own line so that it can be properly tagged when built manually. Not necessary at all, and can remove from this commit if needed, I just thought it would be nice to have :p

**Testing performed:**
Ran a test (e.g. ` GO_TEST_FLAGS='-run TestNetworkRetry -count 1' make integration`), cancelled it after it started running, and checked that appropriate artifacts were cleaned.

<details><summary>Testing workflow (redacted/truncated data denoted with "..."
</summary>

```
$ docker image ls
REPOSITORY   TAG       IMAGE ID   CREATED   SIZE
$ docker container ls -a
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
$ docker network ls
NETWORK ID     NAME      DRIVER    SCOPE
49af465ba355   bridge    bridge    local
d8e5c2fe03b4   host      host      local
c02d09057b67   none      null      local
$ GO_TEST_FLAGS='-run TestNetworkRetry -count 1' make integration
...
=== RUN   TestNetworkRetry
=== RUN   TestNetworkRetry/No_network_interruption,_no_retries_allowed,_success
 Network soci-integration-compose-com2t3qbv6590n89blfg2509610158_default  Creating
 Network soci-integration-compose-com2t3qbv6590n89blfg2509610158_default  Created
 Container soci-integration-registry-com2t3qbv6590n89blf0.test  Creating
 Container soci-integration-compose-com2t3qbv6590n89blfg2509610158-testing-1  Creating
 Container soci-integration-registry-com2t3qbv6590n89blf0.test  Created
 Container soci-integration-compose-com2t3qbv6590n89blfg2509610158-testing-1  Created
 Container soci-integration-compose-com2t3qbv6590n89blfg2509610158-testing-1  Starting
 Container soci-integration-registry-com2t3qbv6590n89blf0.test  Starting
 Container soci-integration-compose-com2t3qbv6590n89blfg2509610158-testing-1  Started
 Container soci-integration-registry-com2t3qbv6590n89blf0.test  Started
    shell.go:88: 
...
^C
```

```
$ docker image ls
REPOSITORY      TAG         IMAGE ID       CREATED              SIZE
soci_base       soci_test   8a88120b4906   About a minute ago   2.24GB
registry        soci_test   669bda21b705   5 weeks ago          42.4MB
moby/buildkit   v0.10.3     a2c9241854f2   24 months ago        142MB
$ docker container ls -a 
CONTAINER ID   IMAGE                   COMMAND                  CREATED              STATUS              PORTS      NAMES
7d5840fcc5a0   soci_base:soci_test     "/integ_entrypoint.sh"   26 seconds ago       Up 12 seconds                  soci-integration-compose-com2t3qbv6590n89blfg2509610158-testing-1
b9359c852269   registry:soci_test      "/entrypoint.sh /etc…"   26 seconds ago       Up 12 seconds       5000/tcp   soci-integration-registry-com2t3qbv6590n89blf0.test
a8615d779eee   moby/buildkit:v0.10.3   "buildkitd"              About a minute ago   Up About a minute              buildx_buildkit_zstd-builder0
$ docker network ls 
NETWORK ID     NAME                                                              DRIVER    SCOPE
49af465ba355   bridge                                                            bridge    local
d8e5c2fe03b4   host                                                              host      local
c02d09057b67   none                                                              null      local
c49fc82e900b   soci-integration-compose-com2t3qbv6590n89blfg2509610158_default   bridge    local
$ make clean-integration
🧹 Cleaning leftover integration test artifacts...
🐳 Cleaning Docker artifacts...
docker stop 7d5840fcc5a0 b9359c852269
7d5840fcc5a0
b9359c852269
docker rm 7d5840fcc5a0 b9359c852269
7d5840fcc5a0
b9359c852269
docker network rm c49fc82e900b
c49fc82e900b
docker image rm 8a88120b4906 669bda21b705
Untagged: soci_base:soci_test
Deleted:
...
Untagged: registry:soci_test
Deleted: 
...
🐳 All SOCI containers, networks, and images cleaned!
All testing artifacts cleaned!
```

```
$ docker image ls 
REPOSITORY      TAG       IMAGE ID       CREATED         SIZE
moby/buildkit   v0.10.3   a2c9241854f2   24 months ago   142MB
$ docker container ls 
CONTAINER ID   IMAGE                   COMMAND       CREATED              STATUS              PORTS     NAMES
a8615d779eee   moby/buildkit:v0.10.3   "buildkitd"   About a minute ago   Up About a minute             buildx_buildkit_zstd-builder0
$ docker network ls
NETWORK ID     NAME      DRIVER    SCOPE
49af465ba355   bridge    bridge    local
d8e5c2fe03b4   host      host      local
c02d09057b67   none      null      local
```
</details>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
