### PR TITLE
Fix config mediatype in Convert

### DIFF
--- a/integration/convert_test.go
+++ b/integration/convert_test.go
@@ -80,6 +80,14 @@ func validateConversion(t *testing.T, sh *shell.Shell, originalDigest, converted
 			continue
 		}
 		manifestDesc := manifests[manifestIdx]
+		if manifestDesc.MediaType != ocispec.MediaTypeImageManifest {
+			t.Errorf("manifest desc %v is not an image manifest", manifestDesc)
+			continue
+		}
+		if manifestDesc.ArtifactType != "" {
+			t.Errorf("manifest desc %v has an artifact type", manifestDesc)
+			continue
+		}
 		if manifestDesc.Annotations == nil {
 			t.Errorf("manifest desc %v has no annotations", manifestDesc)
 			continue
@@ -99,6 +107,18 @@ func validateConversion(t *testing.T, sh *shell.Shell, originalDigest, converted
 		manifestBytes := sh.O("ctr", "content", "get", manifestDesc.Digest.String())
 		if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
 			t.Errorf("failed to decode manifest: %v", err)
+			continue
+		}
+		if manifest.MediaType != ocispec.MediaTypeImageManifest {
+			t.Errorf("manifest %v is not an image manifest", manifest)
+			continue
+		}
+		if manifest.ArtifactType != "" {
+			t.Errorf("manifest %v has an artifact type", manifest)
+			continue
+		}
+		if manifest.Config.MediaType != ocispec.MediaTypeImageConfig {
+			t.Errorf("manifest %v has a non-OCI config", manifest)
 			continue
 		}
 		if manifest.Annotations == nil {

--- a/soci/soci_convert.go
+++ b/soci/soci_convert.go
@@ -234,8 +234,13 @@ func (b *IndexBuilder) annotateImages(ctx context.Context, ociIndex *ocispec.Ind
 		}
 		// Some Registries don't like mixing Docker V2 manifests with OCI image manifests.
 		// Since we use ArtifactTypes for SOCI indexes, we will use OCI image manifests everywhere to increase compatibility.
-		// Registries don't seem to be as picky about layer and config types
+		// We also convert the config if necesssary to make sure it also has an OCI media type. If the config and image
+		// don't agree on OCI vs Docker, registries might think it's some sort of unknown, non-image artifact.
+		// Registries don't seem to be as picky about layers.
 		manifest.MediaType = ocispec.MediaTypeImageManifest
+		// The config itself doesn't have a mediatype, so we only need to update the manifest's descriptor.
+		// We also aren't modifying image contents at all, so we don't need to modify the config contents.
+		manifest.Config.MediaType = ocispec.MediaTypeImageConfig
 
 		idx := slices.IndexFunc(sociIndexes, func(i *IndexWithMetadata) bool { return i.ManifestDesc.Digest == manifestDesc.Digest })
 		if idx >= 0 {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Converting an image to a soci-enabled image also converts docker v2 images to oci v1 images. Before this change, we didn't change the image config's mediatype meaning the image would claim it is an OCI v1 image while the config would claim it's a Docker v2 image. This caused some registries to interpret this as a non-image artifact. This change sets the config media type to be a OCI v1 config.


**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
