### PR TITLE
Ignore benchmark folder for unit/integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
       - 'Dockerfile'
       - 'integration/**'
       - 'scripts/**'
+      - '!benchmark/**'
 
 env:
   GO_VERSION: '1.22.8'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Noticed in https://github.com/awslabs/soci-snapshotter/pull/1409 when making a change to the benchmark folder, that it reran our time-consuming integration tests again, despite benchmarks being unneeded in unit or integration testing.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
