### PR TITLE
Add workflow to label pull requests

### DIFF
--- a/.github/new-pull-request-labels.yml
+++ b/.github/new-pull-request-labels.yml
@@ -1,0 +1,22 @@
+documentation:
+  - '**/*.md'
+
+github_actions:
+  - .github/**
+  - scripts/**
+
+go:
+  - '**/*.go'
+
+testing:
+  - integration/**
+  - '**/*_test.go'
+
+benchmarking:
+  - benchmark/**
+
+dependencies:
+  - cmd/go.mod
+  - cmd.go.sum
+  - go.mod
+  - go.sum

--- a/.github/workflows/new-pull-requests.yml
+++ b/.github/workflows/new-pull-requests.yml
@@ -1,0 +1,27 @@
+name: "New Pull Requests"
+
+on:
+  # It is safe to use pull_request_target here because we are not checking out
+  # code from the pull request branch.
+  #
+  # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-20.04
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      # Use label configuration from main instead of from the pull request branch
+      # to mitigate running untrusted workflows with write permissions.
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: '.github/new-pull-request-labels.yml'
+          sync-labels: true


### PR DESCRIPTION
**Issue #, if available:**
Offline discussion from #1238. Risk for malicious actors contributing code to run on AWS's GitHub Action compute is mitigated by requiring maintainer approval to run workflows; however, this requires changes to GitHub Actions to be monitored by maintainers for malicious changes to workflows with write permissions. It would be helpful to auto label pull requests with `github_actions` for maintainers to more identify the changes need to be thoroughly examined for malicious contributions.

**Description of changes:**
This change adds a GitHub Actions workflow to label new pull requests with the following labels:

- `documentation` - updates to `**/*.md`
- `go` - updates to `**/*.go`
- `testing` - updates to `**/*_test.go`
- `github_actions` - updates to `.github/`
- `benchmarking` - updates to `benchmark/`
- `dependencies` - updates to `go.(mod|sum)`

**Testing performed:**


**Limitations:**
1. Because the new pull requests workflow depends on mainline configuration for labels to avoid checking out code from the pull request branch, a risk mitigation for pwn pull requests, the workflow will not run on the contributing pull request which adds the workflow.

**Alternatives considered:**
1. Variations to the label logic:
a. Requiring all files in a glob to match a label instead of any file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
