### PR TITLE
Test against containerd 2.0 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containerd: ["1.6.33", "1.7.18"]
+        containerd: ["1.6.33", "1.7.18", "2.0.0-rc.3"]
     env:
       DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"
     steps:


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Add containerd-2.0.0-rc.3 to our integ test matrix. We don't want to be surprised by a regression so we should start testing this now before the final 2.0.0 release.

**Testing performed:**
Ran the workflows in my fork: https://github.com/Kern--/soci-snapshotter/pull/140

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
