### PR TITLE
Add SOCI conversion

### DIFF
--- a/cmd/soci/commands/convert.go
+++ b/cmd/soci/commands/convert.go
@@ -20,32 +20,49 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
 	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/reference"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli"
 )
 
-const (
-	// buildToolIdentifier is placed in annotations of the SOCI index
-	// to help identify how a SOCI index was created
-	buildToolIdentifier = "AWS SOCI CLI v0.2"
-	spanSizeFlag        = "span-size"
-	minLayerSizeFlag    = "min-layer-size"
-	optimizationFlag    = "optimizations"
-	sociIndexGCLabel    = "containerd.io/gc.ref.content.soci-index"
-)
+var ErrInvalidDestRef = errors.New(`the destination image must be a tagged ref of the form "registry/repository:tag"`)
 
-// CreateCommand creates SOCI index for an image
-// Output of this command is SOCI layers and SOCI index stored in a local directory
-// SOCI layer is named as <image-layer-digest>.soci.layer
-// SOCI index is named as <image-manifest-digest>.soci.index
-var CreateCommand = cli.Command{
-	Name:      "create",
-	Usage:     "create SOCI index",
-	ArgsUsage: "[flags] <image_ref>",
+func verifyRef(r string) error {
+	if r == "" {
+		return errors.New("reference cannot be empty")
+	}
+
+	ref, err := reference.Parse(r)
+	if err != nil {
+		return fmt.Errorf("could not parse reference: %w", err)
+	}
+
+	object := ref.Object
+	if object == "" {
+		return errors.New("reference must be tagged")
+	}
+	if strings.Contains(object, "@") {
+		return errors.New("reference must not contain a digest")
+	}
+
+	return nil
+}
+
+// ConvertCommand converts an image into a SOCI enabled image.
+// The new image is added to the containerd content store and can
+// be pushed and deployed like a normal image.
+var ConvertCommand = cli.Command{
+	Name:      "convert",
+	Usage:     "convert an OCI image to a SOCI enabled image",
+	ArgsUsage: "[flags] <image_ref> <dest_ref>",
 	Flags: append(
 		internal.PlatformFlags,
 		cli.Int64Flag{
@@ -67,6 +84,15 @@ var CreateCommand = cli.Command{
 		srcRef := cliContext.Args().Get(0)
 		if srcRef == "" {
 			return errors.New("source image needs to be specified")
+		}
+
+		dstRef := cliContext.Args().Get(1)
+		if dstRef == "" {
+			return errors.New("destination image needs to be specified")
+		}
+		err := verifyRef(dstRef)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidDestRef, err)
 		}
 
 		var optimizations []soci.Optimization
@@ -108,11 +134,6 @@ var CreateCommand = cli.Command{
 			return err
 		}
 
-		ps, err := internal.GetPlatforms(ctx, cliContext, srcImg, cs)
-		if err != nil {
-			return err
-		}
-
 		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath())
 		if err != nil {
 			return err
@@ -132,25 +153,49 @@ var CreateCommand = cli.Command{
 			return err
 		}
 
-		for _, plat := range ps {
-			batchCtx, done, err := blobStore.BatchOpen(ctx)
-			if err != nil {
-				return err
-			}
-			defer done(ctx)
+		batchCtx, done, err := blobStore.BatchOpen(ctx)
+		if err != nil {
+			return err
+		}
+		defer done(ctx)
 
-			indexWithMetadata, err := builder.Build(batchCtx, srcImg, soci.WithPlatform(plat), soci.WithNoGarbageCollectionLabel())
-			if err != nil {
-				return err
-			}
-
-			if srcImg.Labels == nil {
-				srcImg.Labels = make(map[string]string)
-			}
-			srcImg.Labels[sociIndexGCLabel] = indexWithMetadata.Desc.Digest.String()
-			is.Update(ctx, srcImg, "labels")
+		var platforms []v1.Platform
+		explicitPlatforms := cliContext.StringSlice(internal.PlatformFlagKey)
+		if len(explicitPlatforms) > 0 {
+			platforms, err = internal.GetPlatforms(ctx, cliContext, srcImg, cs)
+		} else {
+			platforms, err = images.Platforms(ctx, cs, srcImg.Target)
+		}
+		if err != nil {
+			return err
 		}
 
-		return nil
+		desc, err := builder.Convert(batchCtx, srcImg,
+			soci.ConvertWithPlatforms(platforms...),
+			// Don't set a GC label on the converted OCI Index. We will create an image
+			// in containerd that will act as the GC root. This way, the OCI index, SOCI indexes, and
+			// images will be removed when the image is deleted in containerd
+			soci.ConvertWithNoGarbageCollectionLabels(),
+		)
+		if err != nil {
+			return err
+		}
+
+		im := images.Image{
+			Name:   dstRef,
+			Target: *desc,
+		}
+		img, err := is.Get(ctx, dstRef)
+		if err != nil {
+			if !errors.Is(err, errdefs.ErrNotFound) {
+				return err
+			}
+			_, err = is.Create(ctx, im)
+			return err
+		}
+		img.Target = *desc
+		_, err = is.Update(ctx, img)
+
+		return err
 	},
 }

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -241,7 +241,7 @@ if they are available in the snapshotter's local content store.
 				fmt.Printf("pushing soci index with digest: %v\n", indexDesc.Digest)
 			}
 
-			err = oraslib.CopyGraph(context.Background(), src, dst, indexDesc.Descriptor, options)
+			err = oraslib.CopyGraph(ctx, src, dst, indexDesc.Descriptor, options)
 			if err != nil {
 				return fmt.Errorf("error pushing graph to remote: %w", err)
 			}

--- a/cmd/soci/main.go
+++ b/cmd/soci/main.go
@@ -81,7 +81,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "content-store",
 			Usage: "use a specific content store (soci or containerd)",
-			Value: config.DefaultContentStoreType,
+			Value: string(config.DefaultContentStoreType),
 		},
 	}
 
