### PR TITLE
Fix regression in metrics startup order

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -221,7 +221,13 @@ func serve(ctx context.Context, rpc *grpc.Server, addr string, rs snapshots.Snap
 
 	// We need to consider both the existence of MetricsAddress as well as NoPrometheus flag not set
 	if cfg.MetricsAddress != "" && !cfg.NoPrometheus {
-		l, err := net.Listen(cfg.MetricsNetwork, cfg.MetricsAddress)
+		var l net.Listener
+		var err error
+		if cfg.MetricsNetwork == "unix" {
+			l, err = listenUnix(cfg.MetricsAddress)
+		} else {
+			l, err = net.Listen(cfg.MetricsNetwork, cfg.MetricsAddress)
+		}
 		if err != nil {
 			return false, fmt.Errorf("failed to get listener for metrics endpoint: %w", err)
 		}


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Before this change, if the metrics socket was a unix socket, SOCI would
not create the parent dir before trying to bind. This exposed an
implicit dependency on bind order if you tried to put the metrics
address next to the main socket which we broke when we introduced
systemd socket activation.

This change ensures that we create the parent dir before binding the
metrics socket.

**Testing performed:**
`GO_TEST_FLAGS='-run TestSnapshotterStartup' make integration`

I verified that the updated test failed before the snapshotter change and succeeds after.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
