### PR TITLE
Add non-lazy-loaded-layer verification

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -22,6 +22,7 @@ max_concurrency=0  # Actually zero
 no_prometheus=false
 mount_timeout_sec=0
 fuse_metrics_emit_wait_duration_sec=0
+verify_local_mounts=true
 
 ## config/config.go Config
 

--- a/config/fs.go
+++ b/config/fs.go
@@ -56,6 +56,10 @@ type FSConfig struct {
 	MountTimeoutSec                int64  `toml:"mount_timeout_sec"`
 	FuseMetricsEmitWaitDurationSec int64  `toml:"fuse_metrics_emit_wait_duration_sec"`
 
+	// VerifyLocalMounts will verify the shasum of compressed and uncompressed
+	// content for layers pulled ahead of time (i.e. non-FUSE mounts)
+	VerifyLocalMounts bool `toml:"verify_local_mounts" default:"true"`
+
 	RetryableHTTPClientConfig `toml:"http"`
 	BlobConfig                `toml:"blob"`
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Though we attempt to mimic overlay in MountLocal, we do not do any verification once we receive the content. This change adds functionality for this, and the option to disable it as well.

**Testing performed:**
`make && make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
