### PR TITLE
Add test for span arg validation

### DIFF
--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -330,6 +330,9 @@ type BuilderOption func(c *builderConfig) error
 // WithSpanSize specifies span size.
 func WithSpanSize(spanSize int64) BuilderOption {
 	return func(c *builderConfig) error {
+		if spanSize < 0 {
+			return fmt.Errorf("span size must be >= 0")
+		}
 		c.spanSize = spanSize
 		return nil
 	}
@@ -338,6 +341,9 @@ func WithSpanSize(spanSize int64) BuilderOption {
 // WithMinLayerSize specifies min layer size to build a ztoc for a layer.
 func WithMinLayerSize(minLayerSize int64) BuilderOption {
 	return func(c *builderConfig) error {
+		if minLayerSize < 0 {
+			return fmt.Errorf("min layer size must be >= 0")
+		}
 		c.minLayerSize = minLayerSize
 		return nil
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This adds a test that a user cannot specify a min-layer-size or span-size that is negative or larger than what can fit into a signed 64-bit integer.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
