### PR TITLE
Move io abstractions to ioutils

### DIFF
--- a/util/ioutils/multireadcloser.go
+++ b/util/ioutils/multireadcloser.go
@@ -1,0 +1,48 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ioutils
+
+import (
+	"errors"
+	"io"
+)
+
+type MultiReadCloser struct {
+	c []io.ReadCloser
+	io.Reader
+}
+
+func NewMultiReadCloser(rcs []io.ReadCloser) *MultiReadCloser {
+	readers := make([]io.Reader, len(rcs))
+	for i := range len(rcs) {
+		readers[i] = rcs[i]
+	}
+	return &MultiReadCloser{
+		rcs,
+		io.MultiReader(readers...),
+	}
+}
+
+func (mrc *MultiReadCloser) Close() error {
+	var errs []error
+	for _, c := range mrc.c {
+		if err := c.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/util/ioutils/sectionreadcloser.go
+++ b/util/ioutils/sectionreadcloser.go
@@ -1,0 +1,32 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ioutils
+
+import "io"
+
+type SectionReadCloser struct {
+	*io.SectionReader
+	c io.Closer
+}
+
+func NewSectionReadCloser(r *io.SectionReader, c io.Closer) *SectionReadCloser {
+	return &SectionReadCloser{r, c}
+}
+
+func (src *SectionReadCloser) Close() error {
+	return src.c.Close()
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
SOCI has a couple of extensions to combine various `io` interfaces. This PR moves these under `ioutils` instead of defining them in the packages where they were first needed to encourage reuse.

**Testing performed:**
`make && make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
