### PR TITLE
Fix bug in update getting started guide workflow

### DIFF
--- a/.github/workflows/update-getting-started-guide.yml
+++ b/.github/workflows/update-getting-started-guide.yml
@@ -23,9 +23,6 @@ jobs:
       contents: read
       pull-requests: read
 
-    env:
-      RELEASE_TAG: ''
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -33,11 +30,8 @@ jobs:
             docs/getting-started.md
             scripts/update-getting-started-guide-version.sh
 
-      - name: Mock release tag on pull request
-        run: echo "RELEASE_TAG=v0.0.0-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-
       - name: Test update getting started version
-        run: bash scripts/update-getting-started-guide-version.sh --assert ${{ env.RELEASE_TAG }}
+        run: bash scripts/update-getting-started-guide-version.sh --assert v0.0.0-${{ github.event.pull_request.number }}
 
   update-version:
     if: github.event_name == 'release'

--- a/scripts/update-getting-started-guide-version.sh
+++ b/scripts/update-getting-started-guide-version.sh
@@ -69,5 +69,11 @@ assert_diff() {
 
 sed -i -E "s/version=\"([0-9]+\.){2}[0-9]+\"/version=\"${VERSION}\"/" docs/getting-started.md
 
-[ $VERBOSE = true ] && git diff
-[ $ASSERT = true ] && assert_diff
+if [ $VERBOSE = true ]; then
+  git --no-pager diff
+fi
+
+if [ $ASSERT = true ]; then
+  assert_diff
+fi
+


### PR DESCRIPTION
**Issue #, if available:**
Found via testing for #1248

When running in verbose mode, git diff is ran in interactive mode which blocked execution of the script. Additionally when assert mode is disabled, the script failed to exit properly.

**Description of changes:**
This change fixes a bug in the update getting started guide workflow when assertions are disabled. This change also fixes a bug where `--verbose` executed git diff command in interactive mode.

**Testing performed:**
Successfully ran locally:
 1. `bash scripts/update-getting-started-guide.sh --verbose 0.7`
 2. `bash scripts/update-getting-started-guide.sh --assert 0.8`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
