### PR TITLE
Add SOCI CLI root flag

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/service"
 	"github.com/awslabs/soci-snapshotter/service/keychain/cri/v1"
 	crialpha "github.com/awslabs/soci-snapshotter/service/keychain/cri/v1alpha"
+	"github.com/awslabs/soci-snapshotter/soci"
 
 	"github.com/awslabs/soci-snapshotter/service/keychain/dockerconfig"
 	"github.com/awslabs/soci-snapshotter/service/keychain/kubeconfig"
@@ -84,7 +85,6 @@ const (
 	defaultAddress    = "/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"
 	defaultConfigPath = "/etc/soci-snapshotter-grpc/config.toml"
 	defaultLogLevel   = logrus.InfoLevel
-	defaultRootDir    = "/var/lib/soci-snapshotter-grpc"
 )
 
 // logLevel of Debug or Trace may emit sensitive information
@@ -93,7 +93,7 @@ var (
 	address      = flag.String("address", defaultAddress, "address for the snapshotter's GRPC server")
 	configPath   = flag.String("config", defaultConfigPath, "path to the configuration file")
 	logLevel     = flag.String("log-level", defaultLogLevel.String(), "set the logging level [trace, debug, info, warn, error, fatal, panic]")
-	rootDir      = flag.String("root", defaultRootDir, "path to the root directory for this snapshotter")
+	rootDir      = flag.String("root", config.DefaultSociSnapshotterRootPath, "path to the root directory for this snapshotter")
 	printVersion = flag.Bool("version", false, "print the version")
 )
 
@@ -361,7 +361,7 @@ func listen(ctx context.Context, address string) (net.Listener, error) {
 
 func listenUnix(addr string) (net.Listener, error) {
 	// Prepare the directory for the socket
-	if err := os.MkdirAll(filepath.Dir(addr), 0700); err != nil {
+	if err := soci.EnsureSnapshotterRootPath(filepath.Dir(addr)); err != nil {
 		return nil, fmt.Errorf("failed to create directory %q: %w", filepath.Dir(addr), err)
 	}
 

--- a/cmd/soci/commands/convert.go
+++ b/cmd/soci/commands/convert.go
@@ -19,11 +19,9 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
-	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/containerd/containerd/errdefs"
@@ -118,23 +116,13 @@ var ConvertCommand = cli.Command{
 		}
 		spanSize := cliContext.Int64(spanSizeFlag)
 		minLayerSize := cliContext.Int64(minLayerSizeFlag)
-		// Creating the snapshotter's root path first if it does not exist, since this ensures, that
-		// it has the limited permission set as drwx--x--x.
-		// The subsequent oci.New creates a root path dir with too broad permission set.
-		if _, err := os.Stat(config.SociSnapshotterRootPath); os.IsNotExist(err) {
-			if err = os.Mkdir(config.SociSnapshotterRootPath, 0711); err != nil {
-				return err
-			}
-		} else if err != nil {
-			return err
-		}
 
 		blobStore, err := store.NewContentStore(internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
 			return err
 		}
 
-		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath())
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -19,10 +19,8 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
-	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/urfave/cli"
@@ -92,16 +90,6 @@ var CreateCommand = cli.Command{
 		}
 		spanSize := cliContext.Int64(spanSizeFlag)
 		minLayerSize := cliContext.Int64(minLayerSizeFlag)
-		// Creating the snapshotter's root path first if it does not exist, since this ensures, that
-		// it has the limited permission set as drwx--x--x.
-		// The subsequent oci.New creates a root path dir with too broad permission set.
-		if _, err := os.Stat(config.SociSnapshotterRootPath); os.IsNotExist(err) {
-			if err = os.Mkdir(config.SociSnapshotterRootPath, 0711); err != nil {
-				return err
-			}
-		} else if err != nil {
-			return err
-		}
 
 		blobStore, err := store.NewContentStore(internal.ContentStoreOptions(cliContext)...)
 		if err != nil {
@@ -113,7 +101,7 @@ var CreateCommand = cli.Command{
 			return err
 		}
 
-		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath())
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
 		if err != nil {
 			return err
 		}
@@ -127,7 +115,6 @@ var CreateCommand = cli.Command{
 		}
 
 		builder, err := soci.NewIndexBuilder(cs, blobStore, builderOpts...)
-
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -44,7 +44,7 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		db, err := soci.NewDB(soci.ArtifactsDbPath())
+		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/list.go
+++ b/cmd/soci/commands/index/list.go
@@ -132,7 +132,7 @@ var listCommand = cli.Command{
 			f = anyMatch(filters)
 		}
 
-		db, err := soci.NewDB(soci.ArtifactsDbPath())
+		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/rm.go
+++ b/cmd/soci/commands/index/rm.go
@@ -51,7 +51,7 @@ var rmCommand = cli.Command{
 			return fmt.Errorf("cannot create local content store: %w", err)
 		}
 
-		db, err := soci.NewDB(soci.ArtifactsDbPath())
+		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -99,7 +99,7 @@ if they are available in the snapshotter's local content store.
 			return err
 		}
 
-		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath())
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/rebuild_db.go
+++ b/cmd/soci/commands/rebuild_db.go
@@ -41,7 +41,7 @@ var RebuildDBCommand = cli.Command{
 		}
 		defer cancel()
 		containerdContentStore := client.ContentStore()
