### PR TITLE
Refactor SOCI Index Build API

### DIFF
--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -115,21 +115,22 @@ var CreateCommand = cli.Command{
 			return err
 		}
 
-		builderOpts := []soci.BuildOption{
+		builderOpts := []soci.BuilderOption{
 			soci.WithMinLayerSize(minLayerSize),
 			soci.WithSpanSize(spanSize),
 			soci.WithBuildToolIdentifier(buildToolIdentifier),
 			soci.WithOptimizations(optimizations),
+			soci.WithArtifactsDb(artifactsDb),
+		}
+
+		builder, err := soci.NewIndexBuilder(cs, blobStore, builderOpts...)
+
+		if err != nil {
+			return err
 		}
 
 		for _, plat := range ps {
-			builder, err := soci.NewIndexBuilder(cs, blobStore, artifactsDb, append(builderOpts, soci.WithPlatform(plat))...)
-
-			if err != nil {
-				return err
-			}
-
-			_, err = builder.Build(ctx, srcImg)
+			_, err = builder.Build(ctx, srcImg, soci.WithPlatform(plat))
 			if err != nil {
 				return err
 			}

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -34,7 +34,7 @@ func TestSkipBuildingZtoc(t *testing.T) {
 	testcases := []struct {
 		name        string
 		desc        ocispec.Descriptor
-		buildConfig buildConfig
+		buildConfig builderConfig
 		skip        bool
 	}{
 		{
@@ -44,7 +44,7 @@ func TestSkipBuildingZtoc(t *testing.T) {
 				Digest:    parseDigest("sha256:88a7002d88ed7b174259637a08a2ef9b7f4f2a314dfb51fa1a4a6a1d7e05dd01"),
 				Size:      5223,
 			},
-			buildConfig: buildConfig{
+			buildConfig: builderConfig{
 				minLayerSize: 65535,
 			},
 			skip: true,
@@ -56,7 +56,7 @@ func TestSkipBuildingZtoc(t *testing.T) {
 				Digest:    parseDigest("sha256:88a7002d88ed7b174259637a08a2ef9b7f4f2a314dfb51fa1a4a6a1d7e05dd01"),
 				Size:      65535,
 			},
-			buildConfig: buildConfig{
+			buildConfig: builderConfig{
 				minLayerSize: 65535,
 			},
 			skip: false,
@@ -68,7 +68,7 @@ func TestSkipBuildingZtoc(t *testing.T) {
 				Digest:    parseDigest("sha256:88a7002d88ed7b174259637a08a2ef9b7f4f2a314dfb51fa1a4a6a1d7e05dd01"),
 				Size:      5000,
 			},
-			buildConfig: buildConfig{
+			buildConfig: builderConfig{
 				minLayerSize: 500,
 			},
 			skip: false,
@@ -141,7 +141,7 @@ func TestBuildSociIndexNotLayer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can't create a test db")
 	}
-	builder, err := NewIndexBuilder(cs, blobStore, artifactsDb, WithSpanSize(spanSize), WithMinLayerSize(0))
+	builder, err := NewIndexBuilder(cs, blobStore, WithArtifactsDb(artifactsDb), WithSpanSize(spanSize), WithMinLayerSize(0))
 
 	if err != nil {
 		t.Fatalf("cannot create index builer: %v", err)
@@ -213,7 +213,7 @@ func TestBuildSociIndexWithLimits(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can't create a test db")
 			}
-			builder, _ := NewIndexBuilder(cs, blobStore, artifactsDb, WithSpanSize(spanSize), WithMinLayerSize(tc.minLayerSize))
+			builder, _ := NewIndexBuilder(cs, blobStore, WithArtifactsDb(artifactsDb), WithSpanSize(spanSize), WithMinLayerSize(tc.minLayerSize))
 			ztoc, err := builder.buildSociLayer(ctx, desc)
 			if tc.ztocGenerated {
 				// we check only for build skip, which is indicated as nil value for ztoc and nil value for error
@@ -292,7 +292,7 @@ func TestDisableXattrs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("can't create a test db")
 			}
-			builder, _ := NewIndexBuilder(cs, blobStore, artifactsDb, WithOptimizations([]Optimization{XAttrOptimization}))
+			builder, _ := NewIndexBuilder(cs, blobStore, WithArtifactsDb(artifactsDb), WithOptimizations([]Optimization{XAttrOptimization}))
 			builder.maybeAddDisableXattrAnnotation(&desc, &ztoc)
 			disableXAttrs := desc.Annotations[IndexAnnotationDisableXAttrs] == disableXAttrsTrue
 			if disableXAttrs != tc.shouldDisableXattrs {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

The SOCI index build API had two problems:
1. It required an ArtifactsDB as input and ignored the `WithArtifactsDb` option
2. The build platform was taken as input to the builder rather than a specific index build operation. This meant that we had to create a builder in order to create indexes for multiple platforms rather than calling `Build` for each platform.

This change fixes these by:
1. Removing ArtifactsDB from `NewIndexBuilder`. Callers can set the artifacts db using `soci.WithArtifactsDb` instead.
2. Renaming `BuildOption` to `BuilderOption`. `NewIndexBuilder` takes `BuilderOption` which is the same set of functions as before
3. Creating a new `BuildOption` type that is passed to `Build`. This is for options that are specific to an index build operation rather than all builds. Like:
4. Moving platform from `BuilderOption` -> `BuildOption`. Now you can use a single builder for multiple platforms by using `soci.WithPlatform` on each `Build` call.

Note: This is a backwards incompatible change and clients will need changes in order to update.

**Testing performed:**
`make && make test && make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
