### PR TITLE
Enforce lease when building SOCI index

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -122,12 +122,7 @@ var CreateCommand = cli.Command{
 				return err
 			}
 
-			sociIndexWithMetadata, err := builder.Build(ctx, srcImg)
-			if err != nil {
-				return err
-			}
-
-			err = soci.WriteSociIndex(ctx, sociIndexWithMetadata, blobStore, builder.ArtifactsDb)
+			_, err = builder.Build(ctx, srcImg)
 			if err != nil {
 				return err
 			}

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras-go/v2/content/memory"
 )
 
 func TestSkipBuildingZtoc(t *testing.T) {
@@ -136,7 +135,7 @@ func TestBuildSociIndexNotLayer(t *testing.T) {
 	spanSize := int64(65535)
 	ctx := context.Background()
 	cs := newFakeContentStore()
-	blobStore := memory.New()
+	blobStore := NewOrasMemoryStore()
 
 	artifactsDb, err := newTestableDb()
 	if err != nil {
@@ -209,7 +208,7 @@ func TestBuildSociIndexWithLimits(t *testing.T) {
 				Size:      tc.layerSize,
 			}
 			spanSize := int64(65535)
-			blobStore := memory.New()
+			blobStore := NewOrasMemoryStore()
 			artifactsDb, err := newTestableDb()
 			if err != nil {
 				t.Fatalf("can't create a test db")
@@ -305,7 +304,7 @@ func TestDisableXattrs(t *testing.T) {
 			}
 
 			cs := newFakeContentStore()
-			blobStore := memory.New()
+			blobStore := NewOrasMemoryStore()
 			artifactsDb, err := newTestableDb()
 			if err != nil {
 				t.Fatalf("can't create a test db")

--- a/soci/store/store.go
+++ b/soci/store/store.go
@@ -141,7 +141,7 @@ func GetContentStorePath(contentStoreType ContentStoreType) (string, error) {
 
 type CleanupFunc func(context.Context) error
 
-func nopCleanup(context.Context) error { return nil }
+func NopCleanup(context.Context) error { return nil }
 
 func NewContentStore(ctx context.Context, opts ...Option) (context.Context, Store, error) {
 	storeConfig := NewStoreConfig(opts...)
@@ -185,7 +185,7 @@ func (s *SociStore) Delete(_ context.Context, _ digest.Digest) error {
 
 // BatchOpen is a no-op for sociStore; it does not support batching operations.
 func (s *SociStore) BatchOpen(ctx context.Context) (context.Context, CleanupFunc, error) {
-	return ctx, nopCleanup, nil
+	return ctx, NopCleanup, nil
 }
 
 type ContainerdStore struct {
@@ -336,7 +336,7 @@ func (s *ContainerdStore) Delete(ctx context.Context, dgst digest.Digest) error 
 func (s *ContainerdStore) BatchOpen(ctx context.Context) (context.Context, CleanupFunc, error) {
 	ctx, leaseDone, err := s.client.WithLease(ctx)
 	if err != nil {
-		return ctx, nopCleanup, fmt.Errorf("unable to open batch: %w", err)
+		return ctx, NopCleanup, fmt.Errorf("unable to open batch: %w", err)
 	}
 	return ctx, leaseDone, nil
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Previously, in our CLI create command, we would create zTOCs, push them to the content store, then label the index to refer to the zTOCs. This created a problem where a user using the containerd content store might have their zTOCs deleted by the containerd garbage collector before it could be labeled. While a lease was used, it was only done during the latter step, so it did not prevent zTOCs from being deleted before being labeled.

This commit fixes this by using a lease on the entire process via a new command, BuildAndWriteIndex, which is called by "soci create".

This should unblock #1232 as well.

**Testing performed:**
`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
