### PR TITLE
Always use namespace from request context

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -137,8 +137,13 @@ func main() {
 		log.G(ctx).Warn("skipped snapshotter is supported check")
 	}
 
+	serverOpts := []grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(unaryNamespaceInterceptor),
+		grpc.ChainStreamInterceptor(streamNamespaceInterceptor),
+	}
+
 	// Create a gRPC server
-	rpc := grpc.NewServer()
+	rpc := grpc.NewServer(serverOpts...)
 
 	// Configure keychain
 	credsFuncs := []resolver.Credential{dockerconfig.NewDockerConfigKeychain(ctx)}

--- a/cmd/soci-snapshotter-grpc/namespaces.go
+++ b/cmd/soci-snapshotter-grpc/namespaces.go
@@ -1,0 +1,71 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// File copied from
+// https://github.com/containerd/containerd/blame/041743e8afd2bb2189aa904f04bf87b9073892d3/cmd/containerd/server/namespace.go
+
+package main
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/namespaces"
+	"google.golang.org/grpc"
+)
+
+func unaryNamespaceInterceptor(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	if ns, ok := namespaces.Namespace(ctx); ok {
+		// The above call checks the *incoming* metadata, this makes sure the outgoing metadata is also set
+		ctx = namespaces.WithNamespace(ctx, ns)
+	}
+	return handler(ctx, req)
+}
+
+func streamNamespaceInterceptor(srv interface{}, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	ctx := ss.Context()
+	if ns, ok := namespaces.Namespace(ctx); ok {
+		// The above call checks the *incoming* metadata, this makes sure the outgoing metadata is also set
+		ctx = namespaces.WithNamespace(ctx, ns)
+		ss = &wrappedSSWithContext{ctx: ctx, ServerStream: ss}
+	}
+
+	return handler(srv, ss)
+}
+
+type wrappedSSWithContext struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (w *wrappedSSWithContext) Context() context.Context {
+	return w.ctx
+}

--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -100,7 +100,7 @@ var CreateCommand = cli.Command{
 			return err
 		}
 
