### PR TITLE
Show manifest version in soci index ls

### DIFF
--- a/cmd/soci/commands/index/list.go
+++ b/cmd/soci/commands/index/list.go
@@ -160,7 +160,7 @@ var listCommand = cli.Command{
 		}
 
 		writer := tabwriter.NewWriter(os.Stdout, 8, 8, 4, ' ', 0)
-		writer.Write([]byte("DIGEST\tSIZE\tIMAGE REF\tPLATFORM\tMEDIA TYPE\tCREATED\t\n"))
+		writer.Write([]byte("DIGEST\tSIZE\tIMAGE REF\tPLATFORM\tMEDIA TYPE\tMANIFEST VERSION\tCREATED\t\n"))
 
 		for _, ae := range artifacts {
 			imgs, _ := is.List(ctx, fmt.Sprintf("target.digest==%s", ae.ImageDigest))
@@ -178,13 +178,21 @@ var listCommand = cli.Command{
 }
 
 func writeArtifactEntry(w io.Writer, ae *soci.ArtifactEntry, imageRef string) {
+	version := ""
+	switch ae.ArtifactType {
+	case soci.SociIndexArtifactTypeV1:
+		version = "v1"
+	case soci.SociIndexArtifactTypeV2:
+		version = "v2"
+	}
 	w.Write([]byte(fmt.Sprintf(
-		"%s\t%d\t%s\t%s\t%s\t%s\t\n",
+		"%s\t%d\t%s\t%s\t%s\t%s\t%s\t\n",
 		ae.Digest,
 		ae.Size,
 		imageRef,
 		ae.Platform,
 		ae.MediaType,
+		version,
 		getDuration(ae.CreatedAt),
 	)))
 }

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -72,6 +72,7 @@ var (
 	bucketKeyLocation       = []byte("location")
 	bucketKeyType           = []byte("type")
 	bucketKeyMediaType      = []byte("media_type")
+	bucketKeyArtifactType   = []byte("artifact_type")
 	bucketKeyCreatedAt      = []byte("created_at")
 
 	// ArtifactEntryTypeIndex indicates that an ArtifactEntry is a SOCI index artifact
@@ -115,6 +116,8 @@ type ArtifactEntry struct {
 	Type ArtifactEntryType
 	// Media Type of the stored artifact.
 	MediaType string
+	// ArtifactType is the type of artifact stored (e.g. index manifest v1 vs index manifest v2)
+	ArtifactType string
 	// Creation time of SOCI artifact.
 	CreatedAt time.Time
 }
@@ -293,6 +296,7 @@ func (db *ArtifactsDb) addNewArtifacts(ctx context.Context, blobStorePath string
 				Type:           ArtifactEntryTypeIndex,
 				Location:       manifestDigest,
 				MediaType:      sociIndex.MediaType,
+				ArtifactType:   sociIndex.Config.MediaType,
 				CreatedAt:      time.Now(),
 			}
 			if err = db.WriteArtifactEntry(indexEntry); err != nil {
@@ -457,6 +461,7 @@ func loadArtifact(artifactBkt *bolt.Bucket, digest string) (*ArtifactEntry, erro
 	ae.ImageDigest = string(artifactBkt.Get(bucketKeyImageDigest))
 	ae.Platform = string(artifactBkt.Get(bucketKeyPlatform))
 	ae.MediaType = string(artifactBkt.Get(bucketKeyMediaType))
+	ae.ArtifactType = string(artifactBkt.Get(bucketKeyArtifactType))
 	ae.CreatedAt = createdAt
 	return &ae, nil
 }
@@ -492,6 +497,7 @@ func putArtifactEntry(artifacts *bolt.Bucket, ae *ArtifactEntry) error {
 		{bucketKeyPlatform, []byte(ae.Platform)},
 		{bucketKeyType, []byte(ae.Type)},
 		{bucketKeyMediaType, []byte(ae.MediaType)},
+		{bucketKeyArtifactType, []byte(ae.ArtifactType)},
 		{bucketKeyCreatedAt, createdAt},
 	}
 

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -812,6 +812,7 @@ func (b *IndexBuilder) writeSociIndex(ctx context.Context, indexWithMetadata *In
 		Location:       indexWithMetadata.ManifestDesc.Digest.String(),
 		Size:           size,
 		MediaType:      indexWithMetadata.Index.MediaType,
+		ArtifactType:   indexWithMetadata.Index.Config.MediaType,
 		CreatedAt:      indexWithMetadata.CreatedAt,
 	}
 	return desc, b.config.artifactsDb.WriteArtifactEntry(entry)


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This adds a SOCI index manifest version to the output of `soci index ls`


**Testing performed:**
```
$ sudo soci convert --min-layer-size 0 public.ecr.aws/docker/library/busybox:latest public.ecr.aws/docker/library/busybox:latest-soci
$ sudo soci create --min-layer-size 0 public.ecr.aws/docker/library/busybox:latest 
$ sudo soci index ls
DIGEST                                                                     SIZE    IMAGE REF                                       PLATFORM       MEDIA TYPE                                    MANIFEST VERSION    CREATED    
sha256:5ec2624823843d6aeaa3a79cf0ccf3f878b400eca7306f1b1e37bd36aa5f30fa    836     public.ecr.aws/docker/library/busybox:latest    linux/amd64    application/vnd.oci.image.manifest.v1+json    v1                  4s ago     
sha256:3546fbe6707218791d73e70b316fb71141d0d9baebc320ab7f0aff93c07a0995    673     public.ecr.aws/docker/library/busybox:latest    linux/amd64    application/vnd.oci.image.manifest.v1+json    v2                  12s ago    
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
