### PR TITLE
Add metric for failing to prepare local snapshot

### DIFF
--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -110,6 +110,10 @@ const (
 	// Note that a layer not having a ztoc is NOT classified as an error, even though `fs.Mount` returns an error in that case.
 	FuseMountFailureCount = "fuse_mount_failure_count"
 
+	// Number of times that local mounts fail to be created.
+	// This excludes the use case where we defer to container runtime early in the case of no ztoc.
+	LocalMountFailureCount = "local_mount_failure_count"
+
 	// Number of errors of span fetch by background fetcher
 	BackgroundSpanFetchFailureCount = "background_span_fetch_failure_count"
 

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -435,6 +435,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 
 	// Local snapshot setup failed. Generally means something critical has gone wrong.
 	log.G(lCtx).WithError(err).Warnf("failed to prepare local snapshot; %v", ErrDeferToContainerRuntime)
+	commonmetrics.IncOperationCount(commonmetrics.LocalMountFailureCount, digest.Digest(""))
 	return mounts, nil
 }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We previously had no way of knowing if MountLocal fails, so adding this metric could help with telemetry for users, as well as help our integration testing.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