-		ctx, blobStore, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
+		blobStore, err := store.NewContentStore(internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -55,7 +55,7 @@ var infoCommand = cli.Command{
 		if artifactType == soci.ArtifactEntryTypeLayer {
 			return fmt.Errorf("the provided digest is of ztoc not SOCI index. Use \"soci ztoc info\" command to get detailed info of ztoc")
 		}
-		ctx, store, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
+		store, err := store.NewContentStore(internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/rm.go
+++ b/cmd/soci/commands/index/rm.go
@@ -46,8 +46,7 @@ var rmCommand = cli.Command{
 			return fmt.Errorf("please provide either index digests or image ref, but not both")
 		}
 
-		ctx := context.Background()
-		ctx, contentStore, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
+		contentStore, err := store.NewContentStore(internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return fmt.Errorf("cannot create local content store: %w", err)
 		}
@@ -57,6 +56,9 @@ var rmCommand = cli.Command{
 			return err
 		}
 		if ref == "" {
+			ctx, cancel := internal.AppContext(cliContext)
+			defer cancel()
+
 			byteArgs := make([][]byte, len(args))
 			for i, arg := range args {
 				byteArgs[i] = []byte(arg)

--- a/cmd/soci/commands/internal/client.go
+++ b/cmd/soci/commands/internal/client.go
@@ -43,6 +43,9 @@ import (
 	"github.com/urfave/cli"
 )
 
+// All CLI commands should call either [AppContext] or [NewClient]
+// to control the lifecycle of each command
+
 // Largely taken from containerd/cmd/ctr/commands/client.go
 
 // AppContext returns the context for a command. Should only be called once per

--- a/cmd/soci/commands/internal/store.go
+++ b/cmd/soci/commands/internal/store.go
@@ -28,6 +28,5 @@ func ContentStoreOptions(context *cli.Context) []store.Option {
 	return []store.Option{
 		store.WithType(store.ContentStoreType(context.GlobalString("content-store"))),
 		store.WithContainerdAddress(strings.TrimPrefix(context.GlobalString("address"), "unix://")),
-		store.WithNamespace(context.GlobalString("namespace")),
 	}
 }

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -140,7 +140,7 @@ if they are available in the snapshotter's local content store.
 			}, nil
 		}
 
-		ctx, src, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
+		src, err := store.NewContentStore(internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return fmt.Errorf("cannot create local content store: %w", err)
 		}

--- a/cmd/soci/commands/rebuild_db.go
+++ b/cmd/soci/commands/rebuild_db.go
@@ -45,7 +45,7 @@ var RebuildDBCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		ctx, blobStore, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
+		blobStore, err := store.NewContentStore(internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -87,7 +87,7 @@ var getFileCommand = cli.Command{
 }
 
 func getZtoc(ctx context.Context, cliContext *cli.Context, d digest.Digest) (*ztoc.Ztoc, error) {
-	ctx, blobStore, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
+	blobStore, err := store.NewContentStore(internal.ContentStoreOptions(cliContext)...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -17,7 +17,6 @@
 package ztoc
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -71,9 +70,9 @@ var infoCommand = cli.Command{
 		if entry.MediaType == soci.SociIndexArtifactType {
 			return fmt.Errorf("the provided digest belongs to a SOCI index. Use `soci index info` to get the detailed information about it")
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), cliContext.GlobalDuration("timeout"))
+		ctx, cancel := internal.AppContext(cliContext)
 		defer cancel()
-		ctx, store, err := store.NewContentStore(ctx, internal.ContentStoreOptions(cliContext)...)
+		store, err := store.NewContentStore(internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/list.go
+++ b/cmd/soci/commands/ztoc/list.go
@@ -63,6 +63,8 @@ var listCommand = cli.Command{
 
 		var artifacts []*soci.ArtifactEntry
 		if imgRef == "" {
+			_, cancel := internal.AppContext(cliContext)
+			defer cancel()
 			db.Walk(func(ae *soci.ArtifactEntry) error {
 				if ae.Type == soci.ArtifactEntryTypeLayer && (ztocDgst == "" || ae.Digest == ztocDgst) {
 					artifacts = append(artifacts, ae)

--- a/config/fs.go
+++ b/config/fs.go
@@ -42,7 +42,6 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/defaults"
-	"github.com/containerd/containerd/namespaces"
 )
 
 type FSConfig struct {
@@ -174,8 +173,6 @@ type ContentStoreConfig struct {
 	// ContainerdAddress is the containerd socket address.
 	// Applicable if and only if using containerd content store.
 	ContainerdAddress string `toml:"containerd_address"`
-
-	Namespace string `toml:"namespace"`
 }
 
 func parseFSConfig(cfg *Config) {
@@ -285,8 +282,5 @@ func parseContentStoreConfig(cfg *Config) {
 		cfg.ContentStoreConfig.ContainerdAddress = defaults.DefaultAddress
 	} else if cfg.ContentStoreConfig.Type == ContainerdContentStoreType {
 		cfg.ContentStoreConfig.ContainerdAddress = strings.TrimPrefix(cfg.ContentStoreConfig.ContainerdAddress, "unix://")
-	}
-	if cfg.ContentStoreConfig.Namespace == "" {
-		cfg.ContentStoreConfig.Namespace = namespaces.Default
 	}
 }

--- a/fs/source/source.go
+++ b/fs/source/source.go
@@ -85,6 +85,9 @@ const (
 	// TargetSociIndexDigestLabel is a label which contains the digest of the soci index.
 	TargetSociIndexDigestLabel = "containerd.io/snapshot/remote/soci.index.digest"
 
+	// TargetNamespace gives us the namespace that the snapshot was created in
+	TargetNamespace = "containerd.io/snapshot/remote/namespace"
+
 	// HasSociIndexDigest is a label that tells if the layer was pulled with a SOCI index.
 	HasSociIndexDigest = "containerd.io/snapshot/remote/has.soci.index.digest"
 )

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -494,7 +494,7 @@ func TestRunInNamespace(t *testing.T) {
 		for _, createNamespace := range namespaces {
 			for _, runNamespace := range namespaces {
 				t.Run("content store "+string(contentStoreType)+", create in "+createNamespace+", run in "+runNamespace, func(t *testing.T) {
-					rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, false, tcpMetricsConfig, GetContentStoreConfigToml(store.WithType(contentStoreType), store.WithNamespace(runNamespace))))
+					rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, false, tcpMetricsConfig, GetContentStoreConfigToml(store.WithType(contentStoreType))))
 					imageInfo := dockerhub(imageName)
 					indexDigest := buildIndex(sh, imageInfo, withMinLayerSize(0), withContentStoreType(contentStoreType), withNamespace(createNamespace))
 					if indexDigest == "" {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Before this change, any calls (mostly to the containerd content store) would use the namespace specified in the config. This means that making changes to the content store within one namespace would still be accessible when using another namespace. This was done because the context would have a namespace attached in the gRPC header, but not in the context struct, so if we didn't explicitly attach a namespace to the context, any calls to the containerd content store would fail.

This change adds middleware to the gRPC to explicitly attach the context from the header to the context, so that it can be passed to store calls.

This change also removes the config option to specify a specific namespace, which is okay since the CLI was never tied to this and still requires a namespace to be used, and the correct namespace to use is the one attached to the containerd context anyway.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
