### PR TITLE
Remove ORAS Resolve calls in MountLocal

### DIFF
--- a/service/resolver/cri.go
+++ b/service/resolver/cri.go
@@ -276,7 +276,7 @@ func addDefaultScheme(endpoint string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s://%s", defaultScheme(u.Host), endpoint), nil
+	return fmt.Sprintf("%s://%s", DefaultScheme(u.Host), endpoint), nil
 }
 
 // registryEndpoints returns endpoints for a given host.
@@ -313,7 +313,7 @@ func registryEndpoints(config Registry, host string) ([]string, error) {
 			return endpoints, nil
 		}
 	}
-	return append(endpoints, defaultScheme(defaultHost)+"://"+defaultHost), nil
+	return append(endpoints, DefaultScheme(defaultHost)+"://"+defaultHost), nil
 }
 
 // ParseAlphaAuth parses AuthConfig and returns username and password/secret required by containerd.

--- a/service/resolver/registry.go
+++ b/service/resolver/registry.go
@@ -121,7 +121,7 @@ func (rm *RegistryManager) AsRegistryHosts() RegistryHosts {
 				if err != nil {
 					return nil, err
 				}
-				scheme := defaultScheme(host)
+				scheme := DefaultScheme(host)
 				if mirror.Insecure {
 					scheme = "http"
 				}
@@ -162,7 +162,7 @@ func (rm *RegistryManager) AsRegistryHosts() RegistryHosts {
 		if err != nil {
 			return nil, err
 		}
-		scheme := defaultScheme(host)
+		scheme := DefaultScheme(host)
 		registryHosts = append(registryHosts, docker.RegistryHost{
 			Client:       authClient.StandardClient(),
 			Host:         host,
@@ -195,11 +195,11 @@ func multiCredsFuncs(imgRefSpec reference.Spec, credsFuncs ...Credential) func(s
 	}
 }
 
-// defaultScheme returns the default scheme for a registry host.
+// DefaultScheme returns the default scheme for a registry host.
 //
 // Copied over from: https://github.com/containerd/containerd/blob/a901236bf00a6d0ef1fe299c9e5ae72a1dd67869/pkg/cri/server/images/image_pull.go#L474
 // Original Copyright the containerd Authors. Licensed under the Apache License, Version 2.0 (the "License").
-func defaultScheme(host string) string {
+func DefaultScheme(host string) string {
 	if docker.IsLocalhost(host) {
 		return "http"
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This PR has two parts:

Previously in #1025, we fixed an issue where MountLocal would fail as the artifact fetcher would make a call to the remote store, but since we passed it an ORAS Repository, the Resolve call would assume it was given a ref to a manifest, which will never be the case in this call stack.

By passing the artifact fetcher a BlobStore instead in this callstack, we can remove redundant logic. However, the ORAS resolve call will always try to resolve with a HEAD request, which some repos do not support. This is not a problem for the remote snapshot codepath, as it resolves manually via the RoundTripper. These two codepaths should really be using the same logic but currently are not, so by removing the ORAS resolve codepath, we can also squash this bug.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
