### PR TITLE
Support systemd socket activation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN dnf update && dnf upgrade && dnf install -y \
     iptables \
     pigz \
     procps \
+    systemd \
     tar \
     util-linux-core
 RUN cp $GOPATH/src/github.com/awslabs/soci-snapshotter/out/soci /usr/local/bin/ && \
@@ -43,7 +44,9 @@ RUN cp $GOPATH/src/github.com/awslabs/soci-snapshotter/out/soci /usr/local/bin/ 
     mkdir /etc/soci-snapshotter-grpc && \
     mkdir /etc/containerd/ && \
     cp $GOPATH/src/github.com/awslabs/soci-snapshotter/integration/config/etc/soci-snapshotter-grpc/config.toml /etc/soci-snapshotter-grpc/ && \
-    cp $GOPATH/src/github.com/awslabs/soci-snapshotter/integration/config/etc/containerd/config.toml /etc/containerd/ 
+    cp $GOPATH/src/github.com/awslabs/soci-snapshotter/integration/config/etc/containerd/config.toml /etc/containerd/ && \
+    cp $GOPATH/src/github.com/awslabs/soci-snapshotter/soci-snapshotter.service /etc/systemd/system && \
+    cp $GOPATH/src/github.com/awslabs/soci-snapshotter/soci-snapshotter.socket /etc/systemd/system
 RUN curl -sSL --output /tmp/containerd.tgz https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-${TARGETARCH:-amd64}.tar.gz && \
     tar zxvf /tmp/containerd.tgz -C /usr/local/ && \
     rm -f /tmp/containerd.tgz

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -54,30 +54,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// TestSnapshotterStartup tests to run containerd + snapshotter and check plugin is
-// recognized by containerd
-func TestSnapshotterStartup(t *testing.T) {
-	t.Parallel()
-	sh, done := newSnapshotterBaseShell(t)
-	defer done()
-	rebootContainerd(t, sh, "", "")
-	found := false
-	err := sh.ForEach(shell.C("ctr", "plugin", "ls"), func(l string) bool {
-		info := strings.Fields(l)
-		if len(info) < 4 {
-			t.Fatalf("malformed plugin info: %v", info)
-		}
-		if info[0] == "io.containerd.snapshotter.v1" && info[1] == "soci" && info[3] == "ok" {
-			found = true
-			return false
-		}
-		return true
-	})
-	if err != nil || !found {
-		t.Fatalf("failed to get soci snapshotter status using ctr plugin ls: %v", err)
-	}
-}
-
 // TestOptimizeConsistentSociArtifact tests if the Soci artifact is produced consistently across runs.
 // This test does the following:
 // 1. Generate Soci artifact

--- a/soci-snapshotter.service
+++ b/soci-snapshotter.service
@@ -34,7 +34,7 @@ Before=containerd.service
 
 [Service]
 Type=notify
-ExecStart=/usr/local/bin/soci-snapshotter-grpc
+ExecStart=/usr/local/bin/soci-snapshotter-grpc --address fd://
 Restart=always
 RestartSec=5
 

--- a/soci-snapshotter.socket
+++ b/soci-snapshotter.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=soci snapshotter containerd plugin (socket)
+Documentation=https://github.com/awslabs/soci-snapshotter
+
+[Socket]
+ListenStream=/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target

--- a/util/dockershell/shell.go
+++ b/util/dockershell/shell.go
@@ -342,6 +342,26 @@ func (s *Shell) OLog(args ...string) ([]byte, error) {
 	return out, nil
 }
 
+// CombinedOLog executes a command and return the stdout and stderr as a combined stream. When the command fails,
+// the error is reported via Reporter.Logf and this Shell still *accepts* further command execution.
+func (s *Shell) CombinedOLog(args ...string) ([]byte, error) {
+	if s.IsInvalid() {
+		return nil, fmt.Errorf("invalid shell")
+	}
+	if len(args) < 1 {
+		s.Fatal("no command to run")
+		return nil, fmt.Errorf("no command to run")
+	}
+	s.r.Logf(">>> Getting output of: %v\n", args)
+	cmd := s.Command(args[0], args[1:]...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		s.r.Logf("failed to run for getting output from %v: %v", args, err)
+		return out, err
+	}
+	return out, nil
+}
+
 // R executes a command. Stdio is returned as io.Reader. streamed to Reporter.
 func (s *Shell) R(args ...string) (stdout, stderr io.Reader, err error) {
 	if s.IsInvalid() {


### PR DESCRIPTION
**Issue #, if available:**
Closes #1088 

**Description of changes:**
This change adds 2 features:
1) the --address flag of the soci snapshotter supports a network prefix 
2) The soci snapshotter can listen on a file descriptor passed by
   systemd socket activation.

If the user tells soci to listen on a file descriptor, but doesn't use systemd socket activation to launch the process, the snapshotter will fall back to the default address as a unix socket.

The example systemd service file is updated to use systemd activation if possible. There is an example systemd socket file, but no strict dependency from the service file so that users who are always starting SOCI on boot won't get a warning from systemd.

**Testing performed:**
Tested manually and verified that:
1) socket activation works
2) the example systemd unit file works without socket activation
3) setting a custom socket address still works both with and without socket activation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
