### PR TITLE
Prevent pushing SOCI index manifest v2

### DIFF
--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -271,9 +271,10 @@ func GetIndexDescriptorCollection(ctx context.Context, cs content.Store, artifac
 			continue
 		}
 		desc := ocispec.Descriptor{
-			MediaType: entry.MediaType,
-			Digest:    dgst,
-			Size:      entry.Size,
+			MediaType:    entry.MediaType,
+			ArtifactType: entry.ArtifactType,
+			Digest:       dgst,
+			Size:         entry.Size,
 		}
 		descriptors = append(descriptors, IndexDescriptorInfo{
 			Descriptor: desc,


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
SOCI index manifest v2 does not have a subject field and instead relies on a connection to an image via an image index. Before this change, you could use `soci push` to push a SOCI index manifest v2 without the rest of the image which is unusable without the image index. This change detects SOCI index manifest v2 and skips the push.

**Testing performed:**
```
$ sudo soci convert --all-platforms --min-layer-size 0 public.ecr.aws/docker/library/busybox:latest public.ecr.aws/docker/library/busybox:latest-soci
$ sudo soci create --min-layer-size 0 public.ecr.aws/docker/library/busybox:latest
$ sudo soci push public.ecr.aws/docker/library/busybox:latest-soci
[WARN] Skippping SOCI index manifest v2. You should push the whole image with higher level tools like finch or nerdctl.
soci: could not find any soci index manifest v1 to push for platform linux/amd64
$ sudo soci push public.ecr.aws/docker/library/busybox:latest
checking if a soci index already exists in remote repository...
pushing soci index with digest: sha256:5ec2624823843d6aeaa3a79cf0ccf3f878b400eca7306f1b1e37bd36aa5f30fa
soci: error pushing graph to remote: failed to perform "Exists" on destination: HEAD "https://public.ecr.aws/v2/docker/library/busybox/blobs/sha256:e4f42ef6191be62c0890258181482b127438843af5651085248fa36848c5f8f0": response status code 401: Unauthorized

$ sudo soci create --min-layer-size 0 public.ecr.aws/docker/library/busybox:latest-soci 
$ sudo soci push public.ecr.aws/docker/library/busybox:latest-soci
[WARN] Skippping SOCI index manifest v2. You should push the whole image with higher level tools like finch or nerdctl.
checking if a soci index already exists in remote repository...
pushing soci index with digest: sha256:99ffe70c7fb431cbf1a281182b8cdb8ea3baa3b67c2cc71b099fd5aa63c66948
soci: error pushing graph to remote: failed to perform "Exists" on destination: HEAD "https://public.ecr.aws/v2/docker/library/busybox/blobs/sha256:e4f42ef6191be62c0890258181482b127438843af5651085248fa36848c5f8f0": response status code 401: Unauthorized
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
