### PR TITLE
Revert "Disable xattrs by default"

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -19,7 +19,7 @@ allow_no_verification=true
 # disable_verification=false
 # Causes TestRunWithDefaultConfig to break, but
 # fine to use in /etc/soci-snapshotter-grpc-config.toml
-max_concurrency=0
+max_concurrency=0  # Actually zero
 no_prometheus=false
 mount_timeout_sec=0
 fuse_metrics_emit_wait_duration_sec=0

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -33,7 +33,9 @@ Flags:
 
  - ```--span-size``` : Span size that soci index uses to segment layer data. Default is 4MiB 
  - ```--min-layer-size``` : Minimum layer size to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10MiB
- - ```--disable-xattrs``` : When true, adds DisableXAttrs annotation to SOCI index. This annotation often helps performance at pull time. Default is true.
+ - ```--optimizations``` : Enable experimental features by name. Usage is `--optimizations opt_name`.
+   - `xattr` :  When true, adds DisableXAttrs annotation to SOCI index. This annotation often helps performance at pull time.
+     - There is currently a bug using this on an image with volume-mounts in a layer without whiteout directories or xattrs. If in doubt, do not use this on images with volume mounts.
 
 **Example:** 
 ```

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -234,7 +234,6 @@ func TestDisableXattrs(t *testing.T) {
 		name                string
 		metadata            []ztoc.FileMetadata
 		shouldDisableXattrs bool
-		disableXAttrs       bool
 	}{
 		{
 			name: "ztoc with xattrs should not have xattrs disabled",
@@ -247,7 +246,6 @@ func TestDisableXattrs(t *testing.T) {
 				},
 			},
 			shouldDisableXattrs: false,
-			disableXAttrs:       true,
 		},
 		{
 			name: "ztoc with opaque dirs should not have xattrs disabled",
@@ -260,7 +258,6 @@ func TestDisableXattrs(t *testing.T) {
 				},
 			},
 			shouldDisableXattrs: false,
-			disableXAttrs:       true,
 		},
 		{
 			name: "ztoc with no xattrs or opaque dirs should have xattrs disabled",
@@ -273,20 +270,6 @@ func TestDisableXattrs(t *testing.T) {
 				},
 			},
 			shouldDisableXattrs: true,
-			disableXAttrs:       true,
-		},
-		{
-			name: "ztoc with no xattrs and forced GetXAttrs should have xattrs enabled",
-			metadata: []ztoc.FileMetadata{
-				{
-					Name: "dir/",
-				},
-				{
-					Name: "dir/file",
-				},
-			},
-			shouldDisableXattrs: false,
-			disableXAttrs:       false,
 		},
 	}
 	for _, tc := range testcases {
@@ -309,15 +292,11 @@ func TestDisableXattrs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can't create a test db")
 			}
-			opts := []BuildOption{}
-			if !tc.disableXAttrs {
-				opts = append(opts, WithNoDisableXAttrs())
-			}
-			builder, _ := NewIndexBuilder(cs, blobStore, artifactsDb, opts...)
+			builder, _ := NewIndexBuilder(cs, blobStore, artifactsDb, WithOptimizations([]Optimization{XAttrOptimization}))
 			builder.maybeAddDisableXattrAnnotation(&desc, &ztoc)
-			disableXattrs := desc.Annotations[IndexAnnotationDisableXAttrs] == disableXAttrsTrue
-			if disableXattrs != tc.shouldDisableXattrs {
-				t.Fatalf("expected xattrs to be disabled = %v, actual = %v", tc.shouldDisableXattrs, disableXattrs)
+			disableXAttrs := desc.Annotations[IndexAnnotationDisableXAttrs] == disableXAttrsTrue
+			if disableXAttrs != tc.shouldDisableXattrs {
+				t.Fatalf("expected xattrs to be disabled = %v, actual = %v", tc.shouldDisableXattrs, disableXAttrs)
 			}
 		})
 	}


### PR DESCRIPTION
**Issue #, if available:**
Related: #1314 

**Description of changes:**

This reverts commit 2a70d12d833f8e93f62dea30d400bac1e2d7810d and some extra reverts related to it. This is due to a bug we have where containers fail to start if the image has a layer with xattrs disabled and a volume mount is present in said layer.

This ideally gets fixed upstream, but as that might take a while to propagate into nerdctl, for now we should revert this commit so that this is an opt-in behavior instead of a default one. 

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
