### PR TITLE
Consume index annotations

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,156 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+)
+
+func TestConfigDefaults(t *testing.T) {
+	cfg := NewConfig()
+
+	tests := []struct {
+		name     string
+		expected any
+		actual   any
+	}{
+		{
+			name:     "soci v1 enabled",
+			expected: DefaultSOCIV1Enable,
+			actual:   cfg.PullModes.SOCIv1.Enable,
+		},
+		{
+			name:     "soci v2 enabled",
+			expected: DefaultSOCIV2Enable,
+			actual:   cfg.PullModes.SOCIv2.Enable,
+		},
+		{
+			name:     "metrics network",
+			expected: defaultMetricsNetwork,
+			actual:   cfg.MetricsNetwork,
+		},
+		{
+			name:     "cri image service address",
+			expected: DefaultImageServiceAddress,
+			actual:   cfg.CRIKeychainConfig.ImageServicePath,
+		},
+		{
+			name:     "mount timeout",
+			expected: int64(defaultMountTimeoutSec),
+			actual:   cfg.MountTimeoutSec,
+		},
+		{
+			name:     "fuse metric emit wait duration",
+			expected: int64(defaultFuseMetricsEmitWaitDurationSec),
+			actual:   cfg.FuseMetricsEmitWaitDurationSec,
+		},
+		{
+			name:     "max concurrency",
+			expected: int64(defaultMaxConcurrency),
+			actual:   cfg.MaxConcurrency,
+		},
+		{
+			name:     "fuse attr timeout",
+			expected: int64(defaultFuseTimeoutSec),
+			actual:   cfg.FuseConfig.AttrTimeout,
+		},
+		{
+			name:     "fuse entry timeout",
+			expected: int64(defaultFuseTimeoutSec),
+			actual:   cfg.FuseConfig.EntryTimeout,
+		},
+		{
+			name:     "fuse negative timeout",
+			expected: int64(defaultFuseTimeoutSec),
+			actual:   cfg.FuseConfig.NegativeTimeout,
+		},
+		{
+			name:     "bg fetch period",
+			expected: int64(defaultBgFetchPeriodMsec),
+			actual:   cfg.BackgroundFetchConfig.FetchPeriodMsec,
+		},
+		{
+			name:     "bg silence period",
+			expected: int64(defaultBgSilencePeriodMsec),
+			actual:   cfg.BackgroundFetchConfig.SilencePeriodMsec,
+		},
+
+		{
+			name:     "bg max queue size",
+			expected: int(defaultBgMaxQueueSize),
+			actual:   cfg.BackgroundFetchConfig.MaxQueueSize,
+		},
+		{
+			name:     "bg emit metrics period",
+			expected: int64(defaultBgMetricEmitPeriodSec),
+			actual:   cfg.BackgroundFetchConfig.EmitMetricPeriodSec,
+		},
+		{
+			name:     "http dial timeout",
+			expected: int64(defaultDialTimeoutMsec),
+			actual:   cfg.RetryableHTTPClientConfig.TimeoutConfig.DialTimeoutMsec,
+		},
+		{
+			name:     "http header timeout",
+			expected: int64(defaultResponseHeaderTimeoutMsec),
+			actual:   cfg.RetryableHTTPClientConfig.TimeoutConfig.ResponseHeaderTimeoutMsec,
+		},
+		{
+			name:     "http request timeout",
+			expected: int64(defaultRequestTimeoutMsec),
+			actual:   cfg.RetryableHTTPClientConfig.TimeoutConfig.RequestTimeoutMsec,
+		},
+		{
+			name:     "http max retries",
+			expected: int(defaultMaxRetries),
+			actual:   cfg.RetryableHTTPClientConfig.RetryConfig.MaxRetries,
+		},
+		{
+			name:     "http retry min wait",
+			expected: int64(defaultMinWaitMsec),
+			actual:   cfg.RetryableHTTPClientConfig.RetryConfig.MinWaitMsec,
+		},
+		{
+			name:     "http retry max wait",
+			expected: int64(defaultMaxWaitMsec),
+			actual:   cfg.RetryableHTTPClientConfig.RetryConfig.MaxWaitMsec,
+		},
+		{
+			name:     "blob valid interval",
+			expected: int64(defaultValidIntervalSec),
+			actual:   cfg.BlobConfig.ValidInterval,
+		},
+		{
+			name:     "blob fetch timeout",
+			expected: int64(defaultFetchTimeoutSec),
+			actual:   cfg.BlobConfig.FetchTimeoutSec,
+		},
+		{
+			name:     "content store type",
+			expected: SociContentStoreType,
+			actual:   cfg.ContentStoreConfig.Type,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expected != tc.actual {
+				t.Fatalf("invalid default value. expected: %v. actual: %v", tc.expected, tc.actual)
+			}
+		})
+	}
+}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -99,4 +99,10 @@ const (
 
 	// DefaultContentStore chooses the soci or containerd content store as the default
 	DefaultContentStoreType = "containerd"
+
+	// DefaultSOCIV1Enable is the default value for whether SOCI v1 is enabled
+	DefaultSOCIV1Enable = false
+
+	// DefaultSOCIV2Enable is the default value for whether SOCI v2 is enabled
+	DefaultSOCIV2Enable = true
 )

