### PR TITLE
Update Go 1.22.10 in CI

### DIFF
--- a/.github/workflows/benchmark_visualization.yml
+++ b/.github/workflows/benchmark_visualization.yml
@@ -13,7 +13,7 @@ permissions:
   deployments: write
 
 env:
-  GO_VERSION: '1.22.8'
+  GO_VERSION: '1.22.10'
 
 jobs:
   benchmark:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ on:
       - '!benchmark/**'
 
 env:
-  GO_VERSION: '1.22.8'
+  GO_VERSION: '1.22.10'
 
 jobs:
   setup:

--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.22.8'
+  GO_VERSION: '1.22.10'
 
 permissions:
   contents: write

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 0 */2 * *" # every 2 days
 
 env:
-  GO_VERSION: '1.22.8'
+  GO_VERSION: '1.22.10'
 
 jobs:
   check:

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -7,7 +7,7 @@ on:
     branches: ['main', 'release/**']
 
 env:
-  GO_VERSION: '1.22.8'
+  GO_VERSION: '1.22.10'
   GOLANGCI_LINT_VERSION: '1.61.0'
 
 jobs:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,7 +12,7 @@ on:
       - 'Makefile'
 
 env:
-  GO_VERSION: '1.22.8'
+  GO_VERSION: '1.22.10'
 
 permissions:
   contents: write


### PR DESCRIPTION
**Issue #, if available:**
n/a

**Description of changes:**
This change updates the CI toolchain to Go 1.22.10

**Testing performed:**
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
