### PR TITLE
Update to pinned containerd version

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/awslabs/soci-snapshotter v0.0.0-local
-	github.com/containerd/containerd v1.7.23
+	github.com/containerd/containerd v1.7.24-0.20241112045055-4a8b07907920
 	github.com/containerd/containerd/api v1.8.0
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v0.2.1

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -22,8 +22,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
-github.com/containerd/containerd v1.7.23 h1:H2CClyUkmpKAGlhQp95g2WXHfLYc7whAuvZGBNYOOwQ=
-github.com/containerd/containerd v1.7.23/go.mod h1:7QUzfURqZWCZV7RLNEn1XjUCQLEf0bkaK4GjUaZehxw=
+github.com/containerd/containerd v1.7.24-0.20241112045055-4a8b07907920 h1:2ieHPa/+yr21ZpZrgnsTtSy7FmCDARmrZvLkbhmS7Mw=
+github.com/containerd/containerd v1.7.24-0.20241112045055-4a8b07907920/go.mod h1:7QUzfURqZWCZV7RLNEn1XjUCQLEf0bkaK4GjUaZehxw=
 github.com/containerd/containerd/api v1.8.0 h1:hVTNJKR8fMc/2Tiw60ZRijntNMd1U+JVMyTRdsD2bS0=
 github.com/containerd/containerd/api v1.8.0/go.mod h1:dFv4lt6S20wTu/hMcP4350RL87qPWLVa/OHOwmmdnYc=
 github.com/containerd/continuity v0.4.3 h1:6HVkalIp+2u1ZLH1J/pYX2oBVXlJZvh1X1A7bEZ9Su8=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/awslabs/soci-snapshotter
 go 1.22
 
 require (
-	github.com/containerd/containerd v1.7.23
+	github.com/containerd/containerd v1.7.24-0.20241112045055-4a8b07907920
 	github.com/containerd/continuity v0.4.3
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/log v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
-github.com/containerd/containerd v1.7.23 h1:H2CClyUkmpKAGlhQp95g2WXHfLYc7whAuvZGBNYOOwQ=
-github.com/containerd/containerd v1.7.23/go.mod h1:7QUzfURqZWCZV7RLNEn1XjUCQLEf0bkaK4GjUaZehxw=
+github.com/containerd/containerd v1.7.24-0.20241112045055-4a8b07907920 h1:2ieHPa/+yr21ZpZrgnsTtSy7FmCDARmrZvLkbhmS7Mw=
+github.com/containerd/containerd v1.7.24-0.20241112045055-4a8b07907920/go.mod h1:7QUzfURqZWCZV7RLNEn1XjUCQLEf0bkaK4GjUaZehxw=
 github.com/containerd/containerd/api v1.7.19 h1:VWbJL+8Ap4Ju2mx9c9qS1uFSB1OVYr5JJrW2yT5vFoA=
 github.com/containerd/containerd/api v1.7.19/go.mod h1:fwGavl3LNwAV5ilJ0sbrABL44AQxmNjDRcwheXDb6Ig=
 github.com/containerd/continuity v0.4.3 h1:6HVkalIp+2u1ZLH1J/pYX2oBVXlJZvh1X1A7bEZ9Su8=


### PR DESCRIPTION


**Issue #, if available:**

**Description of changes:**
This is to unblock our automation from requiring manual intervention. This PR specifically will allow us to upgrade to continuity v0.4.4.

In the long-term we want to have a more modular way of denylisting certain packages from being upgraded, but for now this is an easy bandage fix for our current issue.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
