### PR TITLE
allow setting version and revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ CMD_DESTDIR ?= /usr/local
 GO111MODULE_VALUE=auto
 OUTDIR ?= $(CURDIR)/out
 PKG=github.com/awslabs/soci-snapshotter
-VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
-REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+REVISION ?= $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 
 GO_BUILDTAGS ?=
 ifneq ($(STATIC),)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Allows setting the VERSION and REVISION variables for use in the Makefile, instead of always inferring them from the git repository. This is useful when building from the source tarball instead of a Git repository.

**Testing performed:**
Built a binary using `VERSION=myversion REVISION=1234567 make soci soci-snapshotter-grpc` and checked the output of `--version` commands:
```
./out/soci --version
soci version myversion 1234567

./out/soci-snapshotter-grpc --version
soci-snapshotter-grpc version myversion 1234567
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
