### PR TITLE
Fallback to containerd if we are unable to fetch SOCI artifacts

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -337,7 +337,7 @@ func (c *sociContext) Init(fsCtx context.Context, ctx context.Context, imageRef,
 
 			desc, err := client.SelectReferrer(ctx, ocispec.Descriptor{Digest: imgDigest}, defaultIndexSelectionPolicy)
 			if err != nil {
-				retErr = fmt.Errorf("cannot fetch list of referrers: %w", err)
+				retErr = fmt.Errorf("%w: cannot fetch list of referrers: %w", snapshot.ErrNoIndex, err)
 				return
 			}
 			indexDesc = desc
@@ -347,7 +347,7 @@ func (c *sociContext) Init(fsCtx context.Context, ctx context.Context, imageRef,
 
 		index, err := FetchSociArtifacts(fsCtx, refspec, indexDesc, store, remoteStore)
 		if err != nil {
-			retErr = fmt.Errorf("error trying to fetch SOCI artifacts: %w", err)
+			retErr = fmt.Errorf("%w: error trying to fetch SOCI artifacts: %w", snapshot.ErrNoIndex, err)
 			return
 		}
 		c.sociIndex = index
@@ -482,7 +482,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	client := src[0].Hosts[0].Client
 	c, err := fs.getSociContext(ctx, imageRef, sociIndexDigest, imgDigest, client)
 	if err != nil {
-		return fmt.Errorf("%w: unable to fetch SOCI artifacts for image %q: %w", snapshot.ErrUnableToLazyLoadImage, imageRef, err)
+		return fmt.Errorf("unable to fetch SOCI artifacts for image %q: %w", imageRef, err)
 	}
 
 	// Resolve the target layer

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -482,7 +482,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	client := src[0].Hosts[0].Client
 	c, err := fs.getSociContext(ctx, imageRef, sociIndexDigest, imgDigest, client)
 	if err != nil {
-		return fmt.Errorf("unable to fetch SOCI artifacts: %w", err)
+		return fmt.Errorf("%w: unable to fetch SOCI artifacts for image %q: %w", snapshot.ErrUnableToLazyLoadImage, imageRef, err)
 	}
 
 	// Resolve the target layer

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -77,7 +77,10 @@ const (
 )
 
 var (
-	// Error returned by `fs.Mount` when there is no ztoc for a particular layer.
+	// ErrUnableToLazyLoadImage is returned by `fs.Mount` when the image cannot/should not be
+	// lazy loaded. (eg: If a SOCI index does not exist for an image)
+	ErrUnableToLazyLoadImage = errors.New("unable to lazy load image")
+	// ErrNoZtoc is returned by `fs.Mount` when there is no zTOC for a particular layer.
 	ErrNoZtoc = errors.New("no ztoc for layer")
 )
 
@@ -307,6 +310,8 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 	lCtx := log.WithLogger(ctx, log.G(ctx).WithField("key", key).WithField("parent", parent))
 	log.G(lCtx).Debug("preparing snapshot")
 
+	var skipLazyLoadingImage bool
+
 	// remote snapshot prepare
 	if !o.skipRemoteSnapshotPrepare(lCtx, base.Labels) {
 		err := o.prepareRemoteSnapshot(lCtx, key, base.Labels)
@@ -326,6 +331,9 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 		log.G(lCtx).WithField(remoteSnapshotLogKey, prepareFailed).WithError(err).Warn("failed to prepare remote snapshot")
 		if !errors.Is(err, ErrNoZtoc) {
 			commonmetrics.IncOperationCount(commonmetrics.FuseMountFailureCount, digest.Digest(""))
+			if errors.Is(err, ErrUnableToLazyLoadImage) {
+				skipLazyLoadingImage = true
+			}
 		}
 	}
 
@@ -335,24 +343,27 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 		// don't fallback here, since there was an error getting mounts
 		return nil, err
 	}
-
-	log.G(ctx).WithField("layerDigest", base.Labels[ctdsnapshotters.TargetLayerDigestLabel]).Info("preparing snapshot as local snapshot")
-	err = o.prepareLocalSnapshot(lCtx, key, base.Labels, mounts)
-	if err == nil {
-		err := o.commit(ctx, false, target, key, append(opts, snapshots.WithLabels(base.Labels))...)
-		if err == nil || errdefs.IsAlreadyExists(err) {
-			// count also AlreadyExists as "success"
-			// there's no need to provide any details on []mount.Mount because mounting is already taken care of
-			// by snapshotter
-			log.G(lCtx).Info("local snapshot successfully prepared")
-			return nil, fmt.Errorf("target snapshot %q: %w", target, errdefs.ErrAlreadyExists)
+	// If the underlying FileSystem deems that the image is unable to be lazy loaded, then we
+	// should completely fallback to the underlying runtime (containerd) to handle pulling and
+	// unpacking all the layers in the image.
+	if !skipLazyLoadingImage {
+		log.G(ctx).WithField("layerDigest", base.Labels[ctdsnapshotters.TargetLayerDigestLabel]).Info("preparing snapshot as local snapshot")
+		err = o.prepareLocalSnapshot(lCtx, key, base.Labels, mounts)
+		if err == nil {
+			err := o.commit(ctx, false, target, key, append(opts, snapshots.WithLabels(base.Labels))...)
+			if err == nil || errdefs.IsAlreadyExists(err) {
+				// count also AlreadyExists as "success"
+				// there's no need to provide any details on []mount.Mount because mounting is already taken care of
+				// by snapshotter
+				log.G(lCtx).Info("local snapshot successfully prepared")
+				return nil, fmt.Errorf("target snapshot %q: %w", target, errdefs.ErrAlreadyExists)
+			}
+			log.G(lCtx).WithError(err).Warn("failed to internally commit local snapshot")
+			// Don't fallback here (= prohibit to use this key again) because the FileSystem
+			// possible has done some work on this "upper" directory.
+			return nil, err
 		}
-		log.G(lCtx).WithError(err).Warn("failed to internally commit local snapshot")
-		// Don't fallback here (= prohibit to use this key again) because the FileSystem
-		// possible has done some work on this "upper" directory.
-		return nil, err
 	}
-
 	log.G(lCtx).WithError(err).Warn("failed to prepare snapshot; deferring to container runtime")
 	return mounts, nil
 }


### PR DESCRIPTION
**Issue #, if available:**
Continuation on #1035
Fixes #1034 

**Description of changes:**
Following up on the last [comment](https://github.com/awslabs/soci-snapshotter/pull/1035#issuecomment-1967131892) on #1035, I made the change to not send a FUSE failure for this new error, and added an integration test.

From original PR:

If we know that we cannot lazy load an image (eg: SOCI index does not exist for an image), we should fallback to the underlying runtime to do the fetching/unpacking of all layers.

**Testing performed:**
`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
