### PR TITLE
Update golangci-lint to v1.63.4 and resolve warnings

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GO_VERSION: '1.22.11'
-  GOLANGCI_LINT_VERSION: '1.61.0'
+  GOLANGCI_LINT_VERSION: '1.63.4'
 
 jobs:
   check:

--- a/fs/remote/blob_test.go
+++ b/fs/remote/blob_test.go
@@ -463,17 +463,17 @@ func multiRoundTripper(t *testing.T, contents []byte, opts ...interface{}) Round
 		})
 		var sparse bool
 		if sorted[0].b == 0 {
-			var max int64
+			var maxRegionEnd int64
 			for _, reg := range sorted {
-				if reg.e > max {
-					if max < reg.b-1 {
+				if reg.e > maxRegionEnd {
+					if maxRegionEnd < reg.b-1 {
 						sparse = true
 						break
 					}
-					max = reg.e
+					maxRegionEnd = reg.e
 				}
 			}
-			if max >= int64(len(contents)-1) && !sparse {
+			if maxRegionEnd >= int64(len(contents)-1) && !sparse {
 				t.Logf("serving whole range %q = %d", ranges, len(contents))
 				header := make(http.Header)
 				header.Add("Content-Length", fmt.Sprintf("%d", len(contents)))

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -362,13 +362,6 @@ func TestSpanManagerRetries(t *testing.T) {
 					t.Fatalf("unexpected err; expected %v, got %v", tc.expectedErr, err)
 				}
 
-				min := func(x, y int) int {
-					if x < y {
-						return x
-					}
-					return y
-				}
-
 				if rdr.errCount != min(tc.spanManagerRetries+1, tc.readerErrors) {
 					t.Fatalf("retry count is unexpected; expected %d, got %d", min(tc.spanManagerRetries+1, tc.readerErrors), rdr.errCount)
 				}

--- a/metadata/util_test.go
+++ b/metadata/util_test.go
@@ -348,7 +348,7 @@ func hasDirChildren(name string, children ...string) check {
 	}
 }
 
-func hasChardev(name string, maj, min int) check {
+func hasChardev(name string, major, minor int) check {
 	return func(t *testing.T, r testableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
@@ -364,14 +364,14 @@ func hasChardev(name string, maj, min int) check {
 			t.Errorf("file %q is not a chardev: %v", name, attr.Mode)
 			return
 		}
-		if attr.DevMajor != maj || attr.DevMinor != min {
-			t.Errorf("unexpected major/minor of chardev %q: %d/%d want %d/%d", name, attr.DevMajor, attr.DevMinor, maj, min)
+		if attr.DevMajor != major || attr.DevMinor != minor {
+			t.Errorf("unexpected major/minor of chardev %q: %d/%d want %d/%d", name, attr.DevMajor, attr.DevMinor, major, minor)
 			return
 		}
 	}
 }
 
-func hasBlockdev(name string, maj, min int) check {
+func hasBlockdev(name string, major, minor int) check {
 	return func(t *testing.T, r testableReader) {
 		id, err := lookup(r, name)
 		if err != nil {
@@ -387,8 +387,8 @@ func hasBlockdev(name string, maj, min int) check {
 			t.Errorf("file %q is not a blockdev: %v", name, attr.Mode)
 			return
 		}
-		if attr.DevMajor != maj || attr.DevMinor != min {
-			t.Errorf("unexpected major/minor of blockdev %q: %d/%d want %d/%d", name, attr.DevMajor, attr.DevMinor, maj, min)
+		if attr.DevMajor != major || attr.DevMinor != minor {
+			t.Errorf("unexpected major/minor of blockdev %q: %d/%d want %d/%d", name, attr.DevMajor, attr.DevMinor, major, minor)
 			return
 		}
 	}

--- a/service/keychain/kubeconfig/kubeconfig.go
+++ b/service/keychain/kubeconfig/kubeconfig.go
@@ -205,8 +205,8 @@ func (kc *keychain) startSyncSecrets(ctx context.Context, client kubernetes.Inte
 				queue.Add(key)
 			}
 		},
-		UpdateFunc: func(old, new interface{}) {
-			key, err := cache.MetaNamespaceKeyFunc(new)
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(newObj)
 			if err == nil {
 				queue.Add(key)
 			}

--- a/service/resolver/client.go
+++ b/service/resolver/client.go
@@ -123,8 +123,8 @@ func jitter(duration time.Duration, divisor int64) time.Duration {
 // overwhelming the repository when it comes back online
 // DefaultBackoff either tries to parse the 'Retry-After' header of the response; or, it uses an
 // exponential backoff 2 ^ numAttempts, limited by max
-func backoffStrategy(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
-	delayTime := rhttp.DefaultBackoff(min, max, attemptNum, resp)
+func backoffStrategy(minDuration, maxDuration time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	delayTime := rhttp.DefaultBackoff(minDuration, maxDuration, attemptNum, resp)
 	return jitter(delayTime, 8)
 }
 


### PR DESCRIPTION
**Issue #, if available:**
n/a

**Description of changes:**
This change updates golangci-lint to v1.63.4 and resolves new linter warnings for shadowing of built-in functions.

**Testing performed:**
CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
