### PR TITLE
Add Go 1.23 branch to build/prebuild workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,13 @@ name: Build
 
 on:
   push:
-    branches: ['main', 'release/**']
+    branches: ['main', 'release/**', 'go-1.23.x']
     paths:
       - '**'
       - '!docs/**' # ignore docs changes
       - '!**.md' # ignore markdown changes
   pull_request:
-    branches: ['main', 'release/**']
+    branches: ['main', 'release/**', 'go-1.23.x']
     paths:
       - '.github/workflows/build.yml'
       - '**.go'

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -2,9 +2,9 @@ name: Pre-build
 
 on:
   push:
-    branches: ['main', 'release/**']
+    branches: ['main', 'release/**', 'go-1.23.x']
   pull_request:
-    branches: ['main', 'release/**']
+    branches: ['main', 'release/**', 'go-1.23.x']
 
 env:
   GO_VERSION: '1.22.11'


### PR DESCRIPTION
**Issue #, if available:**
Prerequisite to https://github.com/awslabs/soci-snapshotter/pull/1476

**Description of changes:**
Add workflows to ensure we pass required tests for our Go 1.23 branch.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
