### PR TITLE
Truncate benchmark logs on re-run

### DIFF
--- a/benchmark/comparisonTest/main.go
+++ b/benchmark/comparisonTest/main.go
@@ -68,7 +68,7 @@ func main() {
 		panic(err)
 	}
 
-	logFile, err := os.OpenFile(outputDir+"/benchmark_log", os.O_RDWR|os.O_CREATE, 0664)
+	logFile, err := os.OpenFile(outputDir+"/benchmark_log", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0664)
 	if err != nil {
 		panic(err)
 	}

--- a/benchmark/performanceTest/main.go
+++ b/benchmark/performanceTest/main.go
@@ -83,7 +83,7 @@ func main() {
 		panic(err)
 	}
 
-	logFile, err := os.OpenFile(outputDir+"/benchmark_log", os.O_RDWR|os.O_CREATE, 0664)
+	logFile, err := os.OpenFile(outputDir+"/benchmark_log", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0664)
 	if err != nil {
 		panic(err)
 	}

--- a/benchmark/stargzTest/main.go
+++ b/benchmark/stargzTest/main.go
@@ -50,7 +50,7 @@ func main() {
 		panic(err)
 	}
 
-	logFile, err := os.OpenFile(outputDir+"/benchmark_log", os.O_RDWR|os.O_CREATE, 0664)
+	logFile, err := os.OpenFile(outputDir+"/benchmark_log", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0664)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**

Rerunning benchmarks did not truncate the benchmark log file before this change. New line would overwrite old lines, but you had to scan timestamps to figure out where exactly the new run was at. It also prevented `tail -f` to get real-time updates.

This change truncates the benchmark file on each execution.

**Testing performed:**

`make benchmarks`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