@@ -91,6 +91,7 @@ func main() {
 		index.Command,
 		ztoc.Command,
 		commands.CreateCommand,
+		commands.ConvertCommand,
 		commands.PushCommand,
 		commands.RebuildDBCommand,
 	}

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -98,5 +98,5 @@ const (
 	defaultMaxWaitMsec = 300_000
 
 	// DefaultContentStore chooses the soci or containerd content store as the default
-	DefaultContentStoreType = "soci"
+	DefaultContentStoreType = "containerd"
 )

--- a/config/fs.go
+++ b/config/fs.go
@@ -277,7 +277,8 @@ func parseBlobConfig(cfg *Config) {
 
 func parseContentStoreConfig(cfg *Config) {
 	if cfg.ContentStoreConfig.Type == "" {
-		cfg.ContentStoreConfig.Type = DefaultContentStoreType
+		// The snapshotter's default content store is soci until we're confident in the containerd integration
+		cfg.ContentStoreConfig.Type = SociContentStoreType
 	} else if cfg.ContentStoreConfig.Type == ContainerdContentStoreType && cfg.ContentStoreConfig.ContainerdAddress == "" {
 		cfg.ContentStoreConfig.ContainerdAddress = defaults.DefaultAddress
 	} else if cfg.ContentStoreConfig.Type == ContainerdContentStoreType {

--- a/integration/convert_test.go
+++ b/integration/convert_test.go
@@ -1,0 +1,211 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/soci"
+	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+var (
+	convertImages = []string{nginxImage, rabbitmqImage, drupalImage, ubuntuImage}
+)
+
+func validateConversion(t *testing.T, sh *shell.Shell, originalDigest, convertedDigest string) {
+	t.Helper()
+
+	if originalDigest == convertedDigest {
+		t.Fatalf("conversion did not change the digest: %s", originalDigest)
+	}
+
+	var index ocispec.Index
+	content := sh.O("ctr", "content", "get", convertedDigest)
+	err := json.Unmarshal(content, &index)
+	if err != nil {
+		t.Fatalf("failed to decode index: %v", err)
+	}
+	var manifests []ocispec.Descriptor
+	var sociIndexes []ocispec.Descriptor
+	for _, manifest := range index.Manifests {
+		if manifest.ArtifactType == soci.SociIndexArtifactTypeV2 {
+			sociIndexes = append(sociIndexes, manifest)
+		} else if manifest.ArtifactType == "" {
+			manifests = append(manifests, manifest)
+		}
+		// ignore unknown artifacts
+	}
+
+	// We can't verify that manifests and soci indexes are 1-1 because there might be other,
+	// non-soci artifacts in the image (e.g. Docker attestation manifests)
+	if len(manifests) < len(sociIndexes) {
+		t.Errorf("the converted image contains more SOCI indexes than manifests. %d manifests, %d soci indexes", len(manifests), len(sociIndexes))
+	}
+	for _, sociIndexDesc := range sociIndexes {
+		if sociIndexDesc.Annotations == nil {
+			t.Errorf("SOCI index %v has no annotations", sociIndexDesc)
+			continue
+		}
+		if sociIndexDesc.Annotations[soci.IndexAnnotationImageManifestDigest] == "" {
+			t.Errorf("SOCI index %v does not contain image digest", sociIndexDesc)
+		}
+		if sociIndexDesc.Platform == nil {
+			t.Errorf("SOCI index %v does not contain platform", sociIndexDesc)
+			continue
+		}
+
+		manifestIdx := slices.IndexFunc(manifests, func(desc ocispec.Descriptor) bool {
+			return desc.Digest.String() == sociIndexDesc.Annotations[soci.IndexAnnotationImageManifestDigest]
+		})
+		if manifestIdx == -1 {
+			t.Errorf("SOCI index %v does not point to a manifest", sociIndexDesc)
+			continue
+		}
+		manifestDesc := manifests[manifestIdx]
+		if manifestDesc.Annotations == nil {
+			t.Errorf("manifest desc %v has no annotations", manifestDesc)
+			continue
+		}
+		if dg, ok := manifestDesc.Annotations[soci.ImageAnnotationSociIndexDigest]; !ok || dg != sociIndexDesc.Digest.String() {
+			t.Errorf("manifest desc %v does not contain expected soci index digest %v", manifestDesc, sociIndexDesc.Digest)
+		}
+		if manifestDesc.Platform == nil {
+			t.Errorf("manifest desc %v does not contain platform", manifestDesc)
+			continue
+		}
+		if manifestDesc.Platform.OS != sociIndexDesc.Platform.OS || manifestDesc.Platform.Architecture != sociIndexDesc.Platform.Architecture {
+			t.Errorf("manifest desc %v does not match SOCI platform %v", manifestDesc, sociIndexDesc.Platform)
+		}
+
+		var manifest ocispec.Manifest
+		manifestBytes := sh.O("ctr", "content", "get", manifestDesc.Digest.String())
+		if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+			t.Errorf("failed to decode manifest: %v", err)
+			continue
+		}
+		if manifest.Annotations == nil {
+			t.Errorf("manifest %v has no annotations", manifest)
+			continue
+		}
+		if dg, ok := manifest.Annotations[soci.ImageAnnotationSociIndexDigest]; !ok || dg != sociIndexDesc.Digest.String() {
+			t.Errorf("manifest %v does not contain expected soci index digest %v", manifestDesc, sociIndexDesc.Digest)
+		}
+	}
+}
+
+func TestConvert(t *testing.T) {
+	sh, done := newSnapshotterBaseShell(t)
+	defer done()
+
+	t.Run("basic conversion", func(t *testing.T) {
+		for _, imageName := range convertImages {
+			t.Run(imageName, func(t *testing.T) {
+				rebootContainerd(t, sh, "", "")
+				imgRef := dockerhub(imageName).ref
+				convertedRef := imgRef + "-soci"
+
+				sh.X("nerdctl", "pull", "--all-platforms", imgRef)
+				sh.X("soci", "convert", "--min-layer-size", "0", imgRef, convertedRef)
+
+				imgDigest := getImageDigest(sh, imgRef)
+				convertedDigest := getImageDigest(sh, convertedRef)
+
+				validateConversion(t, sh, imgDigest, convertedDigest)
+			})
+		}
+	})
+
+	t.Run("conversion idempotency", func(t *testing.T) {
+		for _, imageName := range convertImages {
+			t.Run(imageName, func(t *testing.T) {
+				rebootContainerd(t, sh, "", "")
+				imgRef := dockerhub(imageName).ref
+				convertedRef1 := imgRef + "-soci"
+				convertedRef2 := imgRef + "-soci-2"
+
+				sh.X("nerdctl", "pull", "--all-platforms", imgRef)
+				sh.X("soci", "convert", imgRef, convertedRef1)
+				sh.X("soci", "convert", convertedRef1, convertedRef2)
+
+				convertedDigest1 := getImageDigest(sh, convertedRef1)
+				convertedDigest2 := getImageDigest(sh, convertedRef2)
+				if convertedDigest1 != convertedDigest2 {
+					t.Fatalf("converting an image that was already soci enabled was not idempotent: %s != %s", convertedDigest1, convertedDigest2)
+				}
+			})
+		}
+	})
+
+	t.Run("single platform conversion", func(t *testing.T) {
+		images := []string{cloudwatchAgentx86ImageRef}
+		for _, imgRef := range images {
+			t.Run(imgRef, func(t *testing.T) {
+				rebootContainerd(t, sh, "", "")
+				convertedRef := imgRef + "-soci"
+
+				sh.X("nerdctl", "pull", "--platform", "linux/amd64", imgRef)
+				sh.X("soci", "convert", imgRef, convertedRef)
+
+				imgDigest := getImageDigest(sh, imgRef)
+				convertedDigest := getImageDigest(sh, convertedRef)
+
+				validateConversion(t, sh, imgDigest, convertedDigest)
+			})
+		}
+	})
+
+	t.Run("convert and replace", func(t *testing.T) {
+		for _, imageName := range convertImages {
+			t.Run(imageName, func(t *testing.T) {
+				rebootContainerd(t, sh, "", "")
+				imgRef := dockerhub(imageName).ref
+
+				originalDigest := getImageDigest(sh, imgRef)
+
+				sh.X("nerdctl", "pull", "--all-platforms", imgRef)
+				sh.X("soci", "convert", imgRef, imgRef)
+
+				imgDigest := getImageDigest(sh, imgRef)
+
+				validateConversion(t, sh, originalDigest, imgDigest)
+			})
+		}
+	})
+
+}
+
+func TestConvertAndPush(t *testing.T) {
+	registryConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, registryConfig)
+	defer done()
+	for _, imageName := range convertImages {
+		t.Run(imageName, func(t *testing.T) {
+			rebootContainerd(t, sh, "", "")
+			img := dockerhub(imageName)
+			convertedImg := registryConfig.mirror(imageName)
+
+			sh.X("nerdctl", "pull", "--all-platforms", img.ref)
+			sh.X("soci", "convert", img.ref, convertedImg.ref)
+			sh.X("nerdctl", "login", "--username", registryConfig.user, "--password", registryConfig.pass, convertedImg.ref)
+			sh.X("nerdctl", "push", "--all-platforms", convertedImg.ref)
+		})
+	}
+}

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -401,7 +401,7 @@ func buildIndexByManipulatingZtocData(sh *shell.Shell, indexDigest string, manip
 		if err != nil {
 			return "", fmt.Errorf("unable to marshal ztoc %s: %s", newZtocDesc.Digest.String(), err)
 		}
-		err = testutil.InjectContentStoreContentFromReader(sh, config.DefaultContentStoreType, newZtocDesc, newZtocReader)
+		err = testutil.InjectContentStoreContentFromReader(sh, config.DefaultContentStoreType, indexDigest, newZtocDesc, newZtocReader)
 		if err != nil {
 			return "", fmt.Errorf("cannot inject manipulated ztoc %s: %w", newZtocDesc.Digest.String(), err)
 		}
@@ -424,7 +424,7 @@ func buildIndexByManipulatingZtocData(sh *shell.Shell, indexDigest string, manip
 
 	newIndexDigest := digest.FromBytes(b)
 	desc := ocispec.Descriptor{Digest: newIndexDigest}
-	err = testutil.InjectContentStoreContentFromBytes(sh, config.DefaultContentStoreType, desc, b)
+	err = testutil.InjectContentStoreContentFromBytes(sh, config.DefaultContentStoreType, indexDigest, desc, b)
 	if err != nil {
 		return "", err
 	}

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -260,12 +260,6 @@ func TestFuseOperationFailureMetrics(t *testing.T) {
 }
 
 func TestFuseOperationCountMetrics(t *testing.T) {
-	var withFuseWaitDuration = func(i int64) snapshotterConfigOpt {
-		return func(c *config.Config) {
-			c.ServiceConfig.FSConfig.FuseMetricsEmitWaitDurationSec = i
-		}
-	}
-
 	registryConfig := newRegistryConfig()
 	sh, done := newShellWithRegistry(t, registryConfig)
 	defer done()
@@ -416,7 +410,7 @@ func buildIndexByManipulatingZtocData(sh *shell.Shell, indexDigest string, manip
 		Size:   index.Subject.Size,
 	}
 
-	newIndex := soci.NewIndex(newZtocDescs, &subject, nil)
+	newIndex := soci.NewIndex(soci.V1, newZtocDescs, &subject, nil)
 	b, err := soci.MarshalIndex(newIndex)
 	if err != nil {
 		return "", err

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -510,7 +510,7 @@ func TestPullWithAribtraryBlobInvalidZtocFormat(t *testing.T) {
 			Digest: digest.Digest(imgDigest),
 			Size:   int64(len(imgBytes)),
 		}
-		index := soci.NewIndex(ztocDescs, &subject, nil)
+		index := soci.NewIndex(soci.V1, ztocDescs, &subject, nil)
 
 		b, err := soci.MarshalIndex(index)
 		if err != nil {

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -129,6 +129,7 @@ func TestRunMultipleContainers(t *testing.T) {
 				copyImage(sh, dockerhub(container.containerImage), regConfig.mirror(container.containerImage))
 				// Pull image, create SOCI index
 				indexDigest := buildIndex(sh, regConfig.mirror(container.containerImage), withMinLayerSize(0))
+				sh.X("soci", "push", "--user", regConfig.mirror(container.containerImage).creds, regConfig.mirror(container.containerImage).ref)
 
 				sh.X(append(imagePullCmd, "--soci-index-digest", indexDigest, regConfig.mirror(container.containerImage).ref)...)
 			}
@@ -421,6 +422,7 @@ func TestRestartAfterSigint(t *testing.T) {
 	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, withTCPMetrics))
 	copyImage(sh, dockerhub(containerImage), regConfig.mirror(containerImage))
 	indexDigest := buildIndex(sh, regConfig.mirror(containerImage), withMinLayerSize(0), withSpanSize(100*1024))
+	sh.X("soci", "push", "--user", regConfig.creds(), regConfig.mirror(containerImage).ref)
 	sh.X(append(imagePullCmd, "--soci-index-digest", indexDigest, regConfig.mirror(containerImage).ref)...)
 	testutil.KillMatchingProcess(sh, "soci-snapshotter-grpc")
 

--- a/integration/util_soci_test.go
+++ b/integration/util_soci_test.go
@@ -175,7 +175,7 @@ func validateSociIndex(sh *shell.Shell, contentStoreType store.ContentStoreType,
 	}
 
 	expectedAnnotations := map[string]string{
-		soci.IndexAnnotationBuildToolIdentifier: "AWS SOCI CLI v0.1",
+		soci.IndexAnnotationBuildToolIdentifier: "AWS SOCI CLI v0.2",
 	}
 
 	if diff := cmp.Diff(sociIndex.Annotations, expectedAnnotations); diff != "" {

--- a/soci/soci_convert.go
+++ b/soci/soci_convert.go
@@ -1,0 +1,317 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package soci
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+
+	"github.com/awslabs/soci-snapshotter/soci/store"
+	"github.com/awslabs/soci-snapshotter/util/ociutil"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/platforms"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
+)
+
+type ConvertOption func(*convertConfig) error
+
+type convertConfig struct {
+	platforms []ocispec.Platform
+	gcRoot    bool
+}
+
+// ConvertWithPlatforms sets the platforms that will be indexed during conversion
+func ConvertWithPlatforms(platforms ...ocispec.Platform) ConvertOption {
+	return func(cc *convertConfig) error {
+		cc.platforms = platforms
+		return nil
+	}
+}
+
+// ConvertWithNoGarbageCollectionLabels disables adding a containerd root gc label
+// to the converted image and SOCI indexes. The caller is responsible for ensuring the OCI Index
+// doesn't get garbage collected.
+func ConvertWithNoGarbageCollectionLabels() ConvertOption {
+	return func(cc *convertConfig) error {
+		cc.gcRoot = false
+		return nil
+	}
+}
+
+// Convert converts an image into a SOCI enabled image.
+//
+// At a high level, this process:
+// 1. Creates a SOCI index for each platform (unless overridden by ConvertWithPlatforms)
+// 2. Adds an annotation to each image with the SOCI index digest
+// 3. Appends the SOCI indexes to the list of manifests in the OCI index
+//
+// Notes:
+// Adding an annotation to an image changes the image digest. This is equivalent to creating a new image.
+// This function will serialize and push the new image manifest to the content store and replaces the original
+// image in the OCI index. The layers will be shared, not duplicated.
+//
+// If the image is a single platform image, this function will create an OCI index so that it can bundle the
+// image and SOCI index into a single artifact.
+func (b *IndexBuilder) Convert(ctx context.Context, img images.Image, opts ...ConvertOption) (*ocispec.Descriptor, error) {
+	allPlatforms, err := images.Platforms(ctx, b.contentStore, img.Target)
+	if err != nil {
+		return nil, err
+	}
+	if len(allPlatforms) == 0 {
+		return nil, errors.New("image does not support any platforms")
+	}
+	if images.IsManifestType(img.Target.MediaType) && img.Target.Platform == nil {
+		// If the image's target descriptor is a single manifest, then it will not
+		// contain a platform because that information is stored in the image config instead.
+		// If we directly use this descriptor in the converted image,
+		// runtimes will not be able to pull the correct manifest.
+		// We know the actual platform by inspecting the image config in `images.Platforms`,
+		// so we add that to the target descriptor.
+		img.Target.Platform = &allPlatforms[0]
+	}
+	convertCfg := convertConfig{
+		platforms: allPlatforms,
+		gcRoot:    true,
+	}
+	for _, opt := range opts {
+		err := opt(&convertCfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+	convertCfg.platforms = ociutil.DedupePlatforms(convertCfg.platforms)
+
+	// Initialize the OCI Index
+	ociIndex, err := b.newOciIndex(ctx, img)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the SOCI Indexes
+	indexes, err := b.buildSociIndexesv2ForPlatforms(ctx, img, convertCfg.platforms)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add Annotations to the image manifests
+	err = b.annotateImages(ctx, &ociIndex, indexes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add SOCI indexes to OCI index
+	err = b.addSociIndexes(ctx, &ociIndex, indexes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Serialize the OCI Index
+	ociIndexDesc, err := b.pushOCIObject(ctx, &ociIndex)
+	ociIndexDesc.MediaType = ocispec.MediaTypeImageIndex
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply GC Labels
+	for i, desc := range ociIndex.Manifests {
+		err := store.LabelGCRefContent(ctx, b.blobStore, ociIndexDesc, fmt.Sprintf("m.%d", i), desc.Digest.String())
+		if err != nil {
+			return nil, err
+		}
+	}
+	if convertCfg.gcRoot {
+		err := store.LabelGCRoot(ctx, b.blobStore, ociIndexDesc)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &ociIndexDesc, nil
+}
+
+// buildSociIndexesv2ForPlatforms builds a SOCI index for each specified platform
+func (b *IndexBuilder) buildSociIndexesv2ForPlatforms(ctx context.Context, img images.Image, platforms []ocispec.Platform) ([]*IndexWithMetadata, error) {
+	var indexes []*IndexWithMetadata
+	for _, platform := range platforms {
+		index, err := b.Build(ctx, img,
+			WithPlatform(platform),
+			// Don't set a GC label on the SOCI indexes because their GC will be attached to
+			// the converted image's OCI index. If we label them, they will not get
+			// gcd with the rest of the converted image
+			WithNoGarbageCollectionLabel(),
+			withIndexVersion(V2),
+		)
+		if err != nil {
+			// If a platform produces an empty index, try other platforms.
+			// This is unlikely, but could happen if one platform doesn't have
+			// any layers larger than min layer size. We should still try to index
+			// other platforms.
+			if errors.Is(err, ErrEmptyIndex) {
+				continue
+			}
+			return nil, err
+		}
+		indexes = append(indexes, index)
+	}
+
+	// If we didn't produce any indexes, return that as an error
+	if len(indexes) == 0 {
+		return nil, ErrEmptyIndex
+	}
+	return indexes, nil
+}
+
+// newOciIndex creates an OCI index object for the converted image.
+// If `img.Target` is already an OCI index (or docker manifest list), newOciIndex loads that index,
+// otherwise, it creates a new OCI index containing just the single image target.
+func (b *IndexBuilder) newOciIndex(ctx context.Context, img images.Image) (ocispec.Index, error) {
+	if images.IsIndexType(img.Target.MediaType) {
+		// Load the original target
+		ra, err := b.contentStore.ReaderAt(ctx, img.Target)
+		if err != nil {
+			return ocispec.Index{}, err
+		}
+		b, err := io.ReadAll(io.NewSectionReader(ra, 0, ra.Size()))
+		if err != nil {
+			return ocispec.Index{}, err
+		}
+		err = ociutil.ValidateMediaType(b, img.Target.MediaType)
+		if err != nil {
+			return ocispec.Index{}, err
+		}
+
+		var ociIndex ocispec.Index
+		err = json.Unmarshal(b, &ociIndex)
+		// Some Registries don't like it when you push a Docker v2 manifest
+		// To increase compatibility, change the media type to OCI image manifest
+		ociIndex.MediaType = ocispec.MediaTypeImageIndex
+		return ociIndex, err
+	}
+	return ocispec.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{
+			img.Target,
+		},
+	}, nil
+}
+
+// annotateImages adds the SOCI index digest to the corresponding image manifest descriptor, modifying `ociIndex` in the process.
+// Adding annotations modifies the image manifest, so annotateImages also pushes the modified image manifests to the blobStore,
+// computes the new image digests, and modified the image descriptors in `ociIndex`
+func (b *IndexBuilder) annotateImages(ctx context.Context, ociIndex *ocispec.Index, sociIndexes []*IndexWithMetadata) error {
+	for i := 0; i < len(ociIndex.Manifests); i++ {
+		manifestDesc := &ociIndex.Manifests[i]
+		// images.Manifest validates the mediatype, no need to do it ourselves like
+		// we did when loading the OCI index
+		manifest, err := images.Manifest(ctx, b.contentStore, *manifestDesc, nil)
+		if err != nil {
+			return err
+		}
+		// Some Registries don't like mixing Docker V2 manifests with OCI image manifests.
+		// Since we use ArtifactTypes for SOCI indexes, we will use OCI image manifests everywhere to increase compatibility.
+		// Registries don't seem to be as picky about layer and config types
+		manifest.MediaType = ocispec.MediaTypeImageManifest
+
+		idx := slices.IndexFunc(sociIndexes, func(i *IndexWithMetadata) bool { return i.ManifestDesc.Digest == manifestDesc.Digest })
+		if idx >= 0 {
+			indexWithMetadata := sociIndexes[idx]
+
+			if manifest.Annotations == nil {
+				manifest.Annotations = make(map[string]string)
+			}
+			manifest.Annotations[ImageAnnotationSociIndexDigest] = indexWithMetadata.Desc.Digest.String()
+		}
+
+		newManifestDesc, err := b.pushOCIObject(ctx, manifest)
+		if err != nil {
+			return err
+		}
+
+		// Modify the original
+		manifestDesc.Digest = newManifestDesc.Digest
+		manifestDesc.Size = newManifestDesc.Size
+		manifestDesc.Annotations = manifest.Annotations
+		manifestDesc.MediaType = ocispec.MediaTypeImageManifest
+
+		if idx >= 0 {
+			indexWithMetadata := sociIndexes[idx]
+			if indexWithMetadata.Desc.Annotations == nil {
+				indexWithMetadata.Desc.Annotations = make(map[string]string)
+			}
+			indexWithMetadata.Desc.Annotations[IndexAnnotationImageManifestDigest] = manifestDesc.Digest.String()
+		}
+	}
+	return nil
+}
+
+// addSociIndexes modifies the list of manifests in the OCI index to include the SOCI indexes.
+// If the OCI index already contains a SOCI index for the same platform, the old SOCI index is replaced,
+// otherwise, the SOCI index is appended to list of manifests.
+func (b *IndexBuilder) addSociIndexes(_ context.Context, ociIndex *ocispec.Index, sociIndexes []*IndexWithMetadata) error {
+	for _, indexWithMetadata := range sociIndexes {
+		desc := indexWithMetadata.Desc
+		desc.Platform = indexWithMetadata.Platform
+
+		if indexWithMetadata.Platform == nil {
+			return fmt.Errorf("index does not have a valid platform")
+		}
+		sociIndexPlatform := platforms.Normalize(*indexWithMetadata.Platform)
+		matcher := platforms.OnlyStrict(sociIndexPlatform)
+		i := slices.IndexFunc(ociIndex.Manifests, func(desc ocispec.Descriptor) bool {
+			return desc.ArtifactType == SociIndexArtifactTypeV2 && desc.Platform != nil && matcher.Match(*desc.Platform)
+		})
+
+		if i >= 0 {
+			ociIndex.Manifests[i] = desc
+		} else {
+			ociIndex.Manifests = append(ociIndex.Manifests, desc)
+		}
+	}
+
+	return nil
+}
+
+// pushOCIObject serializes and pushes an OCI object (manifest or OCI index) to the blobStore.
+// It returns the descriptor of the object that was pushed which will only contain the digest and size.
+// It is up to the caller to set other information (MediaType, ArtifactType, Platform, etc) as needed.
+func (b *IndexBuilder) pushOCIObject(ctx context.Context, obj any) (ocispec.Descriptor, error) {
+	bs, err := json.Marshal(obj)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	dg := digest.FromBytes(bs)
+	desc := ocispec.Descriptor{
+		Digest: dg,
+		Size:   int64(len(bs)),
+	}
+	err = b.blobStore.Push(ctx, desc, bytes.NewReader(bs))
+	if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return ocispec.Descriptor{}, err
+	}
+	return desc, nil
+}

--- a/soci/soci_convert_test.go
+++ b/soci/soci_convert_test.go
@@ -1,0 +1,172 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package soci
+
+import (
+	"context"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+var (
+	linuxX86 = &ocispec.Platform{
+		Architecture: "amd64",
+		OS:           "linux",
+	}
+
+	imageDesc = ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:1234",
+		Size:      1234,
+		Platform:  linuxX86,
+	}
+
+	sociIndexDesc = ocispec.Descriptor{
+		MediaType:    ocispec.MediaTypeImageManifest,
+		ArtifactType: SociIndexArtifactTypeV2,
+		Digest:       "sha256:5678",
+		Size:         5678,
+	}
+
+	sociIndexDesc2 = ocispec.Descriptor{
+		MediaType:    ocispec.MediaTypeImageManifest,
+		ArtifactType: SociIndexArtifactTypeV2,
+		Digest:       "sha256:9999",
+		Size:         9999,
+	}
+
+	sociIndexDescWithPlatform  = sociIndexDesc
+	sociIndexDesc2WithPlatform = sociIndexDesc2
+)
+
+func init() {
+	sociIndexDescWithPlatform.Platform = linuxX86
+	sociIndexDesc2WithPlatform.Platform = linuxX86
+}
+
+func TestAddSociIndexes(t *testing.T) {
+	tests := []struct {
+		name        string
+		ociIndex    ocispec.Index
+		sociIndexes []IndexWithMetadata
+		expected    ocispec.Index
+	}{
+		{
+			name: "add soci index",
+			ociIndex: ocispec.Index{
+				MediaType: ocispec.MediaTypeImageIndex,
+				Manifests: []ocispec.Descriptor{imageDesc},
+			},
+			sociIndexes: []IndexWithMetadata{
+				{
+					Desc:     sociIndexDesc,
+					Platform: linuxX86,
+				},
+			},
+			expected: ocispec.Index{
+				MediaType: ocispec.MediaTypeImageIndex,
+				Manifests: []ocispec.Descriptor{
+					imageDesc,
+					sociIndexDescWithPlatform,
+				},
+			},
+		},
+		{
+			name: "add existing soci index to an oci index",
+			ociIndex: ocispec.Index{
+				MediaType: ocispec.MediaTypeImageIndex,
+				Manifests: []ocispec.Descriptor{
+					imageDesc,
+					sociIndexDescWithPlatform,
+				},
+			},
+			sociIndexes: []IndexWithMetadata{
+				{
+					Desc:     sociIndexDesc,
+					Platform: linuxX86,
+				},
+			},
+			expected: ocispec.Index{
+				MediaType: ocispec.MediaTypeImageIndex,
+				Manifests: []ocispec.Descriptor{
+					imageDesc,
+					sociIndexDescWithPlatform,
+				},
+			},
+		},
+		{
+			name: "replace existing soci index in an oci index",
+			ociIndex: ocispec.Index{
+				MediaType: ocispec.MediaTypeImageIndex,
+				Manifests: []ocispec.Descriptor{
+					imageDesc,
+					sociIndexDescWithPlatform,
+				},
+			},
+			sociIndexes: []IndexWithMetadata{
+				{
+					Desc:     sociIndexDesc2,
+					Platform: linuxX86,
+				},
+			},
+			expected: ocispec.Index{
+				MediaType: ocispec.MediaTypeImageIndex,
+				Manifests: []ocispec.Descriptor{
+					imageDesc,
+					sociIndexDesc2WithPlatform,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			builder := IndexBuilder{}
+			actual := test.ociIndex
+			var indexes []*IndexWithMetadata
+			for _, index := range test.sociIndexes {
+				indexes = append(indexes, &index)
+			}
+			err := builder.addSociIndexes(context.Background(), &actual, indexes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if len(actual.Manifests) != len(test.expected.Manifests) {
+				t.Errorf("expected %d manifests, got %d", len(test.expected.Manifests), len(actual.Manifests))
+			}
+			for i, manifest := range actual.Manifests {
+				if manifest.Digest != test.expected.Manifests[i].Digest {
+					t.Errorf("expected digest %s, got %s", test.expected.Manifests[i].Digest, manifest.Digest)
+				}
+				if manifest.MediaType != test.expected.Manifests[i].MediaType {
+					t.Errorf("expected media type %s, got %s", test.expected.Manifests[i].MediaType, manifest.MediaType)
+				}
+				if manifest.ArtifactType != test.expected.Manifests[i].ArtifactType {
+					t.Errorf("expected artifact type %s, got %s", test.expected.Manifests[i].ArtifactType, manifest.ArtifactType)
+				}
+				if manifest.Platform.Architecture != test.expected.Manifests[i].Platform.Architecture {
+					t.Errorf("expected architecture %s, got %s", test.expected.Manifests[i].Platform.Architecture, manifest.Platform.Architecture)
+				}
+				if manifest.Platform.OS != test.expected.Manifests[i].Platform.OS {
+					t.Errorf("expected OS %s, got %s", test.expected.Manifests[i].Platform.OS, manifest.Platform.OS)
+				}
+			}
+		})
+	}
+
+}

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -329,7 +329,7 @@ func TestNewIndex(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			index := NewIndex(tc.blobs, &tc.subject, tc.annotations)
+			index := NewIndex(V1, tc.blobs, &tc.subject, tc.annotations)
 
 			if diff := cmp.Diff(index.Blobs, tc.blobs); diff != "" {
 				t.Fatalf("unexpected blobs; diff = %v", diff)
@@ -377,7 +377,7 @@ func TestDecodeIndex(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			index := NewIndex(tc.blobs, &tc.subject, tc.annotations)
+			index := NewIndex(V1, tc.blobs, &tc.subject, tc.annotations)
 			jsonBytes, err := MarshalIndex(index)
 			if err != nil {
 				t.Fatalf("cannot convert index to json byte data: %v", err)
@@ -417,8 +417,13 @@ func TestMarshalIndex(t *testing.T) {
 		ty    interface{}
 	}{
 		{
-			name:  "successfully roundtrip as Image Manifest",
-			index: NewIndex(blobs, &subject, annotations),
+			name:  "successfully roundtrip a v1 SOCI index",
+			index: NewIndex(V1, blobs, &subject, annotations),
+			ty:    ocispec.Manifest{},
+		},
+		{
+			name:  "successfully roundtrip a v2 SOCI index",
+			index: NewIndex(V2, blobs, nil, annotations),
 			ty:    ocispec.Manifest{},
 		},
 	}

--- a/util/ociutil/ociutil.go
+++ b/util/ociutil/ociutil.go
@@ -1,0 +1,91 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ociutil
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// UnknownDocument represents a manifest, manifest list, or index that has not
+// yet been validated.
+// Copied from https://github.com/containerd/containerd/blob/d5534c6014534e02a0893dd6894d88130f45ae02/core/images/image.go#L381
+type UnknownDocument struct {
+	MediaType string          `json:"mediaType,omitempty"`
+	Config    json.RawMessage `json:"config,omitempty"`
+	Layers    json.RawMessage `json:"layers,omitempty"`
+	Manifests json.RawMessage `json:"manifests,omitempty"`
+	FSLayers  json.RawMessage `json:"fsLayers,omitempty"` // schema 1
+}
+
+// ValidateMediaType returns an error if the byte slice is invalid JSON,
+// if the format of the blob is not supported, or if the media type
+// identifies the blob as one format, but it identifies itself as, or
+// contains elements of another format.
+// Copied from https://github.com/containerd/containerd/blob/d5534c6014534e02a0893dd6894d88130f45ae02/core/images/image.go#L393
+func ValidateMediaType(b []byte, mt string) error {
+	var doc UnknownDocument
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return err
+	}
+	if len(doc.FSLayers) != 0 {
+		return fmt.Errorf("media-type: schema 1 not supported")
+	}
+	if images.IsManifestType(mt) && (len(doc.Manifests) != 0 || images.IsIndexType(doc.MediaType)) {
+		return fmt.Errorf("media-type: expected manifest but found index (%s)", mt)
+	} else if images.IsIndexType(mt) && (len(doc.Config) != 0 || len(doc.Layers) != 0 || images.IsManifestType(doc.MediaType)) {
+		return fmt.Errorf("media-type: expected index but found manifest (%s)", mt)
+	}
+	return nil
+}
+
+func DedupePlatforms(ps []ocispec.Platform) []ocispec.Platform {
+	var matchers []platforms.Matcher
+	var res []ocispec.Platform
+
+NextPlatform:
+	for _, p := range ps {
+		for _, m := range matchers {
+			if m.Match(platforms.Normalize(p)) {
+				continue NextPlatform
+			}
+		}
+		res = append(res, p)
+		matchers = append(matchers, platforms.OnlyStrict(platforms.Normalize(p)))
+	}
+	return res
+}

--- a/util/ociutil/ociutil_test.go
+++ b/util/ociutil/ociutil_test.go
@@ -1,0 +1,108 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ociutil
+
+import (
+	"slices"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func assertPlatformEqual(t *testing.T, expected ocispec.Platform, actual ocispec.Platform) {
+	if expected.OS != actual.OS {
+		t.Fatalf("OS did not match. Expected %v, Got %v", expected.OS, actual.OS)
+	}
+	if expected.OSVersion != actual.OSVersion {
+		t.Fatalf("OSVersion did not match. Expected %v, Got %v", expected.OSVersion, actual.OSVersion)
+	}
+	if !slices.Equal(expected.OSFeatures, actual.OSFeatures) {
+		t.Fatalf("OSFeatures did not match. Expected %v, Got %v", expected.OSFeatures, actual.OSFeatures)
+	}
+	if expected.Architecture != actual.Architecture {
+		t.Fatalf("Architecture did not match. Expected %v, Got %v", expected.Architecture, actual.Architecture)
+	}
+	if expected.Variant != actual.Variant {
+		t.Fatalf("Variant did not match. Expected %v, Got %v", expected.Variant, actual.Variant)
+	}
+}
+
+func TestDedupePlatforms(t *testing.T) {
+	LinuxX86 := ocispec.Platform{
+		OS:           "linux",
+		Architecture: "amd64",
+	}
+	Linuxi386 := ocispec.Platform{
+		OS:           "linux",
+		Architecture: "386",
+	}
+	LinuxX86Denormalized := ocispec.Platform{
+		OS:           "linux",
+		Architecture: "x86_64",
+	}
+
+	tests := []struct {
+		name      string
+		platforms []ocispec.Platform
+		expected  []ocispec.Platform
+	}{
+		{
+			name: "no duplicates results in no change",
+			platforms: []ocispec.Platform{
+				LinuxX86,
+				Linuxi386,
+			},
+			expected: []ocispec.Platform{
+				LinuxX86,
+				Linuxi386,
+			},
+		},
+		{
+			name: "exact duplicates are removed",
+			platforms: []ocispec.Platform{
+				LinuxX86,
+				LinuxX86,
+			},
+			expected: []ocispec.Platform{
+				LinuxX86,
+			},
+		},
+		{
+			name: "denormalized duplciates are removed",
+			platforms: []ocispec.Platform{
+				LinuxX86,
+				LinuxX86Denormalized,
+			},
+			expected: []ocispec.Platform{
+				LinuxX86,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := DedupePlatforms(test.platforms)
+			if len(actual) != len(test.expected) {
+				t.Fatalf("unexpected number of dedupe platforms, expected %d, actual %d. Result: %v", len(test.expected), len(actual), actual)
+			}
+			for i := range actual {
+				assertPlatformEqual(t, test.expected[i], actual[i])
+			}
+		})
+	}
+
+}

--- a/util/testutil/shell.go
+++ b/util/testutil/shell.go
@@ -252,7 +252,10 @@ func injectContainerdContentStoreContentFromReader(sh *shell.Shell, desc ocispec
 	if err := cmd.Run(); err != nil {
 		return err
 	}
-	cmd = sh.Command("ctr", "content", "label", desc.Digest.String(), "")
+	// Labelling the content root is not the right thing to do. We should build the proper set of references
+	// back to an image under a lease, but this should at least be safe because integration containers are
+	// ephemeral for the single test.
+	cmd = sh.Command("ctr", "content", "label", desc.Digest.String(), "containerd.io/gc.root")
 	return cmd.Run()
 }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change adds a command to convert an image to a SOCI-enabled image which contains strong references to both the image and SOCI index in a logically single, deployable artifact.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
