### PR TITLE
Update runners to ubuntu 22.04

### DIFF
--- a/.github/workflows/benchmark_visualization.yml
+++ b/.github/workflows/benchmark_visualization.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
           path: ${{github.workspace}}/benchmark/performanceTest/output/results.json
 
   download-and-convert-benchmark-result-to-visualization-data:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: benchmark
     steps:
       - name: Checkout main branch
@@ -67,7 +67,7 @@ jobs:
 
   push-benchmark-result-gh-pages:
     name: Push benchmark result to Github-pages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: download-and-convert-benchmark-result-to-visualization-data
     strategy:
       matrix:

--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Don't bother bumping deps on forks.
     if: ${{ github.repository == 'awslabs/soci-snapshotter' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/new-pull-requests.yml
+++ b/.github/workflows/new-pull-requests.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   label:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     permissions:
       pull-requests: write

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +32,7 @@ jobs:
       - run: PATH=$PATH:$(pwd) ./scripts/check-flatc.sh
 
   git-secrets:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Pull latest awslabs/git-secrets repo
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         working_dir: ['.', 'cmd']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: golangci/golangci-lint-action@v6
@@ -64,13 +64,13 @@ jobs:
 
   yamllint:
     name: yamllint-lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: yamllint .
 
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: koalaman/shellcheck-alpine:v0.10.0
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   generate-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       # Set during setup.
       RELEASE_TAG: ''
@@ -60,7 +60,7 @@ jobs:
 
   validate-artifacts:
     needs: generate-artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -72,7 +72,7 @@ jobs:
   create-release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [generate-artifacts, validate-artifacts]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/.github/workflows/update-getting-started-guide.yml
+++ b/.github/workflows/update-getting-started-guide.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   test-update-version:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: read
@@ -36,7 +36,7 @@ jobs:
 
   update-version:
     if: github.event_name == 'release'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     permissions:
       # Write permissions needed to create pull request.


### PR DESCRIPTION

**Issue #, if available:**
N/A

**Description of changes:**
GitHub is removing ubuntu 20.04 hosted runners on April 15. This bumps all of our runners to 22.04

The most significant change for us is that ubuntu 22.04 uses libc 2.34 which will be used in our release artifacts and may not be compatible with older systems (e.g. AL2). For affected customers, we also ship a statically linked binary, so this should have minimal impact.

**Testing performed:**

Prebuild workflows look OK:
https://github.com/Kern--/soci-snapshotter/actions/runs/14202477794/job/39792401635

Build workflows look OK:
https://github.com/Kern--/soci-snapshotter/actions/runs/14202477782

Release workflows look OK:
https://github.com/Kern--/soci-snapshotter/actions/runs/14202483438


Final Release
https://github.com/Kern--/soci-snapshotter/releases/tag/v0.0.0

I manually tested that the dynamically linked binaries do not work on AL2, but the statically linked binaries do.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
