### PR TITLE
Add EKS docs to automated version updating

### DIFF
--- a/.github/workflows/update-getting-started-guide.yml
+++ b/.github/workflows/update-getting-started-guide.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           sparse-checkout: |
+            docs/eks.md
             docs/getting-started.md
             scripts/update-getting-started-guide-version.sh
 
@@ -49,6 +50,7 @@ jobs:
         with:
           ref: main
           sparse-checkout: |
+            docs/eks.md
             docs/getting-started.md
             scripts/update-getting-started-guide-version.sh
 

--- a/docs/eks.md
+++ b/docs/eks.md
@@ -132,13 +132,13 @@ cat <<'EOF_SCRIPT' >install_soci.sh
 #!/bin/bash
 # Set environment variables
 ARCH=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
-VERSION=0.7.0
-ARCHIVE=soci-snapshotter-$VERSION-linux-$ARCH.tar.gz
+version="0.7.0"
+ARCHIVE=soci-snapshotter-$version-linux-$ARCH.tar.gz
 
 pushd /tmp
 # Download, verify, and install the soci-snapshotter
-curl --silent --location --fail --output $ARCHIVE https://github.com/awslabs/soci-snapshotter/releases/download/v$VERSION/$ARCHIVE
-curl --silent --location --fail --output $ARCHIVE.sha256sum https://github.com/awslabs/soci-snapshotter/releases/download/v$VERSION/$ARCHIVE.sha256sum
+curl --silent --location --fail --output $ARCHIVE https://github.com/awslabs/soci-snapshotter/releases/download/v$version/$ARCHIVE
+curl --silent --location --fail --output $ARCHIVE.sha256sum https://github.com/awslabs/soci-snapshotter/releases/download/v$version/$ARCHIVE.sha256sum
 sha256sum ./$ARCHIVE.sha256sum
 tar xzvf ./$ARCHIVE -C /usr/local/bin soci-snapshotter-grpc
 rm ./$ARCHIVE
@@ -156,7 +156,7 @@ image_service_path = "/run/containerd/containerd.sock"
 EOF
 
 # Start the soci-snapshotter
-curl --silent --location --fail --output /etc/systemd/system/soci-snapshotter.service https://raw.githubusercontent.com/awslabs/soci-snapshotter/v$VERSION/soci-snapshotter.service
+curl --silent --location --fail --output /etc/systemd/system/soci-snapshotter.service https://raw.githubusercontent.com/awslabs/soci-snapshotter/v$version/soci-snapshotter.service
 systemctl daemon-reload
 systemctl enable --now soci-snapshotter
 

--- a/scripts/update-getting-started-guide-version.sh
+++ b/scripts/update-getting-started-guide-version.sh
@@ -67,7 +67,7 @@ assert_diff() {
   }
 }
 
-sed -i -E "s/version=\"([0-9]+\.){2}[0-9]+\"/version=\"${VERSION}\"/" docs/getting-started.md
+sed -i -E "s/version=\"([0-9]+\.){2}[0-9]+\"/version=\"${VERSION}\"/" docs/getting-started.md docs/eks.md
 
 if [ $VERBOSE = true ]; then
   git --no-pager diff


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`docs/eks.md` includes the latest SOCI version in its contents so we should update that too. Looking at this we should probably clean up some of the shellscript directives used here in general but I'd rather do that in a separate PR since the main point here is to add this to the automation.

Might be worth thinking about if we want to simply have the script check the entirety of docs for this string instead.

**Testing performed:**
Ran ` scripts/update-getting-started-guide-version.sh --verbose v0.0.0` and confirmed the proper changes were made.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
