### PR TITLE
Add review dependencies workflow to CI

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,26 @@
+# Fail third party dependency usage if not covered by the curated set of pre-approved licenses.
+#
+# List was generated from guidance set forth by Amazon open source usage policies.
+#
+# The SOCI project additionally follows the guidance set forth by the CNCF Allowlist License Policy
+# with the exception of pre-existing MPL-2.0 dependencies. (see exceptions below)
+#
+# https://github.com/cncf/foundation/blob/88f1a47550eb2df71b4b6e9c148a1c2f99a1d92e/allowed-third-party-license-policy.md
+allow-licenses:
+  - 'Apache-2.0'
+  - 'BSD-2-Clause'
+  - 'BSD-2-Clause-FreeBSD'
+  - 'BSD-3-Clause'
+  - 'MIT'
+  - 'ISC'
+  - 'Python-2.0'
+  - 'PostgreSQL'
+  - 'X11'
+  - 'Zlib'
+
+# Exception the following usages of MPL-2.0 dependencies
+allow_dependencies_licenses:
+  - pkg:golang/github.com/hashicorp/go-retryablehttp
+  - pkg:golang/github.com/hashicorp/errwrap
+  - pkg:golang/github.com/hashicorp/go-cleanhttp
+  - pkg:golang/github.com/hashicorp/go-multierror

--- a/.github/workflows/review-dependencies.yml
+++ b/.github/workflows/review-dependencies.yml
@@ -1,0 +1,25 @@
+name: Review dependencies
+
+on:
+  pull_request:
+    branches: ['main', 'release/**']
+    paths:
+      - 'go.*'
+      - 'cmd/go.*'
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Write permissions needed to comment review results on PR.
+      # Pwn request risk mitigated by using pull_request workflow trigger
+      # and external contributor workflow runs require maintainer approval.
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          config-file: './.github/dependency-review-config.yml'
+          comment-summary-in-pr: always


### PR DESCRIPTION
**Issue #, if available:**
Alternative to #1249

**Description of changes:**
This change adds a new CI workflow for reviewing added Go dependencies. This includes license and vulnerability checks.

**Testing performed:**
Merged workflow to fork and validated adding `github.com/opencontainers/runc@v1.1.11` dependency failed check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
