### PR TITLE
Dockerfile: update container regsitry to v3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG CONTAINERD_VERSION=1.6.36
 ARG RUNC_VERSION=1.2.5
 ARG NERDCTL_VERSION=1.7.1
 
-FROM public.ecr.aws/docker/library/registry:3.0.0-alpha.1 AS registry
+FROM public.ecr.aws/docker/library/registry:3.0.0 AS registry
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS containerd-snapshotter-base
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Looks like registry v3 was released last week.

https://github.com/distribution/distribution/releases/tag/v3.0.0

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