--- a/config/pull_modes.go
+++ b/config/pull_modes.go
@@ -1,0 +1,55 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+// PullModes contain config related to the ways in
+// in which the SOCI snapshotter can pull images
+type PullModes struct {
+	SOCIv1 V1 `toml:"soci_v1"`
+	SOCIv2 V2 `toml:"soci_v2"`
+}
+
+// V1 contains config for SOCI v1 which uses the
+// OCI referrers API to automatically discover SOCI
+// indexes that reference an image
+type V1 struct {
+	Enable bool `toml:"enable"`
+}
+
+// V2 contains config for SOCI v2 which uses annotations
+// on the container's image manifest to discover SOCI indexes
+// without an out-of-band referrers API call
+type V2 struct {
+	Enable bool `toml:"enable"`
+}
+
+func defaultPullModes(cfg *Config) {
+	cfg.PullModes = DefaultPullModes()
+}
+
+// DefaultPullModes returns a PullModes struct
+// with the SOCI defaults set.
+func DefaultPullModes() PullModes {
+	return PullModes{
+		SOCIv1: V1{
+			Enable: DefaultSOCIV1Enable,
+		},
+		SOCIv2: V2{
+			Enable: DefaultSOCIV2Enable,
+		},
+	}
+}

--- a/config/service.go
+++ b/config/service.go
@@ -35,6 +35,10 @@ package config
 type ServiceConfig struct {
 	FSConfig
 
+	// PullModes controls which pull modes are enabled
+	// and their implementation-specific config
+	PullModes PullModes `toml:"pull_modes"`
+
 	// KubeconfigKeychainConfig is config for kubeconfig-based keychain.
 	KubeconfigKeychainConfig `toml:"kubeconfig_keychain"`
 

--- a/integration/pull_modes_test.go
+++ b/integration/pull_modes_test.go
@@ -1,0 +1,254 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/awslabs/soci-snapshotter/util/dockershell"
+	"github.com/awslabs/soci-snapshotter/util/testutil"
+	"github.com/containerd/platforms"
+)
+
+var (
+	pullModesImages = []string{nginxImage, rabbitmqImage, drupalImage, ubuntuImage}
+)
+
+func createAndPushV2Index(t *testing.T, sh *dockershell.Shell, srcInfo imageInfo, dstInfo imageInfo) string {
+	sh.X("nerdctl", "pull", "--all-platforms", srcInfo.ref)
+	sh.X("soci", "convert", "--min-layer-size", "0", srcInfo.ref, dstInfo.ref)
+	sh.X("nerdctl", "push", "--all-platforms", dstInfo.ref)
+
+	indexDigest, err := sh.OLog("soci",
+		"index", "list",
+		"-q", "--ref", srcInfo.ref,
+		"--platform", platforms.Format(platforms.DefaultSpec()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return strings.Trim(string(indexDigest), "\n")
+}
+
+func createAndPushV1Index(sh *dockershell.Shell, dstInfo imageInfo) string {
+	sh.X("nerdctl", "pull", dstInfo.ref)
+	indexDigest := buildIndex(sh, dstInfo, withMinLayerSize(0))
+	sh.X("soci", "push", "--user", dstInfo.creds, dstInfo.ref)
+	return indexDigest
+}
+
+func TestPullModes(t *testing.T) {
+	for _, imgName := range pullModesImages {
+		t.Run(imgName, func(t *testing.T) {
+			testPullModes(t, imgName)
+		})
+	}
+}
+
+func testPullModes(t *testing.T, imgName string) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	srcInfo := dockerhub(imgName)
+	dstInfo := regConfig.mirror(imgName)
+	sh.X("nerdctl", "login", "-u", regConfig.user, "-p", regConfig.pass, dstInfo.ref)
+
+	// Convert the image and push to the registry,
+	// then create a v1 index for the converted image.
+	// This way, we can pull the same image with various pull modes
+	// and verify which SOCI index (if any) gets used to verify that
+	// the right pull modes are getting used.
+	rebootContainerd(t, sh, "", "")
+	v2IndexDigest := createAndPushV2Index(t, sh, srcInfo, dstInfo)
+	rebootContainerd(t, sh, "", "")
+	v1IndexDigest := createAndPushV1Index(sh, dstInfo)
+
+	tests := []struct {
+		name           string
+		pullModes      config.PullModes
+		pullDigest     string
+		expectedDigest string
+	}{
+		{
+			name: "lazy pulling doesn't happen if both v1 and v2 are disabled",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{
+					Enable: false,
+				},
+				SOCIv2: config.V2{
+					Enable: false,
+				},
+			},
+			expectedDigest: "",
+		},
+		{
+			name: "explicit v1 digest works with everything disabled",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{
+					Enable: false,
+				},
+				SOCIv2: config.V2{
+					Enable: false,
+				},
+			},
+			pullDigest:     v1IndexDigest,
+			expectedDigest: v1IndexDigest,
+		},
+		{
+			name: "explicit v2 digest works with everything disabled",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{
+					Enable: false,
+				},
+				SOCIv2: config.V2{
+					Enable: false,
+				},
+			},
+			pullDigest:     v2IndexDigest,
+			expectedDigest: v2IndexDigest,
+		},
+		{
+			name: "v1 works",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{
+					Enable: true,
+				},
+				SOCIv2: config.V2{
+					Enable: false,
+				},
+			},
+			expectedDigest: v1IndexDigest,
+		},
+		{
+			name: "v2 works",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{
+					Enable: false,
+				},
+				SOCIv2: config.V2{
+					Enable: true,
+				},
+			},
+			expectedDigest: v2IndexDigest,
+		},
+		{
+			name: "v2 is preferred over v1",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{
+					Enable: true,
+				},
+				SOCIv2: config.V2{
+					Enable: true,
+				},
+			},
+			expectedDigest: v2IndexDigest,
+		},
+		{
+			name:           "v2 is used by default",
+			pullModes:      config.DefaultPullModes(),
+			expectedDigest: v2IndexDigest,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, withPullModes(test.pullModes)))
+			rsm, done := testutil.NewRemoteSnapshotMonitor(m)
+			defer done()
+			var indexDigestUsed string
+			m.Add("Look for digest", func(s string) {
+				structuredLog := make(map[string]string)
+				err := json.Unmarshal([]byte(s), &structuredLog)
+				if err != nil {
+					return
+				}
+				if structuredLog["msg"] == "fetching SOCI artifacts using index descriptor" {
+					indexDigestUsed = structuredLog["digest"]
+				}
+			})
+			args := []string{"nerdctl", "pull", "--snapshotter", "soci"}
+			if test.pullDigest != "" {
+				args = append(args, "--soci-index-digest", test.pullDigest)
+			}
+			args = append(args, dstInfo.ref)
+			sh.X(args...)
+			if test.expectedDigest != "" {
+				rsm.CheckAllRemoteSnapshots(t)
+			} else {
+				rsm.CheckAllLocalSnapshots(t)
+			}
+			if indexDigestUsed != test.expectedDigest {
+				t.Fatalf("expected digest %s, got %s", test.expectedDigest, indexDigestUsed)
+			}
+		})
+	}
+}
+
+func TestV1IsNotUsedWhenDisabled(t *testing.T) {
+	for _, imgName := range pullModesImages {
+		t.Run(imgName, func(t *testing.T) {
+			testV1IsNotUsedWhenDisabled(t, imgName)
+		})
+	}
+}
+
+func testV1IsNotUsedWhenDisabled(t *testing.T, imgName string) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, "", "")
+
+	srcInfo := dockerhub(imgName)
+	dstInfo := regConfig.mirror(imgName)
+	copyImage(sh, srcInfo, dstInfo)
+	buildIndex(sh, dstInfo, withMinLayerSize(0))
+	sh.X("soci", "push", "--user", dstInfo.creds, dstInfo.ref)
+
+	m := rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, withPullModes(config.PullModes{
+		SOCIv1: config.V1{
+			Enable: false,
+		},
+		SOCIv2: config.V2{
+			Enable: true,
+		},
+	})))
+
+	rsm, doneRsm := testutil.NewRemoteSnapshotMonitor(m)
+	defer doneRsm()
+	var indexDigestUsed string
+	m.Add("Look for digest", func(s string) {
+		structuredLog := make(map[string]string)
+		err := json.Unmarshal([]byte(s), &structuredLog)
+		if err != nil {
+			return
+		}
+		if structuredLog["msg"] == "fetching SOCI artifacts using index descriptor" {
+			indexDigestUsed = structuredLog["digest"]
+		}
+	})
+	sh.X("nerdctl", "pull", "--snapshotter", "soci", dstInfo.ref)
+	rsm.CheckAllLocalSnapshots(t)
+	if indexDigestUsed != "" {
+		t.Fatalf("expected no digest, got %s", indexDigestUsed)
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -99,9 +99,11 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 		opq = layer.OverlayOpaqueUser
 	}
 	// Configure filesystem and snapshotter
-	fsOpts := append(sOpts.fsOpts, socifs.WithGetSources(
-		source.FromDefaultLabels(source.RegistryHosts(hosts)), // provides source info based on default labels
-	), socifs.WithOverlayOpaqueType(opq))
+	getSources := source.FromDefaultLabels(source.RegistryHosts(hosts)) // provides source info based on default labels
+	fsOpts := append(sOpts.fsOpts, socifs.WithGetSources(getSources),
+		socifs.WithOverlayOpaqueType(opq),
+		socifs.WithPullModes(serviceCfg.PullModes),
+	)
 	if serviceCfg.FSConfig.MaxConcurrency != 0 {
 		fsOpts = append(fsOpts, socifs.WithMaxConcurrency(serviceCfg.FSConfig.MaxConcurrency))
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change adds a new mechanism to discover SOCI indexes without the
OCI referrers API via annotations on the image manifest. The new
mechanism is called SOCI v2 while the original is called SOCI v1.
    
By default, SOCI v1 is disabled and SOCI v2 is enabled.


NOTE:
- This needs to be rebased once #1512 is merged
- Integration tests need the corresponding change to add annotations to the image manifests

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
