### PR TITLE
Fix digest formatting in soci index remove error

### DIFF
--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -355,13 +355,13 @@ func (db *ArtifactsDb) RemoveArtifactEntryByIndexDigest(digest []byte) error {
 
 		dgstBucket := bucket.Bucket(digest)
 		if dgstBucket == nil {
-			return fmt.Errorf("the index of the digest %v doesn't exist", digest)
+			return fmt.Errorf("the index of the digest %s doesn't exist", digest)
 		}
 
 		if indexBucket(dgstBucket) {
 			return bucket.DeleteBucket(digest)
 		}
-		return fmt.Errorf("the digest %v does not correspond to an index", digest)
+		return fmt.Errorf("the digest %s does not correspond to an index", digest)
 	})
 }
 


### PR DESCRIPTION
**Issue #, if available:**
Fixes #1220 

**Description of changes:**
This change fixes the formatting for the SOCI index digest in errors for the SOCI index remove command.

**Testing performed:**
```
sudo soci index rm sha256:doesnotexist
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
