### PR TITLE
Add mention of OCI 1.1 in ECR

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -69,8 +69,8 @@ Registries that are not listed have not been tested by the SOCI maintainers or r
 | Registry                                                                                  | Compatible? | Mechanism     | Notes                                                |
 | ----------------------------------------------------------------------------------------- | ----------- | ------------- | ---------------------------------------------------- |
 | [Docker Hub](https://hub.docker.com)                                                      | No          | N/A           | Does not support image manifests with subject fields |
-| [Amazon Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/)                    | Yes         | Fallback      |                                                      |
-| [Amazon ECR Public Gallery](https://gallery.ecr.aws)                                      | Yes         | Fallback      |                                                      |
+| [Amazon Elastic Container Registry (ECR)](https://aws.amazon.com/ecr/)                    | Yes         | Referrers API      |                                                      |
+| [Amazon ECR Public Gallery](https://gallery.ecr.aws)                                      | Yes         | Referrers API      |                                                      |
 | [Azure Container Registry](https://azure.microsoft.com/en-us/products/container-registry) | Yes         | Referrers API |                                                      |
 | [GitHub Packages (GHCR)](https://github.com/features/packages)                            | Yes         | Fallback      |                                                      |
 | [Google Cloud Container Registry (GCR)](https://cloud.google.com/container-registry)      | Yes         | Fallback      |                                                      |


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
ECR now supports OCI 1.1, so the docs should be changed to reflect this.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