-		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath())
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -65,7 +65,12 @@ var getFileCommand = cli.Command{
 			return err
 		}
 
-		layerReader, err := getLayer(ctx, ztocDigest, client.ContentStore())
+		artifactsDB, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		if err != nil {
+			return err
+		}
+
+		layerReader, err := getLayer(ctx, artifactsDB, ztocDigest, client.ContentStore())
 		if err != nil {
 			return err
 		}
@@ -101,11 +106,7 @@ func getZtoc(ctx context.Context, cliContext *cli.Context, d digest.Digest) (*zt
 	return ztoc.Unmarshal(reader)
 }
 
-func getLayer(ctx context.Context, ztocDigest digest.Digest, cs content.Store) (content.ReaderAt, error) {
-	metadata, err := soci.NewDB(soci.ArtifactsDbPath())
-	if err != nil {
-		return nil, err
-	}
+func getLayer(ctx context.Context, metadata *soci.ArtifactsDb, ztocDigest digest.Digest, cs content.Store) (content.ReaderAt, error) {
 	artifact, err := metadata.GetArtifactEntry(ztocDigest.String())
 	if err != nil {
 		return nil, err

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -59,7 +59,7 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		db, err := soci.NewDB(soci.ArtifactsDbPath())
+		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/list.go
+++ b/cmd/soci/commands/ztoc/list.go
@@ -52,7 +52,7 @@ var listCommand = cli.Command{
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
-		db, err := soci.NewDB(soci.ArtifactsDbPath())
+		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/main.go
+++ b/cmd/soci/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/index"
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/ztoc"
 	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/version"
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/namespaces"
@@ -83,6 +84,11 @@ func main() {
 			Usage: "use a specific content store (soci or containerd)",
 			Value: string(config.DefaultContentStoreType),
 		},
+		cli.StringFlag{
+			Name:  "root",
+			Usage: "path to the root directory for this snapshotter",
+			Value: config.DefaultSociSnapshotterRootPath,
+		},
 	}
 
 	app.Version = fmt.Sprintf("%s %s", version.Version, version.Revision)
@@ -94,6 +100,10 @@ func main() {
 		commands.ConvertCommand,
 		commands.PushCommand,
 		commands.RebuildDBCommand,
+	}
+
+	app.Before = func(context *cli.Context) error {
+		return soci.EnsureSnapshotterRootPath(context.GlobalString("root"))
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -46,8 +46,8 @@ import (
 )
 
 const (
-	// Default path to snapshotter root dir
-	SociSnapshotterRootPath = "/var/lib/soci-snapshotter-grpc/"
+	// DefaultSociSnapshotterRootPath is the default filesystem path for the snapshotter root directory.
+	DefaultSociSnapshotterRootPath = "/var/lib/soci-snapshotter-grpc/"
 
 	defaultConfigPath = "/etc/soci-snapshotter-grpc/config.toml"
 )

--- a/soci/artifacts_test.go
+++ b/soci/artifacts_test.go
@@ -18,6 +18,7 @@ package soci
 
 import (
 	"os"
+	"sync"
 	"testing"
 
 	bolt "go.etcd.io/bbolt"
@@ -98,6 +99,12 @@ func TestGetIndexArtifactEntries(t *testing.T) {
 }
 
 func TestArtifactDB_DoesNotExist(t *testing.T) {
+	resetArtifactDBInit()
+	t.Cleanup(resetArtifactDBInit)
+	once.Do(func() {
+		// Fail db initialization.
+		db = nil
+	})
 	_, err := NewDB(ArtifactsDbPath())
 	if err == nil {
 		t.Fatalf("getArtifactEntry should fail since artifacts.db doesn't exist")
@@ -207,4 +214,9 @@ func newTestableDb() (*ArtifactsDb, error) {
 		return nil, err
 	}
 	return &ArtifactsDb{db: db}, nil
+}
+
+func resetArtifactDBInit() {
+	once = sync.Once{}
+	db = nil
 }

--- a/soci/artifacts_test.go
+++ b/soci/artifacts_test.go
@@ -98,6 +98,33 @@ func TestGetIndexArtifactEntries(t *testing.T) {
 	}
 }
 
+func TestArtifactDbPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     string
+		expected string
+	}{
+		{
+			name:     "default",
+			root:     "",
+			expected: "/var/lib/soci-snapshotter-grpc/artifacts.db",
+		},
+		{
+			name:     "custom",
+			root:     "/tmp",
+			expected: "/tmp/artifacts.db",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ArtifactsDbPath(test.root); got != test.expected {
+				t.Errorf("ArtifactsDbPath() = %v, want %v", got, test.expected)
+			}
+		})
+	}
+}
+
 func TestArtifactDB_DoesNotExist(t *testing.T) {
 	resetArtifactDBInit()
 	t.Cleanup(resetArtifactDBInit)
@@ -105,7 +132,7 @@ func TestArtifactDB_DoesNotExist(t *testing.T) {
 		// Fail db initialization.
 		db = nil
 	})
-	_, err := NewDB(ArtifactsDbPath())
+	_, err := NewDB(ArtifactsDbPath(t.TempDir()))
 	if err == nil {
 		t.Fatalf("getArtifactEntry should fail since artifacts.db doesn't exist")
 	}

--- a/soci/fs.go
+++ b/soci/fs.go
@@ -1,0 +1,43 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package soci
+
+import (
+	"os"
+
+	"github.com/awslabs/soci-snapshotter/config"
+)
+
+// EnsureSnapshotterRootPath ensures that the snapshotter root path exists.
+// It creates the directory with restricted permissions (0711) if it doesn't exist.
+func EnsureSnapshotterRootPath(root string) error {
+	if root == "" {
+		root = config.DefaultSociSnapshotterRootPath
+	}
+
+	// Creating the snapshotter's root path first if it does not exist, since this ensures, that
+	// it has the limited permission set as drwx--x--x.
+	// The subsequent oci.New creates a root path dir with too broad permission set.
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		if err = os.Mkdir(root, 0700); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	return nil
+}

--- a/soci/fs_test.go
+++ b/soci/fs_test.go
@@ -1,0 +1,57 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package soci
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnsureSnapshotterRootPath(t *testing.T) {
+	t.Run("root path does not exist", func(t *testing.T) {
+		testRoot := t.TempDir()
+		if err := os.MkdirAll(testRoot+"/var/lib", 0755); err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+
+		root := testRoot + "/var/lib/soci-snapshotter-grpc"
+		if err := EnsureSnapshotterRootPath(root); err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+
+		if _, err := os.Stat(root); err != nil {
+			t.Fatalf("expected %q to exist, got %q", root, err)
+		}
+	})
+
+	t.Run("root path already exists", func(t *testing.T) {
+		testRoot := t.TempDir()
+		root := testRoot + "/var/lib/soci-snapshotter-grpc"
+
+		if err := os.MkdirAll(root, 0755); err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+
+		if err := EnsureSnapshotterRootPath(root); err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+
+		if _, err := os.Stat(root); err != nil {
+			t.Fatalf("expected %q to exist, got %q", root, err)
+		}
+	})
+}

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/awslabs/soci-snapshotter/ztoc"
 	"github.com/awslabs/soci-snapshotter/ztoc/compression"
@@ -421,20 +422,20 @@ type IndexBuilder struct {
 
 // NewIndexBuilder returns an `IndexBuilder` that is used to create soci indices.
 func NewIndexBuilder(contentStore content.Store, blobStore store.Store, opts ...BuilderOption) (*IndexBuilder, error) {
-	config := &builderConfig{
+	cfg := &builderConfig{
 		spanSize:            defaultSpanSize,
 		minLayerSize:        defaultMinLayerSize,
 		buildToolIdentifier: defaultBuildToolIdentifier,
 	}
 
 	for _, opt := range opts {
-		if err := opt(config); err != nil {
+		if err := opt(cfg); err != nil {
 			return nil, err
 		}
 	}
-	if config.artifactsDb == nil {
+	if cfg.artifactsDb == nil {
 		var err error
-		config.artifactsDb, err = NewDB(ArtifactsDbPath())
+		cfg.artifactsDb, err = NewDB(ArtifactsDbPath(config.DefaultSociSnapshotterRootPath))
 		if err != nil {
 			return nil, err
 		}
@@ -443,8 +444,8 @@ func NewIndexBuilder(contentStore content.Store, blobStore store.Store, opts ...
 	return &IndexBuilder{
 		contentStore: contentStore,
 		blobStore:    blobStore,
-		config:       config,
-		ztocBuilder:  ztoc.NewBuilder(config.buildToolIdentifier),
+		config:       cfg,
+		ztocBuilder:  ztoc.NewBuilder(cfg.buildToolIdentifier),
 	}, nil
 }
 


### PR DESCRIPTION
**Issue #, if available:**
When running unit tests on my local system, I regularly hit test failures for `TestArtifactDB_DoesNotExist`. I found the test setup could be more robust by ensuring db initialization fails to assert the desired behavior.

**Description of changes:**
This change 1) fixes the flaky unit test by ensuring the db initialization will fail during setup and 2) adds the `--root` global flag for the soci command along with refactoring common code between `soci` and `soci-snapshotter-grpc` commands.

**Testing performed:**
Added unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
