### PR TITLE
Change containerd-snapshotter-base to alpine based

### DIFF
--- a/integ_entrypoint.sh
+++ b/integ_entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #   Copyright The Soci Snapshotter Authors.
 

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -739,7 +739,7 @@ insecure = true
 		t.Fatalf("failed to write %v: %v", caCertDir, err)
 	}
 	sh.
-		X("apt-get", "--no-install-recommends", "install", "-y", "iptables").
+		X("apk", "add", "--no-cache", "iptables").
 		X("update-ca-certificates").
 		Retry(100, "nerdctl", "login", "-u", regConfig.user, "-p", regConfig.pass, regConfig.host)
 

--- a/util/testutil/shell.go
+++ b/util/testutil/shell.go
@@ -357,7 +357,7 @@ func KillMatchingProcess(sh *shell.Shell, psLinePattern string) error {
 			if len(es) < 2 {
 				continue
 			}
-			pid, err := strconv.ParseInt(es[1], 10, 32)
+			pid, err := strconv.ParseInt(es[0], 10, 32)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION

**Issue #, if available:**
Fixes #1179 and continuation of #1180 

**Description of changes:**
Changed from using Golang-bookworm to alpine. This was done to use a smaller base image which makes us less prone to security issues. This PR includes all of the necessary changes to make this work.

Additionally, this commit switches to using raw image URLs instead of inserting in the version via a variable, so that dependabot can track new versions.

Additionally, the registry line was moved up to allow proper tagging when building locally instead of with Docker Compose.

**Testing performed:**
Manually ran integration tests on ARM64

| Test failure | Note |
| --- | --- |
| TestFuseOperationFailureMetrics | Known issue documented in #1168 |
| TestPushWithExistingIndices | Successful on rerun |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
