### PR TITLE
Add -config-dump flag

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -207,6 +207,8 @@ github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaL
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
**Issue #, if available:**

Closes #1570

**Description of changes:**

Add a new flag to dump the contents of the resolved soci-snapshotter-grpc configuration

**Testing performed:**

Default config:

<details>

```
./out/soci-snapshotter-grpc --config-dump
http_cache_type = ''
filesystem_cache_type = ''
resolve_result_entry = 0
debug = false
disable_verification = false
max_concurrency = 100
no_prometheus = false
mount_timeout_sec = 30
fuse_metrics_emit_wait_duration_sec = 60
metrics_address = ''
metrics_network = 'tcp'
debug_address = ''
metadata_store = 'db'
skip_check_snapshotter_supported = false

[http]
  DialTimeoutMsec = 3000
  ResponseHeaderTimeoutMsec = 3000
  RequestTimeoutMsec = 30000
  MaxRetries = 8
  MinWaitMsec = 30
  MaxWaitMsec = 300000

[blob]
  valid_interval = 60
  fetching_timeout_sec = 300
  max_retries = 8
  min_wait_msec = 30
  max_wait_msec = 300000
  check_always = false
  force_single_range_mode = false
  max_span_verification_retries = 0

[directory_cache]
  max_lru_cache_entry = 0
  max_cache_fds = 0
  sync_add = false
  direct = true

[fuse]
  attr_timeout = 1
  entry_timeout = 1
  negative_timeout = 1
  log_fuse_operations = false

[background_fetch]
  disable = false
  silence_period_msec = 30000
  fetch_period_msec = 500
  max_queue_size = 100
  emit_metric_period_sec = 10

[content_store]
  type = 'soci'
  containerd_address = ''

[pull_modes]
  [pull_modes.soci_v1]
    enable = false

  [pull_modes.soci_v2]
    enable = true

[kubeconfig_keychain]
  enable_keychain = false
  kubeconfig_path = ''

[cri_keychain]
  enable_keychain = false
  image_service_path = '/run/containerd/containerd.sock'

[resolver]

[snapshotter]
  min_layer_size = 0
  allow_invalid_mounts_on_restart = false
```

</details>

Create `/etc/soci-snapshotter-grpc/config.toml`

```
[snapshotter]
min_layer_size = 111
```

Dump config:

```
./out/soci-snapshotter-grpc --config-dump

...

[snapshotter]
  min_layer_size = 111
  allow_invalid_mounts_on_restart = false
...
```

Start snapshotter as normal:

```
sudo ./out/soci-snapshotter-grpc
{"level":"info","msg":"starting soci-snapshotter-grpc","revision":"7d4a9d67ad07fd5859b54edc4203b8b357434335","time":"2025-05-28T18:59:41.057605500Z","version":"7d4a9d67"}
{"emitMetricPeriod":10000000000,"fetchPeriod":500000000,"level":"info","maxQueueSize":100,"msg":"constructing background fetcher","silencePeriod":30000000000,"time":"2025-05-28T18:59:41.081607690Z"}
{"address":"/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock","level":"info","msg":"soci-snapshotter-grpc successfully started","time":"2025-05-28T18:59:41.082064770Z"}
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
