### PR TITLE
Update SOCI rebuild DB CLI help text and doc

### DIFF
--- a/cmd/soci/commands/rebuild_db.go
+++ b/cmd/soci/commands/rebuild_db.go
@@ -27,7 +27,13 @@ import (
 
 var RebuildDBCommand = cli.Command{
 	Name:  "rebuild-db",
-	Usage: `rebuild the artifacts database. You should use this command after "rpull" so that indices/ztocs can be discovered by commands like "soci index list", and after "index rm" when using the containerd content store so that deleted orphaned zTOCs will be forgotten`,
+	Usage: "rebuilds the artifacts database",
+	UsageText: `
+	soci [global options] rebuild-db
+
+	Use after pulling an image to discover SOCI indices/ztocs or after "index rm"
+	when using the containerd content store to clear the database of removed zTOCs.
+	`,
 	Action: func(cliContext *cli.Context) error {
 		client, ctx, cancel, err := internal.NewClient(cliContext)
 		if err != nil {

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -61,7 +61,8 @@ soci push public.ecr.aws/soci-workshop-examples/ffmpeg:latest
 ```
 
 ### soci rebuild_db
-Use this command after image pull so that indices/ztocs can be discovered by commands like "```soci index list```", and after "```index rm```" when using the containerd content store so that deleted orphaned zTOCs will be forgotten
+Use after pulling an image to discover SOCI indices/ztocs or after "```index rm```" 
+when using the containerd content store to clear the database of removed zTOCs.
 
 **Example:** 
 ```


### PR DESCRIPTION
**Issue #, if available:**
The rebuild database CLI command's help text references rpull which has been removed.

**Description of changes:**
Removes rpull command reference from help text which support has been removed. Aligns help text in CLI and documentation to match.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
