### PR TITLE
Allow insecure localhost connections

### DIFF
--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -29,6 +29,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/awslabs/soci-snapshotter/util/ioutils"
 	"github.com/containerd/containerd/reference"
+	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/log"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
@@ -73,6 +74,11 @@ func newRemoteStore(refspec reference.Spec, client *http.Client) (*remote.Reposi
 		return nil, fmt.Errorf("cannot create repository %s: %w", refspec.Locator, err)
 	}
 	repo.Client = client
+	repo.PlainHTTP, err = docker.MatchLocalhost(refspec.Hostname())
+	if err != nil {
+		return nil, fmt.Errorf("cannot create repository %s: %w", refspec.Locator, err)
+	}
+
 	return repo, nil
 }
 


### PR DESCRIPTION
**Issue #, if available:**
fixes #1282

**Description of changes:**
Before this change, the `docker.MatchLocalhost` function was applied to hosts retrieved from labels on snapshots, but not in the artifact fetcher. This meant that data could be lazily loaded from an insecure localhost, but we couldn't fetch the SOCI index/ztocs from an insecure localhost. This change adds the matcher to the artifact fetcher so that images can be lazily loaded from an insecure localhost.

**Testing performed:**
`make test && make integration`

I also did a manual test against a local `registry:2`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
