### PR TITLE
Remove obsolete "version" definition in tests

### DIFF
--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -139,7 +139,6 @@ disable_verification = {{.DisableVerification}}
 {{.AdditionalConfig}}
 `
 const composeDefaultTemplate = `
-version: "3.7"
 services:
   testing:
    image: soci_base:soci_test
@@ -156,7 +155,6 @@ services:
     - /dev/fuse:/dev/fuse
 `
 const composeRegistryTemplate = `
-version: "3.7"
 services:
  {{.ServiceName}}:
   image: soci_base:soci_test
@@ -188,7 +186,6 @@ services:
 {{.NetworkConfig}}
 `
 const composeRegistryAltTemplate = `
-version: "3.7"
 services:
   {{.ServiceName}}:
     image: soci_base:soci_test
@@ -222,7 +219,6 @@ services:
 `
 
 const composeBuildTemplate = `
-version: "3.7"
 services:
  {{.ServiceName}}:
   image: soci_base:soci_test


### PR DESCRIPTION

**Issue #, if available:**

**Description of changes:**
Per warning messages, the "version" definition in Docker compose files is obsolete, so removing it.

**Testing performed:**
`make integration` and ensured the error message no longer showed up

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
