### PR TITLE
Use rabbitmqImage in FUSE failure test

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -198,7 +198,7 @@ log_fuse_operations = true
 		},
 		{
 			name:  "image with valid-formatted but invalid-data ztocs causes a fuse failure",
-			image: pinnedRabbitmqImage,
+			image: rabbitmqImage,
 			indexDigestFn: func(t *testing.T, sh *shell.Shell, image imageInfo) string {
 				indexDigest, err := buildIndexByManipulatingZtocData(sh, buildIndex(sh, image, withMinLayerSize(0)), manipulateZtocMetadata)
 				if err != nil {


### PR DESCRIPTION
**Issue #, if available:**
Workaround for #1168 to unblock ARM CI

**Description of changes:**
On ARM instances, pinnedRabbitmqImage does not work for this test due to some issues with xattr/whiteout dir detection. This is either a bug in the image or our code, but to get around CI for now we will just use a regular rabbitmq image.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
