### PR TITLE
fix architecture check in verify-release-artifacts

### DIFF
--- a/scripts/verify-release-artifacts.sh
+++ b/scripts/verify-release-artifacts.sh
@@ -30,7 +30,7 @@ if [ "${arch}" == "" ]; then
     esac
 fi
 
-if [ "${arch}" != "amd64" ] && [ "${arch}" != "amd64" ] ; then
+if [ "${arch}" != "amd64" ] && [ "${arch}" != "arm64" ] ; then
     echo "Error: unsupported arch"
     exit 1
 fi


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Previously we were checking the conditional twice for amd64, making it impossible to verify arm64 artifacts.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
