### PR TITLE
Add back containerd 2.0 testing to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
-        containerd: ["1.6.33", "1.7.18"]
+        containerd: ["1.6.33", "1.7.18", "2.0.0-rc.3"]
     env:
       DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"
     steps:


### PR DESCRIPTION
**Issue #, if available:**
It looks like #1309 was lost in #1310

**Description of changes:**
This change adds containerd 2.0 testing back to CI

**Testing performed:**
CI is successful

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
