### PR TITLE
Fix daemon startup latency issue by providing an option to skip snaps…

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -125,8 +125,13 @@ func main() {
 		log.G(ctx).WithError(err).Fatal(err)
 	}
 
-	if err := service.Supported(*rootDir); err != nil {
-		log.G(ctx).WithError(err).Fatalf("snapshotter is not supported")
+	if !cfg.SkipCheckSnapshotterSupported {
+		if err := service.Supported(*rootDir); err != nil {
+			log.G(ctx).WithError(err).Fatalf("snapshotter is not supported")
+		}
+		log.G(ctx).Debug("snapshotter is supported")
+	} else {
+		log.G(ctx).Warn("skipped snapshotter is supported check")
 	}
 
 	// Create a gRPC server

--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,9 @@ type Config struct {
 
 	// MetadataStore is the type of the metadata store to use.
 	MetadataStore string `toml:"metadata_store" default:"db"`
+
+	// SkipCheckSnapshotterSupported is a flag to skip check for overlayfs support needed to confirm if SOCI can work
+	SkipCheckSnapshotterSupported bool `toml:"skip_check_snapshotter_supported"`
 }
 type configParser func(*Config)
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -31,6 +31,7 @@ metrics_network="" # Uses default metrics network
 # no_prometheus=true # Defined above, can't be redeclared
 debug_address=""
 metadata_store="db"
+skip_check_snapshotter_supported=false
 
 [http]
 MaxRetries=0

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,6 +34,7 @@ This set of variables must be at the top of your TOML file due to not belonging 
 - `no_prometheus` — Defined [above](#configfsgofsconfig), cannot be redeclared.
 - `debug_address` (string) — Address where [go pprof](https://pkg.go.dev/net/http/pprof) server will listen. If empty, no logs will be emitted. Default: "".
 - `metadata_store` (string) — Metadata storage type. Only "db" is valid. Default: "db".
+- `skip_check_snapshotter_supported` (bool) - skip check for snapshotter is supported which can give performance benefits for SOCI daemon startup time. This config should only be done if you are sure overlayfs is supported. Default: false
 
 #
 


### PR DESCRIPTION
…hotter supported flag

**Issue #, if available:**
Soci Daemon startup time was long when undergoing simultaneous intense io operations.

**Description of changes:**
Add a config option to skip snapshotter is supported check that an user can configure

**Testing performed:**
1. Test with no option provided in config.toml. This is the default case. There is no change in behaviour
2. Test with option true in config.toml
```
Jun 19 17:05:40 ip-172-31-24-167 soci-snapshotter-grpc[9163]: {"level":"info","msg":"starting soci-snapshotter-grpc","revision":"944f0361363540379f0872eb6d93f49e4365ec66.m","time":"2024-06-19T17:05:40.090552376Z","version":"944f036.m"}
Jun 19 17:05:40 ip-172-31-24-167 soci-snapshotter-grpc[9163]: {"level":"warning","msg":"Skipped snapshotter is supported check ","revision":"944f0361363540379f0872eb6d93f49e4365ec66.m","time":"2024-06-19T17:05:40.090751222Z","version":"944f036.m"}
Jun 19 17:05:40 ip-172-31-24-167 soci-snapshotter-grpc[9163]: {"emitMetricPeriod":10000000000,"fetchPeriod":500000000,"level":"info","maxQueueSize":100,"msg":"constructing background fetcher","silencePeriod":30000000000,"time":"2024-06-19T17:05:40.091041601Z"}
Jun 19 17:05:40 ip-172-31-24-167 soci-snapshotter-grpc[9163]: {"address":"/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock","level":"info","msg":"soci-snapshotter-grpc successfully started","time":"2024-06-19T17:05:40.091712667Z"}
Jun 19 17:05:40 ip-172-31-24-167 systemd[1]: Started soci-snapshotter.service - soci snapshotter containerd plugin.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
