### PR TITLE
Allow building with debug symbols by setting GODEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ ifneq ($(STATIC),)
 endif
 GO_TAGS=$(if $(GO_BUILDTAGS),-tags "$(strip $(GO_BUILDTAGS))",)
 
-GO_LD_FLAGS=-ldflags '-s -w -X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) $(GO_EXTRA_LDFLAGS)
+GO_LD_FLAGS=-ldflags '-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) $(GO_EXTRA_LDFLAGS)
+ifeq ($(GODEBUG),)
+    GO_LD_FLAGS += -s -w
+endif
 ifneq ($(STATIC),)
 	GO_LD_FLAGS += -extldflags "-static"
 endif


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
The default builds of `soci` and `soci-snapshotter-grpc` have debug symbols removed. This change adds a new `GODEBUG` flag to add this information.

It can be used like:
```
GODEBUG=1 make
```

and the resulting executables can be debugged with delve/gdb.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
