### PR TITLE
Update golangci-lint to v1.60.3

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GO_VERSION: '1.21.12'
-  GOLANGCI_LINT_VERSION: '1.56.2'
+  GOLANGCI_LINT_VERSION: '1.60.3'
 
 jobs:
   check:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
     - goimports
     - ineffassign
     - revive
-    - vet
+    - govet
     - unused
     - misspell
   disable:
@@ -22,11 +22,11 @@ issues:
       # it can make it hard to understand what the unused parameter
       # was supposed to be used for.
       text: "unused-parameter:"
-
-run:
-  deadline: 4m
-  skip-dirs:
+  exclude-dirs:
     - docs
     - images
     - out
     - script
+
+run:
+  deadline: 4m

--- a/benchmark/framework/framework.go
+++ b/benchmark/framework/framework.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/containerd/log"
@@ -78,7 +77,7 @@ func (frame *BenchmarkFramework) Run(ctx context.Context) {
 			testDriver.BeforeFunction()
 		}
 		for j := 0; j < testDriver.NumberOfTests; j++ {
-			log.G(ctx).WithField("test_name", testDriver.TestName).Infof("TestStart for " + testDriver.TestName + "_" + strconv.Itoa(j+1))
+			log.G(ctx).WithField("test_name", testDriver.TestName).Infof("TestStart for %s_%d", testDriver.TestName, j+1)
 			fmt.Printf("Running test %d of %d\n", j+1, testDriver.NumberOfTests)
 			res := testing.Benchmark(testDriver.TestFunction)
 			testDriver.FullRunStats.BenchmarkTimes = append(testDriver.FullRunStats.BenchmarkTimes, res.T.Seconds())


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This change updates golangci-lint to v1.60.3 and resolves warnings for deprecated linters and linter settings.

**Testing performed:**
CI verification is enough

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
