### PR TITLE
Require containerd for soci-snapshotter.service

### DIFF
--- a/soci-snapshotter.service
+++ b/soci-snapshotter.service
@@ -29,8 +29,8 @@
 [Unit]
 Description=soci snapshotter containerd plugin
 Documentation=https://github.com/awslabs/soci-snapshotter
-After=network.target
-Before=containerd.service
+After=network.target containerd.service
+Requires=containerd.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
**Issue #, if available:**
For k8s use cases, when SOCI snapshotter is acting as the image endpoint with socket activation, the snapshotter can be started without containerd being up.

**Description of changes:**
This change adds containerd as a startup requirement to ensure when SOCI is started via socket activation that containerd is started first.

If during runtime containerd crashes, SOCI will continue to run albeit some operations like image pulls will fail. This is because when lazy loading, SOCI must continue to handle IO requests for already running containers.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
