### PR TITLE
Use functional args for config in integ tests

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -15,9 +15,7 @@ http_cache_type=""
 filesystem_cache_type=""
 resolve_result_entry=0
 debug=false
-# disable_verification=false
-# Causes TestRunWithDefaultConfig to break, but
-# fine to use in /etc/soci-snapshotter-grpc-config.toml
+disable_verification=false
 max_concurrency=0  # Actually zero
 no_prometheus=false
 mount_timeout_sec=0

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -167,7 +167,7 @@ func TestSociCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, false, GetContentStoreConfigToml(store.WithType(tt.contentStoreType))))
+			rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, withContentStoreConfig(store.WithType(tt.contentStoreType))))
 			platform := platforms.DefaultSpec()
 			if tt.platform != "" {
 				var err error
@@ -216,7 +216,7 @@ func TestSociCreateGarbageCollection(t *testing.T) {
 [plugins."io.containerd.gc.v1.scheduler"]
 	deletion_threshold = 1`
 
-	rebootContainerd(t, sh, getContainerdConfigToml(t, false, extraContainerdConfig), getSnapshotterConfigToml(t, false, tcpMetricsConfig, GetContentStoreConfigToml(store.WithType(config.ContainerdContentStoreType))))
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false, extraContainerdConfig), getSnapshotterConfigToml(t, withTCPMetrics, withContentStoreConfig(store.WithType(config.ContainerdContentStoreType))))
 
 	imgInfo := dockerhub(image)
 	sh.X("nerdctl", "pull", "-q", imgInfo.ref)
@@ -243,7 +243,7 @@ func TestSociImageGCLabel(t *testing.T) {
 [plugins."io.containerd.gc.v1.scheduler"]
 	deletion_threshold = 1`
 
-	rebootContainerd(t, sh, getContainerdConfigToml(t, false, extraContainerdConfig), getSnapshotterConfigToml(t, false, tcpMetricsConfig, GetContentStoreConfigToml(store.WithType(config.ContainerdContentStoreType))))
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false, extraContainerdConfig), getSnapshotterConfigToml(t, withTCPMetrics, withContentStoreConfig(store.WithType(config.ContainerdContentStoreType))))
 
 	imgInfo := dockerhub(image)
 	sh.X("nerdctl", "pull", "-q", imgInfo.ref)

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -50,7 +50,7 @@ func TestSociArtifactsPushAndPull(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
+			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
 
 			platform, err := platforms.Parse(tt.Platform)
 			if err != nil {
@@ -115,7 +115,7 @@ func TestPushAlwaysMostRecentlyCreatedIndex(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
+			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
 
 			imgInfo := regConfig.mirror(tc.ref)
 			copyImage(sh, dockerhub(tc.ref), imgInfo)
@@ -159,7 +159,7 @@ func TestLegacyOCI(t *testing.T) {
 			sh, done := newShellWithRegistry(t, regConfig, withRegistryImageRef(tc.registryImage))
 			defer done()
 
-			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
+			rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
 
 			imageName := ubuntuImage
 			copyImage(sh, dockerhub(imageName), regConfig.mirror(imageName))
@@ -195,7 +195,7 @@ func TestPushWithExistingIndices(t *testing.T) {
 	sh, done := newShellWithRegistry(t, regConfig)
 	defer done()
 
-	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, false))
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
 
 	const (
 		singleFoundMessage   = "soci index found in remote repository with digest:"

--- a/integration/rebuild-db_test.go
+++ b/integration/rebuild-db_test.go
@@ -98,7 +98,7 @@ func TestRebuildArtifactsDB(t *testing.T) {
 	for _, tc := range testCases {
 		for _, contentStoreType := range store.ContentStoreTypes() {
 			t.Run(fmt.Sprintf(tc.name, contentStoreType), func(t *testing.T) {
-				rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, false, GetContentStoreConfigToml(store.WithType(contentStoreType))))
+				rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, withContentStoreConfig(store.WithType(contentStoreType))))
 				if !tc.afterContent {
 					copyImage(sh, dockerhub(img), regConfig.mirror(img))
 					buildIndex(sh, regConfig.mirror(img), withMinLayerSize(0), withContentStoreType(contentStoreType))

--- a/integration/startup_test.go
+++ b/integration/startup_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/awslabs/soci-snapshotter/config"
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
 )
 
@@ -30,10 +31,10 @@ import (
 // This tests a regression with the first implementation of systemd socket activation
 // where we moved creation of the directory later which caused the metrics address
 // bind to fail. This verifies that the directory gets created before binding the metrics socket.
-const metricsConfig = `
-metrics_address="/run/soci-snapshotter-grpc/metrics.sock"
-metrics_network="unix"
-`
+func withCustomMetricsConfig(cfg *config.Config) {
+	cfg.MetricsAddress = "/run/soci-snapshotter-grpc/metrics.sock"
+	cfg.MetricsNetwork = "unix"
+}
 
 // TestSnapshotterStartup tests to run containerd + snapshotter and check plugin is
 // recognized by containerd
@@ -41,7 +42,7 @@ func TestSnapshotterStartup(t *testing.T) {
 	t.Parallel()
 	sh, done := newSnapshotterBaseShell(t)
 	defer done()
-	rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, false, metricsConfig))
+	rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, withCustomMetricsConfig))
 	found := false
 	err := sh.ForEach(shell.C("ctr", "plugin", "ls"), func(l string) bool {
 		info := strings.Fields(l)


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
Before this change, integ tests modeled the SOCI snapshotter config in the string toml form. This change models the config as a config struct and serializes it as needed when running the tests. This should make it easier to override default config without having to expose template variables to every caller.

**Testing performed:**
`make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
