### PR TITLE
Add go license check to CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/third_party_license_usage_request.yaml
+++ b/.github/ISSUE_TEMPLATE/third_party_license_usage_request.yaml
@@ -1,19 +1,23 @@
-name: 3rd Party License Request
-description: File a request for usage of a 3rd party license in the Amazon ECR credential helpers project.
-title: "[3rd Party License Request]: "
+name: 3rd Party License Usage Request
+title: "[3rd Party License Usage Request]: "
+description: File a request for usage of a 3rd party license in the SOCI project.
 labels: "license-request"
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this request!
+        Thanks for taking the time to fill out this request! The SOCI project adheres to the guidance set forth by
+        Amazon Open Source Usage policies and [CNCF Allowlist License Policy](https://github.com/cncf/foundation/blob/88f1a47550eb2df71b4b6e9c148a1c2f99a1d92e/allowed-third-party-license-policy.md) (with the exception of MPL-2.0).
 
   - type: textarea
     id: license-request
     attributes:
-      label: License request
+      label: License usage request
       value: |
+        Dependency: <link to dependency>
         License: <link to license>
+    validations:
+      required: true
 
   - type: textarea
     id: use-case
@@ -25,6 +29,6 @@ body:
       required: true
 
   - type: textarea
-    id: other-solutions
+    id: alternative-solutions
     attributes:
-      label: Other solutions considered
+      label: Alternative solutions considered

--- a/.github/ISSUE_TEMPLATE/third_party_license_usage_request.yaml
+++ b/.github/ISSUE_TEMPLATE/third_party_license_usage_request.yaml
@@ -1,0 +1,30 @@
+name: 3rd Party License Request
+description: File a request for usage of a 3rd party license in the Amazon ECR credential helpers project.
+title: "[3rd Party License Request]: "
+labels: "license-request"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this request!
+
+  - type: textarea
+    id: license-request
+    attributes:
+      label: License request
+      value: |
+        License: <link to license>
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: |
+        Briefly describe the use case the dependency would resolve.
+    validations:
+      required: true
+
+  - type: textarea
+    id: other-solutions
+    attributes:
+      label: Other solutions considered

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -75,3 +75,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: shellcheck ./**/*.sh
+
+  licensing:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - run: ./scripts/install-check-tools.sh
+      - run: ./scripts/check-third-party-licenses.sh

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -20,3 +20,4 @@ set -eux -o pipefail
 ./check-flatc.sh
 ./check-ltag.sh
 ./check-lint.sh
+./check-third-party-licenses.sh

--- a/scripts/check-third-party-licenses.sh
+++ b/scripts/check-third-party-licenses.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -18,19 +18,24 @@ set -euo pipefail
 # Normalize to working directory being root (up one level from ./scripts)
 root=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 
-pushd "${root}/ecr-login"
+pushd "${root}"
 
 # Fail third party dependency usage if not covered by the curated set of pre-approved licenses.
 #
 # List was generated from guidance set forth by Amazon open source usage policies.
 #
+# The SOCI project, with the exception of its usage of MPL-2.0, additionally follows the guidance
+# set forth by the CNCF Allowlist License Policy.
+#
+# https://github.com/cncf/foundation/blob/88f1a47550eb2df71b4b6e9c148a1c2f99a1d92e/allowed-third-party-license-policy.md
+#
 # Additional usage of third party dependencies not covered by the following licenses
 # will need maintainer approval in alignment with Amazon open source usage policies.
 #
-# Requests can be made via https://github.com/awslabs/amazon-ecr-credential-helper/issues/new/choose
+# Requests can be made via https://github.com/awslabs/soci-snapshotter/issues/new/choose
 go-licenses check \
     --include_tests \
-    --ignore github.com/awslabs/amazon-ecr-credential-helper \
-    --allowed_licenses=Apache-2.0,BSD-3-Clause,MIT,ISC, ./...
+    --ignore github.com/awslabs/soci-snapshotter \
+    --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-2-Clause-FreeBSD,BSD-3-Clause,MIT,ISC,Python-2.0,PostgreSQL,X11,Zlib,MPL-2.0 ./...
 
 popd

--- a/scripts/check_third_party_licenses.sh
+++ b/scripts/check_third_party_licenses.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# 	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+set -euo pipefail
+
+# Normalize to working directory being root (up one level from ./scripts)
+root=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+
+pushd "${root}/ecr-login"
+
+# Fail third party dependency usage if not covered by the curated set of pre-approved licenses.
+#
+# List was generated from guidance set forth by Amazon open source usage policies.
+#
+# Additional usage of third party dependencies not covered by the following licenses
+# will need maintainer approval in alignment with Amazon open source usage policies.
+#
+# Requests can be made via https://github.com/awslabs/amazon-ecr-credential-helper/issues/new/choose
+go-licenses check \
+    --include_tests \
+    --ignore github.com/awslabs/amazon-ecr-credential-helper \
+    --allowed_licenses=Apache-2.0,BSD-3-Clause,MIT,ISC, ./...
+
+popd

--- a/scripts/install-check-tools.sh
+++ b/scripts/install-check-tools.sh
@@ -19,3 +19,4 @@ set -eux -o pipefail
 
 go install github.com/kunalkushwaha/ltag@v0.2.4
 go install github.com/vbatts/git-validation@v1.2.0
+go install github.com/google/go-licenses@v1.6.0


### PR DESCRIPTION
**Issue #, if available:**
The SOCI project intends to follow CNCF best practices, but currently has no mechanism for enforcing license checks of 3rd party dependencies. As a maintainer, it would be helpful to validate in CI that each contribution is following the guidance set forth by Amazon and CNCF with respect to usage of open source in the project.

**Description of changes:**
This change imports licenses check mechanism from the Amazon ECR credential helper project to validate usage of 3rd party dependencies is in alignment with Amazon and CNCF Open Source License usage best practices.

**Testing performed:**
Check is successful in CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
