### PR TITLE
fix fuse test failure issues

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -153,10 +153,14 @@ log_fuse_operations = true
 
 	manipulateZtocMetadata := func(zt *ztoc.Ztoc) {
 		for i, md := range zt.FileMetadata {
-			md.UncompressedOffset += 2
-			md.UncompressedSize = math.MaxInt64
-			md.PAXHeaders = map[string]string{"foo": "bar"}
-			zt.FileMetadata[i] = md
+			// Setting UncompressedSize high triggers a "value too large" error
+			// Maniulate regular files to alter ztoc data and trigger fuse ops failure.
+			if md.Type == "reg" {
+				md.UncompressedOffset += 2
+				md.UncompressedSize = math.MaxInt64
+				md.PAXHeaders = map[string]string{"foo": "bar"}
+				zt.FileMetadata[i] = md
+			}
 		}
 	}
 

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -236,7 +236,7 @@ func TestLazyPullWithSparseIndex(t *testing.T) {
 }
 
 func checkFuseMounts(t *testing.T, sh *shell.Shell, remoteSnapshotsExpectedCount int) {
-	mounts := string(sh.O("mount"))
+	mounts := string(sh.O("cat", "/proc/mounts"))
 	remoteSnapshotsActualCount := strings.Count(mounts, "fuse.rawBridge")
 	if remoteSnapshotsExpectedCount != remoteSnapshotsActualCount {
 		t.Fatalf("incorrect number of remote snapshots; expected=%d, actual=%d",


### PR DESCRIPTION
**Issue #, if available:**
While integrating the worklfows to codebuild we ran into some issues with respect to the kernel versions used in the underlying ec2 instances on codebuild.

The two test failures we see are :
- TestFuseOperationFailureMetrics: This test verifies that fuse operations fail if ztoc data is manipulated. We change the UncompressedSize value to verify that we get validation failures and fallback to overlay. The goal of this test is to verify metrics are emited correctly.
Changing UncompressedSize to be a large value results in a `readdirent:value too large for defined data type` error. it goes away if we change the value to a smaller value (100) or if we try and modify regular files.

- A bunch of SOCI tests pull images with soci and then use `mount` to find all of the fuse mounts on the host. We check that the number of fuse mounts on the host == the number of layers that should have been lazily loaded to make sure we are not falling back to overlayfs.
Our test containers’ rootfs are overlay mounts with many lower dirs. Some of these make the line in `/proc/mounts` > busybox `mount` buffer limit. Busybox `mount` then stops processing mounts and never prints the FUSE mounts we’re looking for. Our tests see 0 when they expect N and fail.

The solution is to get mount info via `cat /proc/mounts` rather than `mount`.
**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
