### PR TITLE
Update Go version to 1.21.11 in CI

### DIFF
--- a/.github/workflows/benchmark_visualization.yml
+++ b/.github/workflows/benchmark_visualization.yml
@@ -13,7 +13,7 @@ permissions:
   deployments: write
 
 env:
-  GO_VERSION: '1.21.10'
+  GO_VERSION: '1.21.11'
 
 jobs:
   benchmark:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ on:
       - 'scripts/**'
 
 env:
-  GO_VERSION: '1.21.10'
+  GO_VERSION: '1.21.11'
 
 jobs:
   test:

--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.21.10'
+  GO_VERSION: '1.21.11'
 
 permissions:
   contents: write

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 0 */2 * *" # every 2 days
 
 env:
-  GO_VERSION: '1.21.10'
+  GO_VERSION: '1.21.11'
 
 jobs:
   check:

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -7,7 +7,7 @@ on:
     branches: ['main', 'release/**']
 
 env:
-  GO_VERSION: '1.21.10'
+  GO_VERSION: '1.21.11'
   GOLANGCI_LINT_VERSION: '1.56.2'
 
 jobs:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,7 +12,7 @@ on:
       - 'Makefile'
 
 env:
-  GO_VERSION: '1.21.10'
+  GO_VERSION: '1.21.11'
 
 permissions:
   contents: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG NERDCTL_VERSION=1.7.1
 
 FROM public.ecr.aws/docker/library/registry:3.0.0-alpha.1 AS registry
 
-FROM public.ecr.aws/docker/library/golang:1.21.10-alpine AS containerd-snapshotter-base
+FROM public.ecr.aws/docker/library/golang:1.21.11-alpine AS containerd-snapshotter-base
 
 ARG CONTAINERD_VERSION
 ARG RUNC_VERSION


### PR DESCRIPTION
**Issue #, if available:**
Update go version in CI to 1.21.11

Needed for [CVE 2024-24790](https://www.cve.org/CVERecord?id=CVE-2024-24790)

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
