### PR TITLE
Disable systemd tests on x86 codebuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,11 @@ jobs:
       - name: Install zlib static on AL2 ARM instances
         if: matrix.os == 'al2-arm'
         run: dnf install zlib-static.aarch64 -y
-      - run: make integration-with-coverage
+      - name: Run integration tests
+        run: |
+          if [[ "${{ matrix.os }}" == "ubuntu-x86" ]]; then
+            SKIP_SYSTEMD_TESTS=1
+          fi
+          SKIP_SYSTEMD_TESTS=$SKIP_SYSTEMD_TESTS make integration-with-coverage
       - name: Show test coverage
         run: make show-integration-coverage

--- a/integration/startup_test.go
+++ b/integration/startup_test.go
@@ -17,6 +17,7 @@
 package integration
 
 import (
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -62,6 +63,10 @@ func TestSnapshotterStartup(t *testing.T) {
 // It verifies that SOCI works when using socket activation and that SOCI starts up correctly when
 // it is configured for socket activation, but it launches directly.
 func TestSnapshotterSystemdStartup(t *testing.T) {
+	if os.Getenv("SKIP_SYSTEMD_TESTS") != "" {
+		t.Skip("Skipping systemd tests")
+	}
+
 	tests := []struct {
 		name                 string
 		init                 func(*shell.Shell)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
systemd tests fail on codebuild x86 runners due to some issue with cgroups v2. For now, disable the tests (they should still pass on ARM) so we're not blocking PRs while we investigate.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
