### PR TITLE
Run benchmark workflows on change

### DIFF
--- a/.github/workflows/benchmark-visualization.yml
+++ b/.github/workflows/benchmark-visualization.yml
@@ -7,13 +7,19 @@ on:
       - '**'
       - '!docs/**' # ignore docs changes
       - '!**.md' # ignore markdown changes
+  pull_request:
+    branches: ['main']
+    paths:
+      - '.github/workflows/benchmark-visualization.yml'
+      - 'benchmark/**'
+      - 'Makefile'
 
 permissions:
   contents: write
   deployments: write
 
 env:
-  GO_VERSION: '1.22.11'
+  GO_VERSION: '1.23.7'
 
 jobs:
   benchmark:
@@ -66,6 +72,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.files }}
 
   push-benchmark-result-gh-pages:
+    if: github.event_name == 'push'
     name: Push benchmark result to Github-pages
     runs-on: ubuntu-22.04
     needs: download-and-convert-benchmark-result-to-visualization-data

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -3,6 +3,12 @@ name: Comparision Tests
 on:
   schedule:
     - cron: "0 0 */2 * *" # every 2 days
+  pull_request:
+    branches: ['main']
+    paths:
+      - '.github/workflows/comparison-test.yml'
+      - 'benchmark/**'
+      - 'Makefile'
 
 env:
   GO_VERSION: '1.23.7'


### PR DESCRIPTION
**Issue #, if available:**
Closes #911 (final step)

**Description of changes:**
Added tests so that benchmarks/comparison tests will run when either workflow is modified, if the benchmark folder is touched, or if the Makefile is touched.

I considered making it so `benchmark-visualization.yml` and `comparison-test.yml` would both run when either file was touched (since comparison-test just runs `make benchmark`) but it seemed a little extra — both should run if any actual benchmarks get modified anyway, and if the Makefile target changes.

While I had the hood open, I also changed the benchmark workflow file name for consistency, and bumped the Go version (seems we missed it last time we did a Go version upgrade)

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
