### PR TITLE
Use public ECR zot image

### DIFF
--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -75,7 +75,7 @@ const (
 	// Registry images to use in the test infrastructure. These are not intended to be used
 	// as images in the test itself, but just when we're setting up docker compose.
 	oci10RegistryImage = "registry:soci_test"
-	oci11RegistryImage = "ghcr.io/project-zot/zot-linux-" + runtime.GOARCH + ":v2.0.1"
+	oci11RegistryImage = "public.ecr.aws/soci-workshop-examples/zot:v2.0.3-" + runtime.GOARCH
 )
 
 // Commonly used CLI commands


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Per Amazon best security practices, we switched to using a version of project zot hosted on public ECR instead of ghcr.io.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
