### PR TITLE
Add make target to merge unit/integration test coverage reports

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -89,7 +89,7 @@ require (
 	go.opentelemetry.io/otel v1.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
-	golang.org/x/net v0.39.0 // indirect
+	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/sync v0.15.0 // indirect
 	golang.org/x/term v0.32.0 // indirect

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -298,8 +298,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
-golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=
+golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
 golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=

--- a/docs/build.md
+++ b/docs/build.md
@@ -96,6 +96,28 @@ can run these tests using the following `Makefile` targets:
 - `make test`: run all unit tests.
 - `make integration`: run all integration tests.
 
+### Code Coverage
+
+- `make total-coverage`: generate total code coverage data from unit and integration tests.
+- `make show-total-coverage`: print total test coverage to terminal.
+- `make show-total-coverage-html`: generate HTML total code coverage report.
+
+#### Unit Test Code Coverage Report
+
+Test coverage from SOCI's unit tests can be generated using:
+
+- `make test-with-coverage`: generate test coverage data.
+- `make show-test-coverage`: print unit test coverage to terminal.
+- `make show-test-coverage-html`: generate HTML code coverage report.
+
+#### Integration Test Code Coverage Report
+
+Test coverage from SOCI's integration tests can be generated using:
+
+- `make integration-with-coverage`: generate test coverage data.
+- `make show-integration-test-coverage`: print integration test coverage to terminal.
+- `make show-integration-test-coverage-html`: generate HTML code coverage report.
+
 ### Benchmark SOCI
 We now have a benchmark framework available at [SOCI Benchmarking](/docs/benchmark.md)
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	golang.org/x/sync v0.15.0
 	golang.org/x/sys v0.33.0
 	golang.org/x/time v0.12.0
+	golang.org/x/tools v0.33.0
 	google.golang.org/grpc v1.59.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.27.4
@@ -93,7 +94,7 @@ require (
 	go.opentelemetry.io/otel v1.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
-	golang.org/x/net v0.39.0 // indirect
+	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/term v0.32.0 // indirect
 	golang.org/x/text v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
-golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=
+golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
 golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=

--- a/scripts/merge_cov.go
+++ b/scripts/merge_cov.go
@@ -1,0 +1,149 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"golang.org/x/tools/cover"
+)
+
+func main() {
+	var unitDir, integrationDir, outFile string
+	flag.StringVar(&unitDir, "unit", "", "Directory containing unit test coverage data")
+	flag.StringVar(&integrationDir, "integration", "", "Directory containing integration test coverage data")
+	flag.StringVar(&outFile, "out", "coverage.out", "Output file for total coverage")
+	flag.Parse()
+
+	if unitDir == "" || integrationDir == "" {
+		fmt.Println("Both unit and integration directories must be specified")
+		os.Exit(1)
+	}
+
+	// Find all coverage files
+	unitFiles, err := findCoverageFiles(unitDir)
+	if err != nil {
+		fmt.Printf("Error finding unit test coverage files: %v\n", err)
+		os.Exit(1)
+	}
+
+	integrationFiles, err := findCoverageFiles(integrationDir)
+	if err != nil {
+		fmt.Printf("Error finding integration test coverage files: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Merge coverage profiles
+	profiles, err := mergeCoverProfiles(append(unitFiles, integrationFiles...))
+	if err != nil {
+		fmt.Printf("Error merging coverage profiles: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write total profile to output file
+	if err := writeCoverProfile(profiles, outFile); err != nil {
+		fmt.Printf("Error writing total coverage profile: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Successfully total coverage data to %s\n", outFile)
+}
+
+func findCoverageFiles(dir string) ([]string, error) {
+	var files []string
+
+	// First try to find .out files directly
+	outFiles, err := filepath.Glob(filepath.Join(dir, "*.out"))
+	if err != nil {
+		return nil, err
+	}
+	files = append(files, outFiles...)
+
+	// If no .out files found, try to convert from covdata format
+	if len(files) == 0 {
+		// Create a temporary file for the coverage data
+		tmpFile := filepath.Join(dir, "coverage.out")
+		if err := exec.Command("go", "tool", "covdata", "textfmt", "-i="+dir, "-o="+tmpFile); err == nil {
+			files = append(files, tmpFile)
+		}
+	}
+
+	return files, nil
+}
+
+func mergeCoverProfiles(files []string) ([]*cover.Profile, error) {
+	var total []*cover.Profile
+	profileMap := make(map[string]*cover.Profile)
+
+	for _, file := range files {
+		profiles, err := cover.ParseProfiles(file)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing %s: %v", file, err)
+		}
+
+		for _, p := range profiles {
+			if existing, ok := profileMap[p.FileName]; ok {
+				// Merge blocks for the same file
+				for i, block := range p.Blocks {
+					if i < len(existing.Blocks) {
+						// If the block exists in both profiles, add the counts
+						existing.Blocks[i].Count += block.Count
+					} else {
+						// If the block only exists in the new profile, append it
+						existing.Blocks = append(existing.Blocks, block)
+					}
+				}
+			} else {
+				// New file, add to map
+				profileMap[p.FileName] = p
+			}
+		}
+	}
+
+	// Convert map to slice
+	for _, profile := range profileMap {
+		total = append(total, profile)
+	}
+
+	return total, nil
+}
+
+func writeCoverProfile(profiles []*cover.Profile, outFile string) error {
+	f, err := os.Create(outFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, "mode: set\n")
+	for _, profile := range profiles {
+		for _, block := range profile.Blocks {
+			count := block.Count
+			if count > 0 {
+				count = 1 // Convert to "set" mode
+			}
+			fmt.Fprintf(f, "%s:%d.%d,%d.%d %d %d\n",
+				profile.FileName, block.StartLine, block.StartCol, block.EndLine, block.EndCol, block.NumStmt, count)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Issue #, if available:**
Follow-up to the code coverage work to merge the unit and integration test coverage reports into a single total coverage report.

**Description of changes:**
This change adds a new make target `total-coverage` for running unit and integration tests and merging their code coverage date into a single HTML report. This is helpful for identifying code coverage gaps.

This is local development only; not yet added to CI.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
