### PR TITLE
Remove VerifiableReader

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -560,12 +560,6 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		}
 	}()
 
-	// Verification is needed to instantiate reader
-	l.SkipVerify()
-	log.G(ctx).Infof("Verification forcefully skipped")
-	// Maybe we should reword the log here or remove it entirely,
-	// since the old Verify() function no longer serves any purpose.
-
 	node, err := l.RootNode(0)
 	if err != nil {
 		log.G(ctx).WithError(err).Warnf("Failed to get root node")

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -162,28 +162,27 @@ func makeFile(t *testing.T, contents []byte, prefix string, factory metadata.Sto
 		t.Fatalf("failed to create reader: %v", err)
 	}
 	spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
-	vr, err := NewReader(mr, digest.FromString(""), spanManager, false)
+	r, err := NewReader(mr, digest.FromString(""), spanManager, false)
 	if err != nil {
 		mr.Close()
 		t.Fatalf("failed to make new reader: %v", err)
 	}
-	r := vr.GetReader()
 	tid, _, err := mr.GetChild(mr.RootID(), testName)
 	if err != nil {
-		vr.Close()
+		r.Close()
 		t.Fatalf("failed to get %q: %v", testName, err)
 	}
 	ra, err := r.OpenFile(tid)
 	if err != nil {
-		vr.Close()
+		r.Close()
 		t.Fatalf("Failed to open testing file: %v", err)
 	}
 	f, ok := ra.(*file)
 	if !ok {
-		vr.Close()
+		r.Close()
 		t.Fatalf("invalid type of file %q", tid)
 	}
-	return f, vr.Close
+	return f, r.Close
 }
 
 func testFailReader(t *testing.T, factory metadata.Store) {
@@ -218,12 +217,11 @@ func testFailReader(t *testing.T, factory metadata.Store) {
 				t.Fatalf("free ID not found")
 			}
 			spanManager := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
-			vr, err := NewReader(mr, digest.FromString(""), spanManager, false)
+			r, err := NewReader(mr, digest.FromString(""), spanManager, false)
 			if err != nil {
 				mr.Close()
 				t.Fatalf("failed to make new reader: %v", err)
 			}
-			r := vr.GetReader()
 
 			_, err = r.OpenFile(notexist)
 			if err == nil {


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**

VerifiableReader was code that SOCI inherited from Stargz, but didn't use. With estargz images, the TOC is embedded in the layer in the remote store. When setting up a reader, you can optionally pass a digest of the TOC which the stargz-snaphostter will verify against the actual TOC in the remote registry.

SOCI stores TOCs in zTOCs which have integrity rooted in the SOCI index. Therefore, you get equivalent verification by specifing a SOCI index digest when pulling an image. By the time we're setting up a reader, we've already verified the ztocs and their layer mapping which means there is nothing to verify here.

Initially we initially just made Verify a no-op and bypassed it. This change cleans up that unneeded code entirely.

**Testing performed:**
`make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
