### PR TITLE
ci: add containerd-2.1.0-rc.0 to integration test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
-        containerd: ["1.6.38", "1.7.27", "2.0.4"]
+        containerd: ["1.6.38", "1.7.27", "2.0.4", "2.1.0-rc.0"]
     env:
       DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"
     steps:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The first release candidate for containerd 2.1 is available.

See https://github.com/containerd/containerd/releases/tag/v2.1.0-rc.0

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
