### PR TITLE
Fix incorrect type check for soci ztoc info

### DIFF
--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -67,7 +67,7 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		if entry.MediaType == soci.SociIndexArtifactType {
+		if entry.Type == soci.ArtifactEntryTypeIndex {
 			return fmt.Errorf("the provided digest belongs to a SOCI index. Use `soci index info` to get the detailed information about it")
 		}
 		ctx, cancel := internal.AppContext(cliContext)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
We used to check the artifact's MediaType to determine if the artifact being passed to the command was a SOCI index or a zTOC, but the MediaType will always be the same regardless of the artifact type. This fixes the check to look for the artifact type instead of the MediaType.

**Testing performed:**
Steps to reproduce: 
1. Pull image (I used `rabbitmq:latest`)
2. Create SOCI index
3. Get list of SOCI indexes
4. `sudo soci ztoc info $INDEX` (note that this is a SOCI index, not a zTOC)

This would fail before these changes with an "slice out of bounds" error, but fails with "soci: the provided digest belongs to a SOCI index. Use `soci index info` to get the detailed information about it"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
