### PR TITLE
Move the snapshotter to urfave

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -35,7 +35,6 @@ package main
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	golog "log"
@@ -73,6 +72,7 @@ import (
 	sddaemon "github.com/coreos/go-systemd/v22/daemon"
 	metrics "github.com/docker/go-metrics"
 	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
@@ -86,125 +86,151 @@ const (
 	defaultLogLevel = logrus.InfoLevel
 )
 
-// logLevel of Debug or Trace may emit sensitive information
-// e.g. file contents, file names and paths, network addresses and ports
-var (
-	address      = flag.String("address", defaultAddress, "address for the snapshotter's GRPC server")
-	configPath   = flag.String("config", config.DefaultConfigPath, "path to the configuration file")
-	logLevel     = flag.String("log-level", defaultLogLevel.String(), "set the logging level [trace, debug, info, warn, error, fatal, panic]")
-	rootDir      = flag.String("root", config.DefaultSociSnapshotterRootPath, "path to the root directory for this snapshotter")
-	printVersion = flag.Bool("version", false, "print the version")
-)
-
 func main() {
-	flag.Parse()
-	lvl, err := logrus.ParseLevel(*logLevel)
-	if err != nil {
-		log.L.WithError(err).Fatal("failed to prepare logger")
-	}
-	if *printVersion {
-		fmt.Println("soci-snapshotter-grpc version", version.Version, version.Revision)
-		return
-	}
-	logrus.SetLevel(lvl)
-	logrus.SetFormatter(&logrus.JSONFormatter{
-		TimestampFormat: log.RFC3339NanoFixed,
-	})
-
-	ctx, cancel := context.WithCancel(log.WithLogger(context.Background(), log.L))
-	defer cancel()
-	// Streams log of standard lib (go-fuse uses this) into debug log
-	// Snapshotter should use "github.com/containerd/log" otherwise
-	// logs are always printed as "debug" mode.
-	golog.SetOutput(log.G(ctx).WriterLevel(logrus.DebugLevel))
-	log.G(ctx).WithFields(logrus.Fields{
-		"version":  version.Version,
-		"revision": version.Revision,
-	}).Info("starting soci-snapshotter-grpc")
-
-	cfg, err := config.NewConfigFromToml(*configPath)
-	if err != nil {
-		log.G(ctx).WithError(err).Fatal(err)
+	app := cli.NewApp()
+	app.Name = "soci-snapshotter-grpc"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "address",
+			Usage: "address for the snapshotter's GRPC server",
+			Value: defaultAddress,
+		},
+		cli.StringFlag{
+			Name:  "config",
+			Usage: "path to the configuration file",
+			Value: config.DefaultConfigPath,
+		},
+		cli.StringFlag{
+			Name:  "log-level",
+			Usage: "set the logging level [trace, debug, info, warn, error, fatal, panic]",
+			Value: defaultLogLevel.String(),
+		},
+		cli.StringFlag{
+			Name:  "root",
+			Usage: "path to the root directory for this snapshotter",
+			Value: config.DefaultSociSnapshotterRootPath,
+		},
 	}
 
-	if !cfg.SkipCheckSnapshotterSupported {
-		if err := service.Supported(*rootDir); err != nil {
-			log.G(ctx).WithError(err).Fatalf("snapshotter is not supported")
+	app.Version = fmt.Sprintf("%s %s", version.Version, version.Revision)
+
+	app.Action = func(cliContext *cli.Context) error {
+		lvl, err := logrus.ParseLevel(cliContext.String("log-level"))
+		if err != nil {
+			return fmt.Errorf("failed to prepare logger: %w", err)
 		}
-		log.G(ctx).Debug("snapshotter is supported")
-	} else {
-		log.G(ctx).Warn("skipped snapshotter is supported check")
-	}
+		logrus.SetLevel(lvl)
+		logrus.SetFormatter(&logrus.JSONFormatter{
+			TimestampFormat: log.RFC3339NanoFixed,
+		})
 
-	serverOpts := []grpc.ServerOption{
-		grpc.ChainUnaryInterceptor(unaryNamespaceInterceptor),
-		grpc.ChainStreamInterceptor(streamNamespaceInterceptor),
-	}
+		ctx, cancel := context.WithCancel(log.WithLogger(context.Background(), log.L))
+		defer cancel()
+		// Streams log of standard lib (go-fuse uses this) into debug log
+		// Snapshotter should use "github.com/containerd/log" otherwise
+		// logs are always printed as "debug" mode.
+		golog.SetOutput(log.G(ctx).WriterLevel(logrus.DebugLevel))
+		log.G(ctx).WithFields(logrus.Fields{
+			"version":  version.Version,
+			"revision": version.Revision,
+		}).Info("starting soci-snapshotter-grpc")
 
-	// Create a gRPC server
-	rpc := grpc.NewServer(serverOpts...)
-
-	// Configure keychain
-	credsFuncs := []resolver.Credential{dockerconfig.NewDockerConfigKeychain(ctx)}
-	if cfg.KubeconfigKeychainConfig.EnableKeychain {
-		var opts []kubeconfig.Option
-		if kcp := cfg.KubeconfigKeychainConfig.KubeconfigPath; kcp != "" {
-			opts = append(opts, kubeconfig.WithKubeconfigPath(kcp))
+		cfg, err := config.NewConfigFromToml(cliContext.String("config"))
+		if err != nil {
+			log.G(ctx).WithError(err).Fatal(err)
+			return err
 		}
-		credsFuncs = append(credsFuncs, kubeconfig.NewKubeconfigKeychain(ctx, opts...))
-	}
-	if cfg.CRIKeychainConfig.EnableKeychain {
 
-		connectV1AlphaCRI := func() (runtime_alpha.ImageServiceClient, error) {
-			criConn, err := getCriConn(cfg.CRIKeychainConfig.ImageServicePath)
-			if err != nil {
-				return nil, err
+		rootDir := cliContext.String("root")
+		if !cfg.SkipCheckSnapshotterSupported {
+			if err := service.Supported(rootDir); err != nil {
+				log.G(ctx).WithError(err).Fatalf("snapshotter is not supported")
+				return err
 			}
-			return runtime_alpha.NewImageServiceClient(criConn), nil
+			log.G(ctx).Debug("snapshotter is supported")
+		} else {
+			log.G(ctx).Warn("skipped snapshotter is supported check")
 		}
 
-		connectV1CRI := func() (runtime.ImageServiceClient, error) {
-			criConn, err := getCriConn(cfg.CRIKeychainConfig.ImageServicePath)
-			if err != nil {
-				return nil, err
+		serverOpts := []grpc.ServerOption{
+			grpc.ChainUnaryInterceptor(unaryNamespaceInterceptor),
+			grpc.ChainStreamInterceptor(streamNamespaceInterceptor),
+		}
+
+		// Create a gRPC server
+		rpc := grpc.NewServer(serverOpts...)
+
+		// Configure keychain
+		credsFuncs := []resolver.Credential{dockerconfig.NewDockerConfigKeychain(ctx)}
+		if cfg.KubeconfigKeychainConfig.EnableKeychain {
+			var opts []kubeconfig.Option
+			if kcp := cfg.KubeconfigKeychainConfig.KubeconfigPath; kcp != "" {
+				opts = append(opts, kubeconfig.WithKubeconfigPath(kcp))
 			}
-			return runtime.NewImageServiceClient(criConn), nil
+			credsFuncs = append(credsFuncs, kubeconfig.NewKubeconfigKeychain(ctx, opts...))
+		}
+		if cfg.CRIKeychainConfig.EnableKeychain {
+
+			connectV1AlphaCRI := func() (runtime_alpha.ImageServiceClient, error) {
+				criConn, err := getCriConn(cfg.CRIKeychainConfig.ImageServicePath)
+				if err != nil {
+					return nil, err
+				}
+				return runtime_alpha.NewImageServiceClient(criConn), nil
+			}
+
+			connectV1CRI := func() (runtime.ImageServiceClient, error) {
+				criConn, err := getCriConn(cfg.CRIKeychainConfig.ImageServicePath)
+				if err != nil {
+					return nil, err
+				}
+				return runtime.NewImageServiceClient(criConn), nil
+			}
+
+			// register v1alpha2 CRI server with the gRPC server
+			fAlpha, criServerAlpha := crialpha.NewCRIAlphaKeychain(ctx, connectV1AlphaCRI)
+			runtime_alpha.RegisterImageServiceServer(rpc, criServerAlpha)
+			credsFuncs = append(credsFuncs, fAlpha)
+
+			// register v1 CRI server with the gRPC server
+			f, criServer := cri.NewCRIKeychain(ctx, connectV1CRI)
+			runtime.RegisterImageServiceServer(rpc, criServer)
+			credsFuncs = append(credsFuncs, f)
+		}
+		var fsOpts []fs.Option
+		mt, err := getMetadataStore(ctx, rootDir, *cfg)
+		if err != nil {
+			log.G(ctx).WithError(err).Fatalf("failed to configure metadata store")
+			return err
+		}
+		log.G(ctx).Debug("metadata store initialized")
+
+		fsOpts = append(fsOpts, fs.WithMetadataStore(mt))
+		rs, err := service.NewSociSnapshotterService(ctx, rootDir, &cfg.ServiceConfig,
+			service.WithCredsFuncs(credsFuncs...), service.WithFilesystemOptions(fsOpts...))
+		if err != nil {
+			log.G(ctx).WithError(err).Fatalf("failed to configure snapshotter")
+			return err
 		}
 
-		// register v1alpha2 CRI server with the gRPC server
-		fAlpha, criServerAlpha := crialpha.NewCRIAlphaKeychain(ctx, connectV1AlphaCRI)
-		runtime_alpha.RegisterImageServiceServer(rpc, criServerAlpha)
-		credsFuncs = append(credsFuncs, fAlpha)
+		cleanup, err := serve(ctx, rpc, cliContext.String("address"), rs, *cfg)
+		if err != nil {
+			log.G(ctx).WithError(err).Fatalf("failed to serve snapshotter")
+			return err
+		}
 
-		// register v1 CRI server with the gRPC server
-		f, criServer := cri.NewCRIKeychain(ctx, connectV1CRI)
-		runtime.RegisterImageServiceServer(rpc, criServer)
-		credsFuncs = append(credsFuncs, f)
-	}
-	var fsOpts []fs.Option
-	mt, err := getMetadataStore(ctx, *rootDir, *cfg)
-	if err != nil {
-		log.G(ctx).WithError(err).Fatalf("failed to configure metadata store")
-	}
-	log.G(ctx).Debug("metadata store initialized")
-
-	fsOpts = append(fsOpts, fs.WithMetadataStore(mt))
-	rs, err := service.NewSociSnapshotterService(ctx, *rootDir, &cfg.ServiceConfig,
-		service.WithCredsFuncs(credsFuncs...), service.WithFilesystemOptions(fsOpts...))
-	if err != nil {
-		log.G(ctx).WithError(err).Fatalf("failed to configure snapshotter")
+		if cleanup {
+			log.G(ctx).Debug("Closing the snapshotter")
+			rs.Close()
+		}
+		log.G(ctx).Info("Exiting")
+		return nil
 	}
 
-	cleanup, err := serve(ctx, rpc, *address, rs, *cfg)
-	if err != nil {
-		log.G(ctx).WithError(err).Fatalf("failed to serve snapshotter")
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "soci-snapshotter-grpc: %v\n", err)
+		os.Exit(1)
 	}
-
-	if cleanup {
-		log.G(ctx).Debug("Closing the snapshotter")
-		rs.Close()
-	}
-	log.G(ctx).Info("Exiting")
 }
 
 func serve(ctx context.Context, rpc *grpc.Server, addr string, rs snapshots.Snapshotter, cfg config.Config) (bool, error) {


### PR DESCRIPTION

**Issue #, if available:**

**Description of changes:**
Before this change, the SOCI CLI used urfave CLI, but the snapshotter used go's flag package. This moved the snapshotter to urfave as well.

This is an alternative path to #1587. The plan is to move the snapshotter first, then upgrate to v3.

**Testing performed:**
```
sudo soci-snapshotter-grpc --version
sudo soci-snapshotter-grpc --log-level trace
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
