### PR TITLE
Add dependabot configuration to ignore Go minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,11 +28,17 @@ updates:
       - dependency-name: "google.golang.org/grpc"
       - dependency-name: "k8s.io/*"
 
-  # Automatic upgrade for base images used in the Dockerfile
+  # Automatic update for base images used in the Dockerfile
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # Skip major and minor updates for the base Go image.
+      # Major updates should not occur.
+      # Minor updates for the Go toolchain should be done manually to be aligned with release CI.
+      - dependency-name: "docker/library/golang"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   # Automatic upgrade for Github Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
**Issue #, if available:**
#1234 was opened which updated the container image past the minimum version in go.mod.

**Description of changes:**
This change adds dependabot configuration to ignore Go 1.22.x Dockerfile updates while Go 1.21 is still supported to align with minimum version in go.mod.

**Testing performed:**
Created repo to test dependabot configuration to skip Dockerfile updates.

https://github.com/austinvazquez/fantastic-enigma
https://github.com/austinvazquez/fantastic-enigma/blob/main/.github/dependabot.yml#L10
https://github.com/austinvazquez/fantastic-enigma/pull/1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
