### PR TITLE
Add codebuild integrations for our workflows

### DIFF
--- a/.github/workflows/benchmark_visualization.yml
+++ b/.github/workflows/benchmark_visualization.yml
@@ -17,7 +17,9 @@ env:
 
 jobs:
   benchmark:
-    runs-on: codebuild-soci-visualization-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
+    # skip running benchmarks in forks
+    if: github.repository == 'awslabs/soci-snapshotter'
+    runs-on: codebuild-soci-snapshotter-benchmark-visualization-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v4
@@ -37,7 +39,8 @@ jobs:
           path: ${{github.workspace}}/benchmark/performanceTest/output/results.json
 
   download-and-convert-benchmark-result-to-visualization-data:
-    runs-on: codebuild-soci-visualization-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
+    if: github.repository == 'awslabs/soci-snapshotter'
+    runs-on: codebuild-soci-snapshotter-benchmark-visualization-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     needs: benchmark
     steps:
       - name: Checkout main branch
@@ -66,8 +69,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.files }}
 
   push-benchmark-result-gh-pages:
+    if: github.repository == 'awslabs/soci-snapshotter'
     name: Push benchmark result to Github-pages
-    runs-on: codebuild-soci-visualization-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
+    runs-on: codebuild-soci-snapshotter-benchmark-visualization-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     needs: download-and-convert-benchmark-result-to-visualization-data
     strategy:
       matrix:

--- a/.github/workflows/benchmark_visualization.yml
+++ b/.github/workflows/benchmark_visualization.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-visualization-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
           path: ${{github.workspace}}/benchmark/performanceTest/output/results.json
 
   download-and-convert-benchmark-result-to-visualization-data:
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-visualization-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     needs: benchmark
     steps:
       - name: Checkout main branch
@@ -67,7 +67,7 @@ jobs:
 
   push-benchmark-result-gh-pages:
     name: Push benchmark result to Github-pages
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-visualization-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     needs: download-and-convert-benchmark-result-to-visualization-data
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
   test-on-fork:
     if: github.repository != 'awslabs/soci-snapshotter'
-    runs-on: ubuntu-22.04
+    runs-on: codebuild-test-codebuild2-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
 
   integration-on-fork:
     if: github.repository != 'awslabs/soci-snapshotter'
-    runs-on: ubuntu-22.04
+    runs-on: codebuild-test-codebuild2-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-build-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
       - run: make
       - run: make test
   integration:
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-build-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,9 @@ env:
   GO_VERSION: '1.21.10'
 
 jobs:
-  test:
-    runs-on: codebuild-soci-build-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
+  test-on-codebuild:
+    if: github.repository == 'awslabs/soci-snapshotter'
+    runs-on: codebuild-soci-snapshotter-build-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -33,8 +34,39 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - run: make
       - run: make test
-  integration:
-    runs-on: codebuild-soci-build-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
+
+  test-on-fork:
+    if: github.repository != 'awslabs/soci-snapshotter'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - run: make
+      - run: make test
+
+  integration-on-codebuild:
+    if: github.repository == 'awslabs/soci-snapshotter'
+    runs-on: codebuild-soci-snapshotter-build-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        containerd: ["1.6.30", "1.7.14"]
+    env:
+      DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - run: make integration
+
+  integration-on-fork:
+    if: github.repository != 'awslabs/soci-snapshotter'
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Don't bother bumping deps on forks.
     if: ${{ github.repository == 'awslabs/soci-snapshotter' || github.event_name == 'workflow_dispatch' }}
-    runs-on: codebuild-soci-bump-dependencies-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-medium
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Don't bother bumping deps on forks.
     if: ${{ github.repository == 'awslabs/soci-snapshotter' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-bump-dependencies-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-medium
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -9,7 +9,8 @@ env:
 
 jobs:
   check:
-    runs-on: codebuild-soci-comparision-test-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
+    if: github.repository == 'awslabs/soci-snapshotter'
+    runs-on: codebuild-soci-snapshotter-comparison-test-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-comparision-test-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   check:
-    runs-on: codebuild-soci-prebuild-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-small
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +32,7 @@ jobs:
       - run: PATH=$PATH:$(pwd) ./scripts/check-flatc.sh
 
   git-secrets:
-    runs-on: codebuild-soci-prebuild-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-small
+    runs-on: ubuntu-22.04
     steps:
       - name: Pull latest awslabs/git-secrets repo
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         working_dir: ['.', 'cmd']
-    runs-on: codebuild-soci-prebuild-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-small
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: golangci/golangci-lint-action@v6
@@ -64,13 +64,14 @@ jobs:
 
   yamllint:
     name: yamllint-lint
-    runs-on: codebuild-soci-prebuild-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-small
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - run: pip install yamllint
       - run: yamllint .
 
   shellcheck:
-    runs-on: codebuild-soci-prebuild-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-small
+    runs-on: ubuntu-22.04
     container: koalaman/shellcheck-alpine:v0.10.0
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-prebuild-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-small
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +32,7 @@ jobs:
       - run: PATH=$PATH:$(pwd) ./scripts/check-flatc.sh
 
   git-secrets:
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-prebuild-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-small
     steps:
       - name: Pull latest awslabs/git-secrets repo
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         working_dir: ['.', 'cmd']
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-prebuild-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-small
     steps:
       - uses: actions/checkout@v4
       - uses: golangci/golangci-lint-action@v6
@@ -64,13 +64,13 @@ jobs:
 
   yamllint:
     name: yamllint-lint
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-prebuild-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-small
     steps:
       - uses: actions/checkout@v4
       - run: yamllint .
 
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-prebuild-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-small
     container: koalaman/shellcheck-alpine:v0.10.0
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   generate-artifacts:
-    runs-on: codebuild-soci-release-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
+    runs-on: ubuntu-22.04
     env:
       # Set during setup.
       RELEASE_TAG: ''
@@ -60,7 +60,7 @@ jobs:
 
   validate-artifacts:
     needs: generate-artifacts
-    runs-on: codebuild-soci-release-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -72,7 +72,7 @@ jobs:
   create-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [generate-artifacts, validate-artifacts]
-    runs-on: codebuild-soci-release-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   generate-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-release-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     env:
       # Set during setup.
       RELEASE_TAG: ''
@@ -60,7 +60,7 @@ jobs:
 
   validate-artifacts:
     needs: generate-artifacts
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-release-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -72,7 +72,7 @@ jobs:
   create-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [generate-artifacts, validate-artifacts]
-    runs-on: ubuntu-20.04
+    runs-on: codebuild-soci-release-workflow-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Requires #1255 
This PR adds the capability to run our workloads on codebuild instances. This allows us to manage the instance size/performance in a consistent manner. It also allows the use of ARM runners which will enable us to automate the release process for arm binaries in the future.

~~Running the Integration tests on both GH runners and codebuild to make sure we are able to identify any potential kernel specific issues.~~

_Don't see any compelling reasons to run the integration tests on both github and codebuild and have kept the fork runs exclusively on github. If there are any kernel issues then we will see it when we make updates and run these tests in the fork._


We now use Ubuntu 22.04 as the underlying OS for all our workloads

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
