### PR TITLE
[release/0.6] Bump version of containerd to 1.7.18 for latest and 1.6.33 for LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containerd: ["1.6.30", "1.7.14"]
+        containerd: ["1.6.33", "1.7.18"]
     env:
       DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-ARG CONTAINERD_VERSION=1.6.30
+ARG CONTAINERD_VERSION=1.6.33
 ARG RUNC_VERSION=1.1.12
 ARG NERDCTL_VERSION=1.7.1
 ARG GO_VERSION=1.21.10


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Backport: Bump version of containerd to 1.7.18 for latest and 1.6.33 for LTS

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
