### PR TITLE
Add parallel pull + unpack mode to SOCI

### DIFF
--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -277,6 +277,8 @@ go.opentelemetry.io/otel/metric v1.21.0 h1:tlYWfeo+Bocx5kLEloTjbcDwBuELRrIFxwdQ3
 go.opentelemetry.io/otel/metric v1.21.0/go.mod h1:o1p3CA8nNHW8j5yuQLdc1eeqEaPfzug24uvsyIEJRWM=
 go.opentelemetry.io/otel/trace v1.21.0 h1:WD9i5gzvoUPuXIXH24ZNBudiarZDKuekPqi/E8fpfLc=
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
+go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/cmd/soci/commands/internal/client.go
+++ b/cmd/soci/commands/internal/client.go
@@ -34,8 +34,8 @@ package internal
 
 import (
 	gocontext "context"
-	"strings"
 
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/epoch"
@@ -78,7 +78,7 @@ func AppContext(context *cli.Context) (gocontext.Context, gocontext.CancelFunc) 
 // NewClient returns a new containerd client
 func NewClient(context *cli.Context, opts ...containerd.ClientOpt) (*containerd.Client, gocontext.Context, gocontext.CancelFunc, error) {
 	opts = append(opts, containerd.WithTimeout(context.GlobalDuration("timeout")))
-	address := strings.TrimPrefix(context.GlobalString("address"), "unix://")
+	address := config.TrimSocketAddress(context.GlobalString("address"))
 	client, err := containerd.New(address, opts...)
 	if err != nil {
 		return nil, nil, nil, err

--- a/cmd/soci/commands/internal/store.go
+++ b/cmd/soci/commands/internal/store.go
@@ -17,8 +17,6 @@
 package internal
 
 import (
-	"strings"
-
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/urfave/cli"
 )
@@ -27,6 +25,6 @@ import (
 func ContentStoreOptions(context *cli.Context) []store.Option {
 	return []store.Option{
 		store.WithType(store.ContentStoreType(context.GlobalString("content-store"))),
-		store.WithContainerdAddress(strings.TrimPrefix(context.GlobalString("address"), "unix://")),
+		store.WithContainerdAddress(context.GlobalString("address")),
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ type Config struct {
 }
 type configParser func(*Config) error
 
-var parsers = []configParser{parseRootConfig, parseServiceConfig, parseFSConfig}
+var parsers = []configParser{parseRootConfig, parseServiceConfig, parseFSConfig, parseImagePullConfig}
 
 // NewConfig returns an initialized Config with default values set.
 func NewConfig() *Config {

--- a/config/config.go
+++ b/config/config.go
@@ -74,7 +74,7 @@ type Config struct {
 	// SkipCheckSnapshotterSupported is a flag to skip check for overlayfs support needed to confirm if SOCI can work
 	SkipCheckSnapshotterSupported bool `toml:"skip_check_snapshotter_supported"`
 }
-type configParser func(*Config)
+type configParser func(*Config) error
 
 var parsers = []configParser{parseRootConfig, parseServiceConfig, parseFSConfig}
 
@@ -113,11 +113,12 @@ func parseConfig(cfg *Config) {
 	}
 }
 
-func parseRootConfig(cfg *Config) {
+func parseRootConfig(cfg *Config) error {
 	if cfg.MetricsNetwork == "" {
 		cfg.MetricsNetwork = defaultMetricsNetwork
 	}
 	if cfg.MetadataStore == "" {
 		cfg.MetadataStore = defaultMetadataStore
 	}
+	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ type Config struct {
 }
 type configParser func(*Config) error
 
-var parsers = []configParser{parseRootConfig, parseServiceConfig, parseFSConfig, parseImagePullConfig}
+var parsers = []configParser{parseRootConfig, parseServiceConfig, parseFSConfig, parseParallelConfig}
 
 // NewConfig returns an initialized Config with default values set.
 func NewConfig() *Config {

--- a/config/config.toml
+++ b/config/config.toml
@@ -30,6 +30,23 @@ debug_address=""
 metadata_store="db"
 skip_check_snapshotter_supported=false
 
+[pull_modes.parallel_pull_unpack]
+enable=false
+max_concurrent_downloads=-1
+max_concurrent_downloads_per_image=3
+concurrent_download_chunk_size=""
+max_concurrent_unpacks=-1
+max_concurrent_unpacks_per_image=1
+discard_unpacked_layers=false
+
+[pull_modes.parallel_pull_unpack.decompress_streams."gzip"]
+path = "/usr/bin/gzip"
+args = ["-d", "-c"]
+
+[pull_modes.parallel_pull_unpack.decompress_streams."zstd"]
+path = "/usr/bin/zstd"
+args = ["-d", "-c"]
+
 [http]
 MaxRetries=0
 MinWaitMsec=0

--- a/config/config.toml
+++ b/config/config.toml
@@ -43,10 +43,6 @@ discard_unpacked_layers=false
 path = "/usr/bin/gzip"
 args = ["-d", "-c"]
 
-[pull_modes.parallel_pull_unpack.decompress_streams."zstd"]
-path = "/usr/bin/zstd"
-args = ["-d", "-c"]
-
 [http]
 MaxRetries=0
 MinWaitMsec=0

--- a/config/config.toml
+++ b/config/config.toml
@@ -100,7 +100,7 @@ emit_metric_period_sec=0
 
 [content_store]
 type="" # will set to 'soci' by default
-# Socket address for containerd. Only applicable using containerd content store.
+# Socket address for containerd.
 # Defaults to '/run/containerd/containerd.sock'
 containerd_address=""
 namespace="" # will set to 'default' by default

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,7 +44,7 @@ func TestConfigDefaults(t *testing.T) {
 		{
 			name:     "parallel pull enabled",
 			expected: DefaultParallelPullUnpackEnable,
-			actual:   cfg.PullModes.ParallelPullUnpack.Enable,
+			actual:   cfg.PullModes.Parallel.Enable,
 		},
 		{
 			name:     "metrics network",
@@ -162,6 +162,31 @@ func TestConfigDefaults(t *testing.T) {
 			expected: SociContentStoreType,
 			actual:   cfg.ContentStoreConfig.Type,
 		},
+		{
+			name:     "max concurrent downloads",
+			expected: int64(defaultMaxConcurrentDownloads),
+			actual:   cfg.PullModes.Parallel.MaxConcurrentDownloads,
+		},
+		{
+			name:     "max concurrent downloads per image",
+			expected: int64(defaultMaxConcurrentDownloadsPerImage),
+			actual:   cfg.PullModes.Parallel.MaxConcurrentDownloadsPerImage,
+		},
+		{
+			name:     "concurrent download chunk size",
+			expected: int64(defaultConcurrentDownloadChunkSize),
+			actual:   cfg.PullModes.Parallel.ConcurrentDownloadChunkSize,
+		},
+		{
+			name:     "max concurrent unpack",
+			expected: int64(defaultMaxConcurrentUnpacks),
+			actual:   cfg.PullModes.Parallel.MaxConcurrentUnpacks,
+		},
+		{
+			name:     "max concurrent unpack per image",
+			expected: int64(defaultMaxConcurrentUnpacksPerImage),
+			actual:   cfg.PullModes.Parallel.MaxConcurrentUnpacksPerImage,
+		},
 	}
 
 	for _, tc := range tests {
@@ -208,20 +233,20 @@ args = ["-d", "-c"]
 				if err != nil {
 					t.Errorf("Expected no error, got %v", err)
 				}
-				if len(actual.PullModes.ParallelPullUnpack.DecompressStreams) != 2 {
-					t.Errorf("Expected 2 decompression streams, got %d", len(actual.PullModes.ParallelPullUnpack.DecompressStreams))
+				if len(actual.PullModes.Parallel.DecompressStreams) != 2 {
+					t.Errorf("Expected 2 decompression streams, got %d", len(actual.PullModes.Parallel.DecompressStreams))
 				}
-				if actual.PullModes.ParallelPullUnpack.DecompressStreams["gzip"].Path != "/usr/bin/gzip" {
-					t.Errorf("Expected gzip path to be /usr/bin/gzip, got %s", actual.PullModes.ParallelPullUnpack.DecompressStreams["gzip"].Path)
+				if actual.PullModes.Parallel.DecompressStreams["gzip"].Path != "/usr/bin/gzip" {
+					t.Errorf("Expected gzip path to be /usr/bin/gzip, got %s", actual.PullModes.Parallel.DecompressStreams["gzip"].Path)
 				}
-				if len(actual.PullModes.ParallelPullUnpack.DecompressStreams["gzip"].Args) != 2 {
-					t.Errorf("Expected two args, got %d", len(actual.PullModes.ParallelPullUnpack.DecompressStreams["gzip"].Args))
+				if len(actual.PullModes.Parallel.DecompressStreams["gzip"].Args) != 2 {
+					t.Errorf("Expected two args, got %d", len(actual.PullModes.Parallel.DecompressStreams["gzip"].Args))
 				}
-				if actual.PullModes.ParallelPullUnpack.DecompressStreams["zstd"].Path != "/usr/bin/zstd" {
-					t.Errorf("Expected zstd path to be /usr/bin/zstd, got %s", actual.PullModes.ParallelPullUnpack.DecompressStreams["zstd"].Path)
+				if actual.PullModes.Parallel.DecompressStreams["zstd"].Path != "/usr/bin/zstd" {
+					t.Errorf("Expected zstd path to be /usr/bin/zstd, got %s", actual.PullModes.Parallel.DecompressStreams["zstd"].Path)
 				}
-				if len(actual.PullModes.ParallelPullUnpack.DecompressStreams["zstd"].Args) != 2 {
-					t.Errorf("Expected two args, got %d", len(actual.PullModes.ParallelPullUnpack.DecompressStreams["zstd"].Args))
+				if len(actual.PullModes.Parallel.DecompressStreams["zstd"].Args) != 2 {
+					t.Errorf("Expected two args, got %d", len(actual.PullModes.Parallel.DecompressStreams["zstd"].Args))
 				}
 			},
 		},
@@ -235,8 +260,8 @@ concurrent_download_chunk_size = "1MB"
 				if err != nil {
 					t.Errorf("Expected no error, got %v", err)
 				}
-				if actual.PullModes.ParallelPullUnpack.ConcurrentDownloadChunkSize != 1*1024*1024 {
-					t.Errorf("Expected concurrent_download_chunk_size to be %d, got %d", 1*1024*1024, actual.PullModes.ParallelPullUnpack.ConcurrentDownloadChunkSize)
+				if actual.PullModes.Parallel.ConcurrentDownloadChunkSize != 1*1024*1024 {
+					t.Errorf("Expected concurrent_download_chunk_size to be %d, got %d", 1*1024*1024, actual.PullModes.Parallel.ConcurrentDownloadChunkSize)
 				}
 			},
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,6 +39,11 @@ func TestConfigDefaults(t *testing.T) {
 			actual:   cfg.PullModes.SOCIv2.Enable,
 		},
 		{
+			name:     "parallel pull enabled",
+			expected: DefaultParallelPullUnpackEnable,
+			actual:   cfg.PullModes.ParallelPullUnpack.Enable,
+		},
+		{
 			name:     "metrics network",
 			expected: defaultMetricsNetwork,
 			actual:   cfg.MetricsNetwork,

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -92,7 +92,7 @@ const (
 	// defaultResponseHeaderTimeoutMsec is the default number of milliseconds before timeout while waiting for response header from a remote endpoint. See `TimeoutConfig.ResponseHeaderTimeout`.
 	defaultResponseHeaderTimeoutMsec = 3_000
 	// defaultRequestTimeoutMsec is the default number of milliseconds that the entire request can take before timeout. See `TimeoutConfig.RequestTimeout`.
-	defaultRequestTimeoutMsec = 30_000
+	defaultRequestTimeoutMsec = 300_000
 
 	// defaults based on a target total retry time of at least 5s. 30*((2^8)-1)>5000
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -49,6 +49,11 @@ const (
 	DefaultImageServiceAddress = "/run/containerd/containerd.sock"
 )
 
+// ParallelPullUnpack defaults
+const (
+	Unbounded = -1
+)
+
 // FSConfig defaults
 const (
 	defaultFuseTimeoutSec = 1
@@ -106,4 +111,26 @@ const (
 
 	// DefaultSOCIV2Enable is the default value for whether SOCI v2 is enabled
 	DefaultSOCIV2Enable = true
+
+	// DefaultParallelPullEnable is the default value for whether parallel pull and unpack is enabled
+	DefaultParallelPullUnpackEnable = false
+
+	// Defaults for ParallelPullUnpack.
+	// The default values should mirror default containerd values.
+
+	// defaultMaxConcurrentDownloads sets the default value for how many reads can be done over the network at a time.
+	defaultMaxConcurrentDownloads = Unbounded
+	// defaultMaxConcurrentDownloadsPerImage sets the default value for how many reads a single image can do over the network at a time.
+	// This must be less than or equal to MaxConcurrentDownloads.
+	defaultMaxConcurrentDownloadsPerImage = 3
+
+	// defaultConcurrentDownloadChunkSize sets the default value for the max size, in bytes, of downloaded content per network read.
+	// When unbounded, full layer is downloaded in one request
+	defaultConcurrentDownloadChunkSize = Unbounded
+
+	// defaultMaxConcurrentUnpacks sets the default value for the max number of layers that will be unpacked at once.
+	defaultMaxConcurrentUnpacks = Unbounded
+	// defaultMaxConcurrentUnpacks sets the default value for the max number of layers per image that will be unpacked at once.
+	// This must be less than or equal to MaxConcurrentUnpacks.
+	defaultMaxConcurrentUnpacksPerImage = 1
 )

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,0 +1,19 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package config defines the SOCI snapshotter default configuration and
+// utility commands for parsing configuration from a TOML file.
+package config // import "github.com/awslabs/soci-snapshotter/config"

--- a/config/fs.go
+++ b/config/fs.go
@@ -171,6 +171,10 @@ const (
 	SociContentStoreType       ContentStoreType = "soci"
 )
 
+func TrimSocketAddress(address string) string {
+	return strings.TrimPrefix(address, "unix://")
+}
+
 // ContentStoreConfig chooses and configures the content store
 type ContentStoreConfig struct {
 	Type ContentStoreType `toml:"type"`
@@ -289,12 +293,14 @@ func parseBlobConfig(cfg *Config) error {
 
 func parseContentStoreConfig(cfg *Config) error {
 	if cfg.ContentStoreConfig.Type == "" {
-		// The snapshotter's default content store is soci until we're confident in the containerd integration
+		// We are intentionally not using containerd as the default content store until we do more testing.
+		// Until we are confident, use the SOCI store instead.
 		cfg.ContentStoreConfig.Type = SociContentStoreType
-	} else if cfg.ContentStoreConfig.Type == ContainerdContentStoreType && cfg.ContentStoreConfig.ContainerdAddress == "" {
+	}
+	if cfg.ContentStoreConfig.ContainerdAddress == "" {
 		cfg.ContentStoreConfig.ContainerdAddress = defaults.DefaultAddress
-	} else if cfg.ContentStoreConfig.Type == ContainerdContentStoreType {
-		cfg.ContentStoreConfig.ContainerdAddress = strings.TrimPrefix(cfg.ContentStoreConfig.ContainerdAddress, "unix://")
+	} else {
+		cfg.ContentStoreConfig.ContainerdAddress = TrimSocketAddress(cfg.ContentStoreConfig.ContainerdAddress)
 	}
 	return nil
 }

--- a/config/parallel.go
+++ b/config/parallel.go
@@ -1,0 +1,114 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	sizeRegex = regexp.MustCompile(`(?i)^\s*(\d+(\.\d+)?)(\s*(gb|mb|kb|b)?)?\s*$`)
+
+	unitMultipliers = map[string]float64{
+		"":   1, // no unit specified, treat as bytes
+		"b":  1,
+		"kb": 1024,
+		"mb": 1024 * 1024,
+		"gb": 1024 * 1024 * 1024,
+	}
+)
+
+// DecompressStream specifies the configuration for a decompression implementation.
+type DecompressStream struct {
+	// Path is the system path to the decompression binary.
+	Path string `toml:"path"`
+
+	// Args is a list of command arguments passed to the decompression binary.
+	Args []string `toml:"args"`
+}
+
+// ParallelConfig modifies behavior for eager image pulls.
+// Set any of the TOML vals to negative to unbound any of these operations.
+type ParallelConfig struct {
+	MaxConcurrentDownloads         int64 `toml:"max_concurrent_downloads"`
+	MaxConcurrentDownloadsPerImage int64 `toml:"max_concurrent_downloads_per_image"`
+
+	ConcurrentDownloadChunkSizeStr string `toml:"concurrent_download_chunk_size"`
+	ConcurrentDownloadChunkSize    int64  `toml:"-"`
+
+	MaxConcurrentUnpacks         int64 `toml:"max_concurrent_unpacks"`
+	MaxConcurrentUnpacksPerImage int64 `toml:"max_concurrent_unpacks_per_image"`
+
+	// DecompressStreams modifies the implementations used to unpack compressed layer tarballs.
+	DecompressStreams map[string]DecompressStream `toml:"decompress_streams"`
+
+	DiscardUnpackedLayers bool `toml:"discard_unpacked_layers"`
+}
+
+func defaultParallelConfig() ParallelConfig {
+	return ParallelConfig{
+		MaxConcurrentDownloads:         defaultMaxConcurrentDownloads,
+		MaxConcurrentDownloadsPerImage: defaultMaxConcurrentDownloadsPerImage,
+		ConcurrentDownloadChunkSize:    defaultConcurrentDownloadChunkSize,
+		MaxConcurrentUnpacks:           defaultMaxConcurrentUnpacks,
+		MaxConcurrentUnpacksPerImage:   defaultMaxConcurrentUnpacksPerImage,
+	}
+}
+
+func parseParallelConfig(cfg *Config) error {
+	size, err := parseSize(cfg.PullModes.Parallel.ConcurrentDownloadChunkSizeStr)
+	if err != nil {
+		return err
+	}
+	cfg.PullModes.Parallel.ConcurrentDownloadChunkSize = size
+	return nil
+}
+
+func parseSize(sizeStr string) (int64, error) {
+	if sizeStr == "" {
+		return defaultConcurrentDownloadChunkSize, nil // use default value for empty string
+	}
+
+	matches := sizeRegex.FindStringSubmatch(sizeStr)
+	if matches == nil {
+		return 0, fmt.Errorf("invalid size format: %s", sizeStr)
+	}
+
+	numStr, unitStr := matches[1], strings.ToLower(strings.TrimSpace(matches[4]))
+	num, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse size number: %v", err)
+	}
+
+	multiplier, ok := unitMultipliers[unitStr]
+	if !ok {
+		return 0, fmt.Errorf("unknown size unit: %s", unitStr)
+	}
+
+	size := int64(num * multiplier)
+	if size < 0 {
+		return 0, fmt.Errorf("size cannot be negative: %s", sizeStr)
+	}
+	if size == 0 {
+		size = defaultConcurrentDownloadChunkSize // use default value for zero size
+	}
+
+	return size, nil
+}

--- a/config/pull_modes.go
+++ b/config/pull_modes.go
@@ -16,19 +16,12 @@
 
 package config
 
-import (
-	"fmt"
-	"regexp"
-	"strconv"
-	"strings"
-)
-
 // PullModes contain config related to the ways in
 // in which the SOCI snapshotter can pull images
 type PullModes struct {
-	SOCIv1             V1                 `toml:"soci_v1"`
-	SOCIv2             V2                 `toml:"soci_v2"`
-	ParallelPullUnpack ParallelPullUnpack `toml:"parallel_pull_unpack"`
+	SOCIv1   V1       `toml:"soci_v1"`
+	SOCIv2   V2       `toml:"soci_v2"`
+	Parallel Parallel `toml:"parallel_pull_unpack"`
 }
 
 // V1 contains config for SOCI v1 which uses the
@@ -45,33 +38,12 @@ type V2 struct {
 	Enable bool `toml:"enable"`
 }
 
-// ParallelPull modifies behavior for eager image pulls.
-// Set any of the TOML vals to negative to unbound any of these operations.
-type ParallelPullUnpack struct {
+// Parallel contains config for parallel pull and unpacks
+// Parallel mode does not implment lazy loading strategy but
+// aims to speed up the process via concurrent operations.
+type Parallel struct {
+	ParallelConfig
 	Enable bool `toml:"enable"`
-
-	MaxConcurrentDownloads         int64 `toml:"max_concurrent_downloads"`
-	MaxConcurrentDownloadsPerImage int64 `toml:"max_concurrent_downloads_per_image"`
-
-	ConcurrentDownloadChunkSizeStr string `toml:"concurrent_download_chunk_size"`
-	ConcurrentDownloadChunkSize    int64  `toml:"-"`
-
-	MaxConcurrentUnpacks         int64 `toml:"max_concurrent_unpacks"`
-	MaxConcurrentUnpacksPerImage int64 `toml:"max_concurrent_unpacks_per_image"`
-
-	// DecompressStreams modifies the implementations used to unpack compressed layer tarballs.
-	DecompressStreams map[string]DecompressStream `toml:"decompress_streams"`
-
-	DiscardUnpackedLayers bool `toml:"discard_unpacked_layers"`
-}
-
-// DecompressStream specifies the configuration for a decompression implementation.
-type DecompressStream struct {
-	// Path is the system path to the decompression binary.
-	Path string `toml:"path"`
-
-	// Args is a list of command arguments passed to the decompression binary.
-	Args []string `toml:"args"`
 }
 
 func defaultPullModes(cfg *Config) error {
@@ -89,69 +61,9 @@ func DefaultPullModes() PullModes {
 		SOCIv2: V2{
 			Enable: DefaultSOCIV2Enable,
 		},
-		ParallelPullUnpack: ParallelPullUnpack{
-			Enable:                         DefaultParallelPullUnpackEnable,
-			MaxConcurrentDownloads:         defaultMaxConcurrentDownloads,
-			MaxConcurrentDownloadsPerImage: defaultMaxConcurrentDownloadsPerImage,
-			ConcurrentDownloadChunkSize:    defaultConcurrentDownloadChunkSize,
-			MaxConcurrentUnpacks:           defaultMaxConcurrentUnpacks,
-			MaxConcurrentUnpacksPerImage:   defaultMaxConcurrentUnpacksPerImage,
+		Parallel: Parallel{
+			Enable:         DefaultParallelPullUnpackEnable,
+			ParallelConfig: defaultParallelConfig(),
 		},
 	}
-}
-
-var (
-	sizeRegex = regexp.MustCompile(`(?i)^\s*(\d+(\.\d+)?)(\s*(gb|mb|kb|b)?)?\s*$`)
-
-	unitMultipliers = map[string]float64{
-		"":   1, // no unit specified, treat as bytes
-		"b":  1,
-		"kb": 1024,
-		"mb": 1024 * 1024,
-		"gb": 1024 * 1024 * 1024,
-	}
-)
-
-func parseImagePullConfig(cfg *Config) error {
-	sizeStr := cfg.PullModes.ParallelPullUnpack.ConcurrentDownloadChunkSizeStr
-	if sizeStr != "" {
-		size, err := parseSize(sizeStr)
-		if err != nil {
-			return err
-		}
-		cfg.PullModes.ParallelPullUnpack.ConcurrentDownloadChunkSize = size
-	}
-	return nil
-}
-
-func parseSize(sizeStr string) (int64, error) {
-	if sizeStr == "" {
-		return -1, nil // use default value for empty string
-	}
-
-	matches := sizeRegex.FindStringSubmatch(sizeStr)
-	if matches == nil {
-		return 0, fmt.Errorf("invalid size format: %s", sizeStr)
-	}
-
-	numStr, unitStr := matches[1], strings.ToLower(strings.TrimSpace(matches[4]))
-	num, err := strconv.ParseFloat(numStr, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse size number: %v", err)
-	}
-
-	multiplier, ok := unitMultipliers[unitStr]
-	if !ok {
-		return 0, fmt.Errorf("unknown size unit: %s", unitStr)
-	}
-
-	size := int64(num * multiplier)
-	if size < 0 {
-		return 0, fmt.Errorf("size cannot be negative: %s", sizeStr)
-	}
-	if size == 0 {
-		size = -1 // use default value for zero size
-	}
-
-	return size, nil
 }

--- a/config/pull_modes.go
+++ b/config/pull_modes.go
@@ -16,11 +16,19 @@
 
 package config
 
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
 // PullModes contain config related to the ways in
 // in which the SOCI snapshotter can pull images
 type PullModes struct {
-	SOCIv1 V1 `toml:"soci_v1"`
-	SOCIv2 V2 `toml:"soci_v2"`
+	SOCIv1             V1                 `toml:"soci_v1"`
+	SOCIv2             V2                 `toml:"soci_v2"`
+	ParallelPullUnpack ParallelPullUnpack `toml:"parallel_pull_unpack"`
 }
 
 // V1 contains config for SOCI v1 which uses the
@@ -37,8 +45,38 @@ type V2 struct {
 	Enable bool `toml:"enable"`
 }
 
-func defaultPullModes(cfg *Config) {
+// ParallelPull modifies behavior for eager image pulls.
+// Set any of the TOML vals to negative to unbound any of these operations.
+type ParallelPullUnpack struct {
+	Enable bool `toml:"enable"`
+
+	MaxConcurrentDownloads         int64 `toml:"max_concurrent_downloads"`
+	MaxConcurrentDownloadsPerImage int64 `toml:"max_concurrent_downloads_per_image"`
+
+	ConcurrentDownloadChunkSizeStr string `toml:"concurrent_download_chunk_size"`
+	ConcurrentDownloadChunkSize    int64  `toml:"-"`
+
+	MaxConcurrentUnpacks         int64 `toml:"max_concurrent_unpacks"`
+	MaxConcurrentUnpacksPerImage int64 `toml:"max_concurrent_unpacks_per_image"`
+
+	// DecompressStreams modifies the implementations used to unpack compressed layer tarballs.
+	DecompressStreams map[string]DecompressStream `toml:"decompress_streams"`
+
+	DiscardUnpackedLayers bool `toml:"discard_unpacked_layers"`
+}
+
+// DecompressStream specifies the configuration for a decompression implementation.
+type DecompressStream struct {
+	// Path is the system path to the decompression binary.
+	Path string `toml:"path"`
+
+	// Args is a list of command arguments passed to the decompression binary.
+	Args []string `toml:"args"`
+}
+
+func defaultPullModes(cfg *Config) error {
 	cfg.PullModes = DefaultPullModes()
+	return nil
 }
 
 // DefaultPullModes returns a PullModes struct
@@ -51,5 +89,69 @@ func DefaultPullModes() PullModes {
 		SOCIv2: V2{
 			Enable: DefaultSOCIV2Enable,
 		},
+		ParallelPullUnpack: ParallelPullUnpack{
+			Enable:                         DefaultParallelPullUnpackEnable,
+			MaxConcurrentDownloads:         defaultMaxConcurrentDownloads,
+			MaxConcurrentDownloadsPerImage: defaultMaxConcurrentDownloadsPerImage,
+			ConcurrentDownloadChunkSize:    defaultConcurrentDownloadChunkSize,
+			MaxConcurrentUnpacks:           defaultMaxConcurrentUnpacks,
+			MaxConcurrentUnpacksPerImage:   defaultMaxConcurrentUnpacksPerImage,
+		},
 	}
+}
+
+var (
+	sizeRegex = regexp.MustCompile(`(?i)^\s*(\d+(\.\d+)?)(\s*(gb|mb|kb|b)?)?\s*$`)
+
+	unitMultipliers = map[string]float64{
+		"":   1, // no unit specified, treat as bytes
+		"b":  1,
+		"kb": 1024,
+		"mb": 1024 * 1024,
+		"gb": 1024 * 1024 * 1024,
+	}
+)
+
+func parseImagePullConfig(cfg *Config) error {
+	sizeStr := cfg.PullModes.ParallelPullUnpack.ConcurrentDownloadChunkSizeStr
+	if sizeStr != "" {
+		size, err := parseSize(sizeStr)
+		if err != nil {
+			return err
+		}
+		cfg.PullModes.ParallelPullUnpack.ConcurrentDownloadChunkSize = size
+	}
+	return nil
+}
+
+func parseSize(sizeStr string) (int64, error) {
+	if sizeStr == "" {
+		return -1, nil // use default value for empty string
+	}
+
+	matches := sizeRegex.FindStringSubmatch(sizeStr)
+	if matches == nil {
+		return 0, fmt.Errorf("invalid size format: %s", sizeStr)
+	}
+
+	numStr, unitStr := matches[1], strings.ToLower(strings.TrimSpace(matches[4]))
+	num, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse size number: %v", err)
+	}
+
+	multiplier, ok := unitMultipliers[unitStr]
+	if !ok {
+		return 0, fmt.Errorf("unknown size unit: %s", unitStr)
+	}
+
+	size := int64(num * multiplier)
+	if size < 0 {
+		return 0, fmt.Errorf("size cannot be negative: %s", sizeStr)
+	}
+	if size == 0 {
+		size = -1 // use default value for zero size
+	}
+
+	return size, nil
 }

--- a/config/service.go
+++ b/config/service.go
@@ -83,8 +83,9 @@ type SnapshotterConfig struct {
 	AllowInvalidMountsOnRestart bool `toml:"allow_invalid_mounts_on_restart"`
 }
 
-func parseServiceConfig(cfg *Config) {
+func parseServiceConfig(cfg *Config) error {
 	if cfg.CRIKeychainConfig.ImageServicePath == "" {
 		cfg.CRIKeychainConfig.ImageServicePath = DefaultImageServiceAddress
 	}
+	return nil
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -48,7 +48,7 @@ This set of variables must be at the top of your TOML file due to not belonging 
 - `MaxWaitMsec` (int) — Max time between network request attempts. Default: 300000.
 - `DialTimeoutMsec` (int) — Max time for a connection before timeout. Default: 3000.
 - `ResponseHeaderTimeoutMsec` (int) — Maximum duration waiting for response headers before timeout. Default: 3000.
-- `RequestTimeoutMsec` (int) — Maximum duration waiting for entire request before timeout. Default: 30000.
+- `RequestTimeoutMsec` (int) — Maximum duration waiting for entire request before timeout. Default: 300000.
 
 ### [blob]
 - `valid_interval` (int) — Checks blob regularly at this interval in seconds. Default: 60.

--- a/fs/adaptive_fetch_image_layers.go
+++ b/fs/adaptive_fetch_image_layers.go
@@ -1,0 +1,866 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"maps"
+	rand "math/rand/v2"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/containerd/log"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	alphanumeric              = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	defaultUnpackDirLen       = 10 // Arbitrary length
+	unlimited           int64 = 0
+	maxRetriesUniqueID        = 10 // Arbitrary amount
+	unpackDir                 = "unpack"
+	unpackDirPerm             = 0700
+	layerUnpackDir            = "fs"
+	layerUnpackDirPerm        = 0700
+)
+
+var (
+	// TODO: pipe through garbage collection frequency to configuration.
+	// The default frequency for garbage collection. This value was arbitrarily chosen.
+	garbageCollectionInterval = 10 * time.Second
+
+	// TODO: pipe through garbage collection job expiration.
+	// The default expiration time for in progress jobs to be garbage collected.
+	garbageCollectionJobExpiration = 2 * time.Hour
+)
+
+var (
+	ErrImageUnpackJobNotFound    = errors.New("image unpack job not found")
+	ErrImageUnpackJobHasNoLayers = errors.New("image unpack job has no layers")
+	ErrImageUnpackJobExpired     = errors.New("image unpack job has expired")
+	ErrLayerHasNoJobs            = errors.New("layer has no jobs")
+
+	ErrNoClaimableLayerJobs    = errors.New("no claimable jobs")
+	ErrLayerJobNotFound        = errors.New("specified layer job not found")
+	ErrLayerJobCannotBeCleaned = errors.New("layer job cannot be cleaned (is not claimed or cancelled)")
+
+	// ErrLayerIngestDoesNotExist can occur during layer unpack operations when parallel layer download has disabled.
+	ErrLayerIngestDoesNotExist = errors.New("layer ingest does not exist")
+
+	// ErrLayerUnpackDestinationHasContent can occur during layer unpack operations. Before writing content to disk,
+	// the unpacker verifies the destination directory has no pre-existing content as a layer of protection from
+	// container image layer poisoning attacks.
+	ErrLayerUnpackDestinationHasContent = errors.New("layer unpack destination has content")
+)
+
+type SemaphoreWithNil struct {
+	smp *semaphore.Weighted
+}
+
+func NewSemaphoreWithNil(n int64) *SemaphoreWithNil {
+	s := &SemaphoreWithNil{}
+	if n > unlimited {
+		s.smp = semaphore.NewWeighted(n)
+	}
+	return s
+}
+
+func (s *SemaphoreWithNil) Acquire(ctx context.Context, n int64) error {
+	if s.smp != nil {
+		return s.smp.Acquire(ctx, n)
+	}
+	return nil
+}
+
+func (s *SemaphoreWithNil) Release(n int64) {
+	if s.smp != nil {
+		s.smp.Release(n)
+	}
+}
+
+type unpackJobs struct {
+	imagePullCfg config.ParallelPullUnpack
+
+	globalConcurrentDownloadsLimiter *SemaphoreWithNil
+	globalConcurrentUnpacksLimiter   *SemaphoreWithNil
+
+	storage LayerUnpackJobStorage
+
+	images map[string]*imageUnpackJob
+	mu     sync.Mutex
+}
+
+func newUnpackJobs(ctx context.Context, ParallelPullUnpack config.ParallelPullUnpack, storage LayerUnpackJobStorage) (*unpackJobs, error) {
+	var (
+		globalConcurrentDownloadsLimit = ParallelPullUnpack.MaxConcurrentDownloads
+		globalConcurrentUnpacksLimit   = ParallelPullUnpack.MaxConcurrentUnpacks
+	)
+
+	if err := checkParallelPullUnpack(ParallelPullUnpack); err != nil {
+		return nil, fmt.Errorf("error validating image pull config: %w", err)
+	}
+
+	log.G(ctx).WithFields(log.Fields{
+		"max_concurrent_downloads":           ParallelPullUnpack.MaxConcurrentDownloads,
+		"max_concurrent_downloads_per_image": ParallelPullUnpack.MaxConcurrentDownloadsPerImage,
+		"max_concurrent_unpacks":             ParallelPullUnpack.MaxConcurrentUnpacks,
+		"max_concurrent_unpacks_per_image":   ParallelPullUnpack.MaxConcurrentUnpacksPerImage,
+		"discard_unpack_layers":              ParallelPullUnpack.DiscardUnpackedLayers,
+	}).Info("Parallel image pull enabled")
+
+	if ParallelPullUnpack.MaxConcurrentDownloads == config.Unbounded {
+		globalConcurrentDownloadsLimit = unlimited
+	}
+
+	if ParallelPullUnpack.MaxConcurrentUnpacks == config.Unbounded {
+		globalConcurrentUnpacksLimit = unlimited
+	}
+
+	jobs := &unpackJobs{
+		imagePullCfg:                     ParallelPullUnpack,
+		globalConcurrentDownloadsLimiter: NewSemaphoreWithNil(globalConcurrentDownloadsLimit),
+		globalConcurrentUnpacksLimiter:   NewSemaphoreWithNil(globalConcurrentUnpacksLimit),
+		images:                           make(map[string]*imageUnpackJob),
+		storage:                          storage,
+		mu:                               sync.Mutex{},
+	}
+
+	garbageCollector := newGarbageCollector(garbageCollectionInterval, jobs, storage)
+	go garbageCollector.Run(ctx)
+
+	return jobs, nil
+}
+
+func checkParallelPullUnpack(cfg config.ParallelPullUnpack) error {
+	// If global concurrent downloads/unpacks are unlimited, any value for per-image concurrent downloads/unpacks are valid
+	var err error
+	if cfg.MaxConcurrentDownloads > unlimited && cfg.MaxConcurrentDownloadsPerImage > cfg.MaxConcurrentDownloads {
+		err = errors.New("global download limit less than per-image download limit")
+	}
+
+	// If global concurrent downloads/unpacks are limited, per-image concurrent downloads/unpacks should be <= the global value
+	if cfg.MaxConcurrentUnpacks > unlimited && cfg.MaxConcurrentUnpacksPerImage > cfg.MaxConcurrentUnpacks {
+		err = errors.Join(err, errors.New("global unpack limit less than per-image unpack limit"))
+	}
+	return err
+}
+
+// GetOrAddImageJob adds the requisite image job to unpackJobs.
+// If the job already exists, return nil.
+// Else, return the newly created imageUnpackJob.
+func (jobs *unpackJobs) GetOrAddImageJob(imageDigest string, cancel context.CancelCauseFunc) *imageUnpackJob {
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+
+	if jobs.imageExists(imageDigest) {
+		return jobs.images[imageDigest]
+	}
+
+	jobs.images[imageDigest] = newImageUnpackJob(imageDigest,
+		withImageDownloadsLimit(jobs.imagePullCfg.MaxConcurrentDownloadsPerImage),
+		withImageUnpacksLimit(jobs.imagePullCfg.MaxConcurrentUnpacksPerImage),
+		withGlobalConcurrentDownloadsLimiter(jobs.globalConcurrentDownloadsLimiter),
+		withGlobalConcurrentUnpacksLimiter(jobs.globalConcurrentUnpacksLimiter),
+		withCancelFunc(cancel),
+	)
+
+	return jobs.images[imageDigest]
+}
+
+// AddLayerJob both adds the job to the in-memory store and creates the requisite folder on disk
+func (jobs *unpackJobs) AddLayerJob(imageJob *imageUnpackJob, layerDigest string) (*layerUnpackJob, error) {
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+
+	layerJob, err := newLayerUnpackJob(layerDigest, jobs.storage, withImageUnpackJob(imageJob))
+	if err != nil {
+		return nil, err
+	}
+
+	jobs.images[imageJob.imageDigest].layers[layerDigest] =
+		append(jobs.images[imageJob.imageDigest].layers[layerDigest], layerJob)
+
+	return layerJob, nil
+}
+
+func (jobs *unpackJobs) checkLayerExists(imageDigest, layerDigest string) error {
+	if !jobs.imageExists(imageDigest) {
+		return fmt.Errorf("%w: %s", ErrImageUnpackJobNotFound, imageDigest)
+	}
+
+	if len(jobs.images[imageDigest].layers) == 0 {
+		return fmt.Errorf("%w: %s", ErrImageUnpackJobHasNoLayers, imageDigest)
+	}
+
+	if len(jobs.images[imageDigest].layers[layerDigest]) == 0 {
+		return fmt.Errorf("%w: %s", ErrLayerHasNoJobs, layerDigest)
+	}
+
+	return nil
+}
+
+func (jobs *unpackJobs) ImageExists(imageDigest string) bool {
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+
+	return jobs.imageExists(imageDigest)
+}
+
+func (jobs *unpackJobs) imageExists(imageDigest string) bool {
+	_, ok := jobs.images[imageDigest]
+	return ok
+}
+
+// Claim marks a job so that no other jobs can attempt to rebase it.
+// Claim should always be followed by a remove on the same job.
+func (jobs *unpackJobs) Claim(imageDigest, layerDigest string) (*layerUnpackJob, error) {
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+
+	if err := jobs.checkLayerExists(imageDigest, layerDigest); err != nil {
+		return nil, fmt.Errorf("claim job: %w", err)
+	}
+
+	// Loop through all available jobs until we can claim one
+	for _, status := range jobs.images[imageDigest].layers[layerDigest] {
+		if status.Claim() {
+			return status, nil
+		}
+	}
+
+	return nil, ErrNoClaimableLayerJobs
+}
+
+var (
+	errEmptyJobID            = errors.New("job id is empty")
+	errUniqueJobIDGenFailure = errors.New("failed to generate unique job id")
+	errJobNotFound           = errors.New("job not found")
+)
+
+// LayerUnpackJobStorage defines an interface for persisting layer unpack job state
+// to a durable storage medium.
+type LayerUnpackJobStorage interface {
+	// Create an unpack job in storage and return its unique identifier.
+	Create() (string, error)
+
+	// GetJobPath returns a path on disk to use for a specified unpack job.
+	GetJobPath(string) (string, error)
+
+	// Keys lists all jobs in storage.
+	Keys() ([]string, error)
+
+	// Delete a specified unpack job from storage.
+	Delete(string) error
+}
+
+// LayerUnpackDiskStorage persists image unpack jobs to disk.
+type LayerUnpackDiskStorage struct {
+	unpackRoot string
+}
+
+func newLayerUnpackDiskStorage(root string) (LayerUnpackJobStorage, error) {
+	directory := filepath.Join(root, unpackDir)
+
+	// Check if unpack directory already exists, and remove it if found.
+	if _, err := os.Stat(directory); err == nil {
+		// Directory exists, remove it
+		if err := os.RemoveAll(directory); err != nil {
+			return nil, fmt.Errorf("failed to remove existing unpack directory: %w", err)
+		}
+		log.G(context.Background()).WithField("dir", directory).Debug("removed existing unpack directory")
+	}
+
+	// Create a fresh unpack directory
+	if err := os.MkdirAll(directory, unpackDirPerm); err != nil {
+		return nil, err
+	}
+
+	return &LayerUnpackDiskStorage{
+		unpackRoot: directory,
+	}, nil
+}
+
+// Create an unpack job on disk with a unique identifier.
+func (disk LayerUnpackDiskStorage) Create() (string, error) {
+	key, err := disk.generateUniqueKey()
+	if err != nil {
+		return "", err
+	}
+
+	err = os.MkdirAll(filepath.Join(disk.unpackRoot, key, layerUnpackDir), layerUnpackDirPerm)
+	if err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+func (disk LayerUnpackDiskStorage) generateUniqueKey() (string, error) {
+	for attempt := range maxRetriesUniqueID {
+		key := generateUniqueString(defaultUnpackDirLen)
+		if len(key) > 0 && !disk.contains(key) {
+			return key, nil
+		}
+		log.G(context.Background()).WithField("id", key).WithField("attempt", attempt+1).Debug("randomly generated id already exists in storage")
+	}
+	return "", errUniqueJobIDGenFailure
+}
+
+func generateUniqueString(n int) string {
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for range n {
+		sb.WriteByte(alphanumeric[rand.Int64()%int64(len(alphanumeric))])
+	}
+	return sb.String()
+}
+
+func (disk LayerUnpackDiskStorage) GetJobPath(id string) (string, error) {
+	if !disk.contains(id) {
+		return "", errJobNotFound
+	}
+	return disk.getJobPath(id), nil
+}
+
+func (disk LayerUnpackDiskStorage) getJobPath(id string) string {
+	return filepath.Join(disk.unpackRoot, id)
+}
+
+// Keys unpack jobs found on disk.
+// If the root unpack directory does not exist, then an empty list will be returned with no error.
+func (disk LayerUnpackDiskStorage) Keys() ([]string, error) {
+	entries, err := os.ReadDir(disk.unpackRoot)
+	if errors.Is(err, fs.ErrNotExist) {
+		// No unpack jobs found on disk. Return an empty list; not an error.
+		return []string{}, nil
+	} else if err != nil {
+		return []string{}, err
+	}
+
+	unpackJobs := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			unpackJobs = append(unpackJobs, entry.Name())
+		}
+	}
+
+	return unpackJobs, nil
+}
+
+func (disk LayerUnpackDiskStorage) contains(id string) bool {
+	_, err := os.Stat(disk.getJobPath(id))
+	return err == nil
+}
+
+// Delete the specified layer unpack job from disk.
+func (disk LayerUnpackDiskStorage) Delete(id string) error {
+	if id == "" {
+		return errEmptyJobID
+	}
+	return os.RemoveAll(disk.getJobPath(id))
+}
+
+type unpackJobsSnapshot struct {
+	inMemory  map[string]*layerUnpackJobSnapshot
+	inStorage []string
+}
+
+type layerUnpackJobSnapshot struct {
+	imageID           string
+	creationTimestamp int64
+}
+
+func (jobs *unpackJobs) Snapshot(ctx context.Context) (*unpackJobsSnapshot, error) {
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+
+	snapshot := &unpackJobsSnapshot{
+		inMemory: make(map[string]*layerUnpackJobSnapshot),
+	}
+
+	// All jobs in storage are keyed by layerUnpackID, so go through every single layerUnpackJob
+	for _, image := range jobs.images {
+		for _, layerJobs := range image.layers {
+			for _, v := range layerJobs {
+				snapshot.inMemory[v.layerUnpackID] = &layerUnpackJobSnapshot{
+					imageID:           v.imageDigest,
+					creationTimestamp: v.creationTimestamp,
+				}
+			}
+		}
+	}
+
+	inStorage, err := jobs.storage.Keys()
+	if err != nil {
+		return nil, err
+	}
+	snapshot.inStorage = inStorage
+
+	return snapshot, nil
+}
+
+// Remove will remove the specified layer digest from memory,
+// indicating all fetch and decompress operations have concluded,
+// successful or otherwise.
+// This will only remove cancelled or claimed jobs.
+// If no available jobs meet this criteria, it will return an error.
+func (jobs *unpackJobs) Remove(job *layerUnpackJob, cause error) error {
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+
+	return jobs.remove(job, cause)
+}
+
+func (jobs *unpackJobs) RemoveImageWithError(imageDigest string, cause error) error {
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+
+	imageJob, ok := jobs.images[imageDigest]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrImageUnpackJobNotFound, imageDigest)
+	}
+
+	// Cancelling an image will cancel all layer unpack jobs.
+	imageJob.Cancel(cause)
+	delete(jobs.images, imageDigest)
+	return nil
+}
+
+func (jobs *unpackJobs) remove(job *layerUnpackJob, cause error) error {
+	imageDigest := job.imageDigest
+	layerDigest := job.layerDigest
+	layerUnpackID := job.layerUnpackID
+
+	if err := jobs.checkLayerExists(imageDigest, layerDigest); err != nil {
+		return fmt.Errorf("remove job: %w", err)
+	}
+
+	for i, status := range jobs.images[imageDigest].layers[layerDigest] {
+		if status.layerUnpackID == layerUnpackID {
+			// Proceed only if status is claimed or cancelled
+			switch status.status.Load() {
+			case LayerUnpackJobClaimed:
+			case LayerUnpackJobCancelled:
+			default:
+				return fmt.Errorf("%w: %s", ErrLayerJobCannotBeCleaned, layerUnpackID)
+			}
+
+			jobs.images[imageDigest].layers[layerDigest] = slices.Delete(jobs.images[imageDigest].layers[layerDigest], i, i+1)
+			if len(jobs.images[imageDigest].layers[layerDigest]) == 0 {
+				delete(jobs.images[imageDigest].layers, layerDigest)
+			}
+			if len(jobs.images[imageDigest].layers) == 0 {
+				// Call cancel to avoid context leak
+				jobs.images[imageDigest].cancel(cause)
+				delete(jobs.images, imageDigest)
+			}
+			return nil
+		}
+	}
+
+	return ErrLayerJobNotFound
+}
+
+type imageUnpackJob struct {
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+
+	imageDigest       string
+	creationTimestamp int64
+
+	globalConcurrentDownloadsLimiter *SemaphoreWithNil
+	globalConcurrentUnpacksLimiter   *SemaphoreWithNil
+	concurrentDownloadsLimiter       *SemaphoreWithNil
+	concurrentUnpacksLimiter         *SemaphoreWithNil
+
+	layers map[string][]*layerUnpackJob
+}
+
+type imageUnpackOption func(*imageUnpackJob)
+
+func withImageDownloadsLimit(limit int64) imageUnpackOption {
+	return func(job *imageUnpackJob) {
+		if limit == config.Unbounded {
+			limit = unlimited
+		}
+		job.concurrentDownloadsLimiter = NewSemaphoreWithNil(limit)
+	}
+}
+
+func withImageUnpacksLimit(limit int64) imageUnpackOption {
+	return func(job *imageUnpackJob) {
+		if limit == config.Unbounded {
+			limit = unlimited
+		}
+		job.concurrentUnpacksLimiter = NewSemaphoreWithNil(limit)
+	}
+}
+
+func withGlobalConcurrentDownloadsLimiter(smp *SemaphoreWithNil) imageUnpackOption {
+	return func(job *imageUnpackJob) {
+		job.globalConcurrentDownloadsLimiter = smp
+	}
+
+}
+
+func withGlobalConcurrentUnpacksLimiter(smp *SemaphoreWithNil) imageUnpackOption {
+	return func(job *imageUnpackJob) {
+		job.globalConcurrentUnpacksLimiter = smp
+	}
+}
+
+func withCancelFunc(cancel context.CancelCauseFunc) imageUnpackOption {
+	return func(job *imageUnpackJob) {
+		job.cancel = cancel
+	}
+}
+
+var now = func() time.Time {
+	return time.Now()
+}
+
+func newImageUnpackJob(imageDigest string, opts ...imageUnpackOption) *imageUnpackJob {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	job := &imageUnpackJob{
+		ctx:                              ctx,
+		cancel:                           cancel,
+		imageDigest:                      imageDigest,
+		creationTimestamp:                now().UnixNano(),
+		globalConcurrentDownloadsLimiter: NewSemaphoreWithNil(unlimited),
+		globalConcurrentUnpacksLimiter:   NewSemaphoreWithNil(unlimited),
+		concurrentDownloadsLimiter:       NewSemaphoreWithNil(unlimited),
+		concurrentUnpacksLimiter:         NewSemaphoreWithNil(unlimited),
+		layers:                           make(map[string][]*layerUnpackJob),
+	}
+
+	for _, opt := range opts {
+		opt(job)
+	}
+
+	return job
+}
+
+func (job *imageUnpackJob) Cancel(cause error) {
+	job.cancel(cause)
+}
+
+type layerUnpackJobStatus int
+
+const (
+	LayerUnpackJobInProgress layerUnpackJobStatus = iota
+	LayerUnpackJobClaimed
+	LayerUnpackJobDone
+	LayerUnpackJobFailed
+	LayerUnpackJobCancelled
+)
+
+// LayerUnpackResourceController implements various controls for a layer unpack resources.
+type LayerUnpackResourceController interface {
+	// AcquireUnpackLease rate limits unpackers based on global and per image unpack concurrency limits.
+	AcquireUnpackLease(context.Context) (func(), error)
+
+	// GetUnpackIngestReader returns a reader for the compressed layer tarball on disk for unpacking.
+	GetUnpackIngestReader() (io.ReadCloser, error)
+
+	// VerifyUnpackDestinationIsReady verifies the destination for a layer unpack exists and has no pre-existing content.
+	VerifyUnpackDestinationIsReady() error
+}
+
+type layerUnpackJobOption func(*layerUnpackJob)
+
+type layerUnpackJob struct {
+	// Inherit fields from parent via withImageUnpackJob
+	imageDigest                      string
+	cancel                           context.CancelCauseFunc
+	globalConcurrentDownloadsLimiter *SemaphoreWithNil
+	globalConcurrentUnpacksLimiter   *SemaphoreWithNil
+	concurrentDownloadsLimiter       *SemaphoreWithNil
+	concurrentUnpacksLimiter         *SemaphoreWithNil
+	creationTimestamp                int64
+
+	// Unique to layerUnpackJob struct
+	layerUnpackID string
+	layerDigest   string
+	ingestPath    string
+	upperPath     string
+	errCh         chan error
+	status        atomic.Value
+}
+
+func withImageUnpackJob(image *imageUnpackJob) layerUnpackJobOption {
+	return func(luj *layerUnpackJob) {
+		luj.imageDigest = image.imageDigest
+		luj.cancel = image.cancel
+		luj.globalConcurrentDownloadsLimiter = image.globalConcurrentDownloadsLimiter
+		luj.globalConcurrentUnpacksLimiter = image.globalConcurrentUnpacksLimiter
+		luj.concurrentDownloadsLimiter = image.concurrentDownloadsLimiter
+		luj.concurrentUnpacksLimiter = image.concurrentUnpacksLimiter
+		luj.creationTimestamp = image.creationTimestamp
+	}
+}
+
+// Note: unpacker needs to provide same errCh for all layers associated with a ingest so
+// the channel is correctly sized.
+func newLayerUnpackJob(layerDigest string, storage LayerUnpackJobStorage, opts ...layerUnpackJobOption) (*layerUnpackJob, error) {
+	id, err := storage.Create()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new layer unpack job in storage for layer %s: %w", layerDigest, err)
+	}
+
+	path, err := storage.GetJobPath(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch unpack root for layer %s: %w", layerDigest, err)
+	}
+
+	luj := &layerUnpackJob{
+		layerUnpackID: id,
+		layerDigest:   layerDigest,
+		ingestPath:    filepath.Join(path, layerDigest),
+		upperPath:     filepath.Join(path, layerUnpackDir),
+		status:        atomic.Value{},
+		errCh:         make(chan error, 1),
+	}
+
+	for _, opt := range opts {
+		opt(luj)
+	}
+
+	luj.status.Store(LayerUnpackJobInProgress)
+
+	return luj, nil
+}
+
+func (job *layerUnpackJob) AcquireDownload(ctx context.Context, n int64) error {
+	if err := job.concurrentDownloadsLimiter.Acquire(ctx, n); err != nil {
+		return err
+	}
+	return job.globalConcurrentDownloadsLimiter.Acquire(ctx, n)
+}
+
+func (job *layerUnpackJob) ReleaseDownload(n int64) {
+	job.concurrentDownloadsLimiter.Release(n)
+	job.globalConcurrentDownloadsLimiter.Release(n)
+}
+
+// AcquireUnpackLease is a blocking call to acquire the bandwidth to unpack a layer in parallel.
+// A closure function is returned for freeing resources along with an error if the allocation is unsuccessful.
+func (job *layerUnpackJob) AcquireUnpackLease(ctx context.Context) (func(), error) {
+	if err := job.concurrentUnpacksLimiter.Acquire(ctx, 1); err != nil {
+		return nil, err
+	}
+
+	if err := job.globalConcurrentUnpacksLimiter.Acquire(ctx, 1); err != nil {
+		// Context was cancelled before global lock was acquired; release the per image lock
+		// that was already acquired.
+		job.concurrentUnpacksLimiter.Release(1)
+		return nil, err
+	}
+
+	return func() {
+		job.concurrentUnpacksLimiter.Release(1)
+		job.globalConcurrentUnpacksLimiter.Release(1)
+	}, nil
+}
+
+func (job *layerUnpackJob) Cancel(cause error) {
+	job.cancel(cause)
+	job.status.Store(LayerUnpackJobCancelled)
+}
+
+// Claim claims this job and returns true if job is unclaimed,
+// and false if the job is already claimed.
+func (job *layerUnpackJob) Claim() bool {
+	return job.status.CompareAndSwap(LayerUnpackJobInProgress, LayerUnpackJobClaimed)
+}
+
+// GetIngestLocation returns the filepath of the compressed tarball for a layer unpack job.
+func (job *layerUnpackJob) GetIngestLocation() string {
+	return job.ingestPath
+}
+
+// GetUnpackIngestReader returns the reader for the compressed tarball on disk.
+func (job *layerUnpackJob) GetUnpackIngestReader() (io.ReadCloser, error) {
+	// If ingest path is empty, then the compressed tarball was not pulled ahead of time.
+	if job.ingestPath == "" {
+		return nil, ErrLayerIngestDoesNotExist
+	}
+
+	return os.Open(job.GetIngestLocation())
+}
+
+// GetUnpackUpperPath returns the filepath for the temporary unpack directory for a layer unpack job.
+func (job *layerUnpackJob) GetUnpackUpperPath() string {
+	return job.upperPath
+}
+
+// VerifyUnpackDestinationIsReady verifies the unpack destination exists and has no pre-existing content.
+func (job *layerUnpackJob) VerifyUnpackDestinationIsReady() error {
+	f, err := os.Open(job.GetUnpackUpperPath())
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	return ErrLayerUnpackDestinationHasContent
+}
+
+// garbageCollectionPolicy defines the interface for implementing different garbage collection
+// strategies to manage unpack job resources. Implementations of this interface determine
+// how and when resources should be cleaned up during the image unpacking process.
+//
+// The policy is enforced periodically by the garbage collector to maintain system resources
+// and clean up stale or unused resources.
+type garbageCollectionPolicy interface {
+	MarkAndSweep(context.Context, *unpackJobsSnapshot)
+}
+
+type diskSpaceGarbageCollectionPolicy interface {
+	garbageCollectionPolicy
+}
+
+// GarbageCollectIfNotInMemory defines a garbage collection policy for freeing resources
+// for unpacks found on-disk not being tracked in memory.
+type garbageCollectIfNotFoundInMemory struct {
+	storage LayerUnpackJobStorage
+}
+
+// MarkAndSweep all image unpack resources in persistent state which have no reference in-memory.
+func (gcp garbageCollectIfNotFoundInMemory) MarkAndSweep(ctx context.Context, jobs *unpackJobsSnapshot) {
+	logger := log.G(ctx).WithField("policy", "NotFoundInMemory")
+
+	jobs.inStorage = slices.DeleteFunc(jobs.inStorage, func(id string) bool {
+		if _, ok := jobs.inMemory[id]; ok {
+			// Job is tracked in-memory, skip.
+			return false
+		}
+
+		jobCtxLogger := logger.WithField("id", id)
+		jobCtxLogger.Trace("Marked for cleanup")
+
+		if err := gcp.storage.Delete(id); err != nil {
+			jobCtxLogger.WithError(err).Error("Failed to free resources for untracked image unpack")
+			return false
+		}
+
+		return true
+	})
+}
+
+type memoryGarbageCollectionPolicy interface {
+	garbageCollectionPolicy
+}
+
+type garbageCollectIfExpired struct {
+	expiryTime time.Duration
+
+	// cancelImageUnpack still cancel all layer unpack jobs associated with an image unpack.
+	cancelImageUnpack func(string) error
+}
+
+// MarkAndSweep marks all in-progress jobs which that were created before the expiry time for garbage collection.
+func (p garbageCollectIfExpired) MarkAndSweep(ctx context.Context, jobs *unpackJobsSnapshot) {
+	logger := log.G(ctx).WithField("policy", "Expired")
+	cancelledImages := map[string]struct{}{}
+
+	maps.DeleteFunc(jobs.inMemory, func(id string, layer *layerUnpackJobSnapshot) bool {
+		// All layers from the same image share the creation timestamp. Cancelling one layer will cancel all of them.
+		// So just remove the layer from the snapshot if it has already been cancelled.
+		if _, ok := cancelledImages[layer.imageID]; ok {
+			return true
+		}
+
+		if time.Since(time.Unix(0, layer.creationTimestamp)) > p.expiryTime {
+			jobCtxLogger := logger.WithField("id", id)
+			jobCtxLogger.Trace("Marked for cleanup")
+
+			if err := p.cancelImageUnpack(layer.imageID); err != nil {
+				jobCtxLogger.WithError(err).Error("Failed to cancel job")
+				return false
+			}
+			cancelledImages[layer.imageID] = struct{}{}
+
+			jobCtxLogger.Trace("Reclaimed memory")
+			return true
+		}
+		return false
+	})
+}
+
+type garbageCollector struct {
+	interval time.Duration
+	snapshot func(context.Context) (*unpackJobsSnapshot, error)
+
+	unusedMemory    []memoryGarbageCollectionPolicy
+	unusedDiskSpace diskSpaceGarbageCollectionPolicy
+}
+
+func newGarbageCollector(interval time.Duration, jobs *unpackJobs, storage LayerUnpackJobStorage) *garbageCollector {
+	return &garbageCollector{
+		interval: interval,
+		snapshot: func(ctx context.Context) (*unpackJobsSnapshot, error) {
+			return jobs.Snapshot(ctx)
+		},
+		unusedMemory: []memoryGarbageCollectionPolicy{
+			garbageCollectIfExpired{
+				expiryTime: garbageCollectionJobExpiration,
+				cancelImageUnpack: func(id string) error {
+					return jobs.RemoveImageWithError(id, ErrImageUnpackJobExpired)
+				},
+			},
+		},
+		unusedDiskSpace: garbageCollectIfNotFoundInMemory{storage: storage},
+	}
+}
+
+// Run starts the garbage collector and runs the lifetime of the provided context.
+func (gc garbageCollector) Run(ctx context.Context) {
+	ticker := time.NewTicker(gc.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			snapshot, err := gc.snapshot(ctx)
+			if err != nil {
+				log.G(ctx).WithError(err).Error("Failed to take snapshot of unpack jobs")
+				continue
+			}
+
+			for _, policy := range gc.unusedMemory {
+				policy.MarkAndSweep(ctx, snapshot)
+			}
+
+			// Free disk after memory for garbage collection efficiency.
+			gc.unusedDiskSpace.MarkAndSweep(ctx, snapshot)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/fs/adaptive_fetch_image_layers_test.go
+++ b/fs/adaptive_fetch_image_layers_test.go
@@ -1,0 +1,506 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/goleak"
+)
+
+const (
+	testGarbageCollectionFrequency = 100 * time.Millisecond
+)
+
+func init() {
+	garbageCollectionInterval = testGarbageCollectionFrequency
+}
+
+var (
+	helloWorldImageDigest = "sha256:7e1a4e2d11e2ac7a8c3f768d4166c2defeb09d2a750b010412b6ea13de1efb19"
+	helloWorldLayerDigest = "sha256:e6590344b1a5dc518829d6ea1524fc12f8bcd14ee9a02aa6ad8360cce3a9a9e9"
+)
+
+func TestParallelPullUnpackValidation(t *testing.T) {
+	tc := []struct {
+		name       string
+		cfg        config.ParallelPullUnpack
+		expectFail bool
+	}{
+		{
+			name: "empty image pull config is valid",
+		},
+		{
+			name: "logical image pull config is valid",
+			cfg: config.ParallelPullUnpack{
+				MaxConcurrentDownloads:         9,
+				MaxConcurrentDownloadsPerImage: 3,
+				MaxConcurrentUnpacks:           3,
+				MaxConcurrentUnpacksPerImage:   1,
+			},
+		},
+		{
+			name: "illogical image pull config is not valid",
+			cfg: config.ParallelPullUnpack{
+				MaxConcurrentDownloads:         1,
+				MaxConcurrentDownloadsPerImage: 3,
+				MaxConcurrentUnpacks:           1,
+				MaxConcurrentUnpacksPerImage:   3,
+			},
+			expectFail: true,
+		},
+	}
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			testCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			_, err := newUnpackJobs(testCtx, tt.cfg, newVirtualDisk())
+			if (err != nil) != tt.expectFail {
+				if tt.expectFail {
+					t.Fatalf("expected bad image config to fail but succeeded")
+				} else {
+					t.Fatalf("expected good image config to succeed but failed")
+				}
+			}
+		})
+	}
+}
+
+// TestNoGoroutinesAreLeakedWhenGarbageCollectionIsCancelled asserts that garbage collection
+// goroutines are cleaned up when the context is cancelled.
+func TestNoGoroutinesAreLeakedWhenGarbageCollectionIsCancelled(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, _ = newUnpackJobs(testCtx, config.ParallelPullUnpack{}, newVirtualDisk())
+	await(3 * ticks)
+}
+
+// TestSystemResourcesAreGarbageCollectedForCompletedJobs asserts all completed image unpack jobs
+// are cleaned up by the garbage collector.
+func TestSystemResourcesAreGarbageCollectedForCompletedJobs(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	disk := newVirtualDisk()
+	disk.CreateCompletedImageUnpackJobs(3 * jobs)
+
+	inProgressJobs, _ := newUnpackJobs(testCtx, config.ParallelPullUnpack{}, disk)
+	await(3 * ticks)
+
+	disk.AssertAllUnusedResourcesHaveBeenGarbageCollected(t, inProgressJobs)
+}
+
+// TestInProgressJobsAreNotGarbageCollected asserts any in-progress image unpack jobs
+// are not marked and reclaimed by the garbage collector.
+func TestInProgressJobsAreNotGarbageCollected(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	disk := newVirtualDisk()
+	disk.CreateCompletedImageUnpackJobs(3 * jobs)
+
+	inProgressJobs, _ := newUnpackJobs(testCtx, config.ParallelPullUnpack{}, disk)
+	createEphemeralInProgressImageUnpackJob(t, inProgressJobs)
+	await(3 * ticks)
+
+	disk.AssertAllUsedResourcesHaveNotBeenGarbageCollected(t, inProgressJobs)
+}
+
+// TestExpiredJobsAreGarbageCollected asserts any in-progress image unpack jobs
+// that have been running longer than the default expiry time are cancelled and reclaimed
+// by the garbage collector.
+func TestExpiredJobsAreGarbageCollected(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	disk := newVirtualDisk()
+	inProgressJobs, _ := newUnpackJobs(testCtx, config.ParallelPullUnpack{}, disk)
+	createExpiredInProgressImageUnpackJob(t, inProgressJobs)
+
+	await(3 * ticks)
+
+	disk.AssertAllUnusedResourcesHaveBeenGarbageCollected(t, inProgressJobs)
+}
+
+const (
+	ticks = 1
+	jobs  = 1
+)
+
+func await(numberOfTicks int) {
+	ticker := time.NewTicker(garbageCollectionInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		if numberOfTicks == 0 {
+			return
+		}
+		numberOfTicks--
+	}
+}
+
+func createEphemeralInProgressImageUnpackJob(t testing.TB, inProgressJobs *unpackJobs) {
+	imageJob := inProgressJobs.GetOrAddImageJob(helloWorldImageDigest, func(cause error) {})
+	_, err := inProgressJobs.AddLayerJob(imageJob, helloWorldLayerDigest)
+	if err != nil {
+		t.Fatalf("Failed to create ephemeral in-progress image unpack job: %v", err)
+	}
+}
+
+func createExpiredInProgressImageUnpackJob(t testing.TB, inProgressJobs *unpackJobs) {
+	originalNow := now
+	defer func() {
+		now = originalNow
+	}()
+
+	// Set the current time to be in the past so the created job is expired.
+	now = func() time.Time {
+		return time.Now().Add(-1 * garbageCollectionJobExpiration)
+	}
+
+	imageJob := inProgressJobs.GetOrAddImageJob(helloWorldImageDigest, func(cause error) {})
+	_, err := inProgressJobs.AddLayerJob(imageJob, helloWorldLayerDigest)
+	if err != nil {
+		t.Fatalf("Failed to create ephemeral in-progress image unpack job: %v", err)
+	}
+}
+
+type LayerUnpackVirtualStorage struct {
+	jobs sync.Map
+}
+
+func newVirtualDisk() *LayerUnpackVirtualStorage {
+	return &LayerUnpackVirtualStorage{}
+}
+
+func (virtual *LayerUnpackVirtualStorage) Create() (string, error) {
+	id, err := virtual.generateUniqueKey()
+	if err != nil {
+		return "", err
+	}
+
+	virtual.jobs.Store(id, struct{}{})
+
+	return id, nil
+}
+
+func (virtual *LayerUnpackVirtualStorage) generateUniqueKey() (string, error) {
+	for range 10 {
+		id := generateUniqueString(defaultUnpackDirLen)
+		if _, ok := virtual.jobs.Load(id); !ok {
+			return id, nil
+		}
+	}
+	return "", errUniqueJobIDGenFailure
+}
+
+func (virtual *LayerUnpackVirtualStorage) GetJobPath(id string) (string, error) {
+	if _, ok := virtual.jobs.Load(id); ok {
+		return id, nil
+	}
+	return "", errJobNotFound
+}
+
+func (virtual *LayerUnpackVirtualStorage) Keys() ([]string, error) {
+	jobs := []string{}
+
+	virtual.jobs.Range(func(key, value any) bool {
+		jobs = append(jobs, key.(string))
+		return true
+	})
+
+	return jobs, nil
+}
+
+func (virtual *LayerUnpackVirtualStorage) Delete(id string) error {
+	if _, ok := virtual.jobs.Load(id); !ok {
+		return errJobNotFound
+	}
+
+	virtual.jobs.Delete(id)
+	return nil
+}
+
+func (virtual *LayerUnpackVirtualStorage) CreateCompletedImageUnpackJobs(numberOfJobs int) {
+	for range numberOfJobs {
+		_, _ = virtual.Create()
+	}
+}
+
+func (virtual *LayerUnpackVirtualStorage) AssertAllUnusedResourcesHaveBeenGarbageCollected(t testing.TB, inProgressJobs *unpackJobs) {
+	snapshot, err := inProgressJobs.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to snapshot state: %v", err)
+	}
+
+	virtual.jobs.Range(func(key, value any) bool {
+		if _, ok := snapshot.inMemory[key.(string)]; ok {
+			t.Fatalf("Expected all unused resources to be garbage collected, but found %s was not reclaimed", key)
+		}
+		return true
+	})
+}
+
+func (virtual *LayerUnpackVirtualStorage) AssertAllUsedResourcesHaveNotBeenGarbageCollected(t testing.TB, inProgressJobs *unpackJobs) {
+	snapshot, err := inProgressJobs.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to snapshot state: %v", err)
+	}
+
+	for id := range snapshot.inMemory {
+		if _, ok := virtual.jobs.Load(id); !ok {
+			t.Fatalf("Expected all used resources to be not garbage collected, but did not find %s in persistent storage", id)
+		}
+	}
+}
+
+func TestLayerUnpackDiskStorage(t *testing.T) {
+	type testContextKey string
+
+	subtests := []struct {
+		name    string
+		arrange func(testing.TB) (context.Context, LayerUnpackJobStorage)
+		act     func(testing.TB, context.Context, LayerUnpackJobStorage) context.Context
+		assert  func(testing.TB, context.Context, LayerUnpackJobStorage)
+	}{
+		{
+			name: "CreateEmptyUnpackDirectoryIfItAlreadyExists",
+			arrange: func(t testing.TB) (context.Context, LayerUnpackJobStorage) {
+				root := t.TempDir()
+				rootUnpack := filepath.Join(root, unpackDir)
+				if err := os.MkdirAll(rootUnpack, unpackDirPerm); err != nil {
+					t.Fatalf("Failed to create directory: %v", err)
+				}
+
+				markerPath := filepath.Join(rootUnpack, "marker")
+				if _, err := os.Create(markerPath); err != nil {
+					t.Fatalf("Failed to create marker file: %v", err)
+				}
+
+				uut, err := newLayerUnpackDiskStorage(root)
+				if err != nil {
+					t.Fatalf("Failed to create uut: %v", err)
+				}
+				return context.WithValue(context.Background(), testContextKey("marker"), markerPath), uut
+			},
+			act: func(_ testing.TB, ctx context.Context, _ LayerUnpackJobStorage) context.Context {
+				return ctx
+			},
+			assert: func(t testing.TB, ctx context.Context, _ LayerUnpackJobStorage) {
+				markerPath := ctx.Value(testContextKey("marker")).(string)
+				if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+					t.Fatalf("Expected marker file to be deleted, but it still exists")
+				}
+			},
+		},
+		{
+			name: "Create",
+			arrange: func(t testing.TB) (context.Context, LayerUnpackJobStorage) {
+				uut, err := newLayerUnpackDiskStorage(t.TempDir())
+				if err != nil {
+					t.Fatalf("Failed to create uut: %v", err)
+				}
+				return context.Background(), uut
+			},
+			act: func(t testing.TB, ctx context.Context, uut LayerUnpackJobStorage) context.Context {
+				id, err := uut.Create()
+				if err != nil {
+					t.Fatalf("Failed to create job: %v", err)
+				}
+				return context.WithValue(ctx, testContextKey("id"), id)
+			},
+			assert: func(t testing.TB, ctx context.Context, uut LayerUnpackJobStorage) {
+				id := ctx.Value(testContextKey("id")).(string)
+				if _, err := uut.GetJobPath(id); err != nil {
+					t.Fatalf("Failed to fetch job: %v", err)
+				}
+			},
+		},
+		{
+			name: "Keys",
+			arrange: func(t testing.TB) (context.Context, LayerUnpackJobStorage) {
+				uut, err := newLayerUnpackDiskStorage(t.TempDir())
+				if err != nil {
+					t.Fatalf("Failed to create uut: %v", err)
+				}
+
+				ids := []string{}
+				for range 3 {
+					id, err := uut.Create()
+					if err != nil {
+						t.Fatalf("Failed to create job: %v", err)
+					}
+					ids = append(ids, id)
+				}
+
+				return context.WithValue(context.Background(), testContextKey("expectedIDs"), ids), uut
+			},
+			act: func(t testing.TB, ctx context.Context, uut LayerUnpackJobStorage) context.Context {
+				ids, err := uut.Keys()
+				if err != nil {
+					t.Fatalf("Failed to list all jobs: %v", err)
+				}
+				return context.WithValue(ctx, testContextKey("actualIDs"), ids)
+			},
+			assert: func(t testing.TB, ctx context.Context, uut LayerUnpackJobStorage) {
+				expectedIDs := ctx.Value(testContextKey("expectedIDs")).([]string)
+				actualIDs := ctx.Value(testContextKey("actualIDs")).([]string)
+				if len(expectedIDs) != len(actualIDs) {
+					t.Fatalf("Expected %d jobs, but got %d jobs", len(expectedIDs), len(actualIDs))
+				}
+
+				slices.Sort(expectedIDs)
+				slices.Sort(actualIDs)
+
+				if cmp.Diff(expectedIDs, actualIDs) != "" {
+					t.Fatalf("Expected %v, but got %v", expectedIDs, actualIDs)
+				}
+			},
+		},
+		{
+			name: "GetJobPath",
+			arrange: func(t testing.TB) (context.Context, LayerUnpackJobStorage) {
+				root := t.TempDir()
+				uut, err := newLayerUnpackDiskStorage(root)
+				if err != nil {
+					t.Fatalf("Failed to create uut: %v", err)
+				}
+				unpackDir := filepath.Join(root, unpackDir)
+				return context.WithValue(context.Background(), testContextKey("root"), unpackDir), uut
+			},
+			act: func(t testing.TB, ctx context.Context, uut LayerUnpackJobStorage) context.Context {
+				id, err := uut.Create()
+				if err != nil {
+					t.Fatalf("Failed to create job: %v", err)
+				}
+				return context.WithValue(ctx, testContextKey("id"), id)
+			},
+			assert: func(t testing.TB, ctx context.Context, uut LayerUnpackJobStorage) {
+				root := ctx.Value(testContextKey("root")).(string)
+				id := ctx.Value(testContextKey("id")).(string)
+
+				path, err := uut.GetJobPath(id)
+				if err != nil {
+					t.Fatalf("Failed to fetch job: %v", err)
+				}
+
+				if path != filepath.Join(root, id) {
+					t.Fatalf("Expected %s, but got %s", filepath.Join(root, id), path)
+				}
+			},
+		},
+		{
+			name: "Delete",
+			arrange: func(t testing.TB) (context.Context, LayerUnpackJobStorage) {
+				uut, err := newLayerUnpackDiskStorage(t.TempDir())
+				if err != nil {
+					t.Fatalf("Failed to create uut: %v", err)
+				}
+				id, err := uut.Create()
+				if err != nil {
+					t.Fatalf("Failed to create job: %v", err)
+				}
+				return context.WithValue(context.Background(), testContextKey("id"), id), uut
+			},
+			act: func(t testing.TB, ctx context.Context, uut LayerUnpackJobStorage) context.Context {
+				err := uut.Delete(ctx.Value(testContextKey("id")).(string))
+				if err != nil {
+					t.Fatalf("Failed to delete job: %v", err)
+				}
+				return ctx
+			},
+			assert: func(t testing.TB, ctx context.Context, uut LayerUnpackJobStorage) {
+				id := ctx.Value(testContextKey("id")).(string)
+				keys, err := uut.Keys()
+				if err != nil {
+					t.Fatalf("Failed to list all jobs: %v", err)
+				}
+				if slices.Contains(keys, id) {
+					t.Fatalf("Expected job to be deleted, but found it")
+				}
+			},
+		},
+	}
+
+	for _, test := range subtests {
+		t.Run(test.name, func(t *testing.T) {
+			testCtx, uut := test.arrange(t)
+			testCtx = test.act(t, testCtx, uut)
+			test.assert(t, testCtx, uut)
+		})
+	}
+}
+
+func TestLayerUnpackJob(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	disk := newVirtualDisk()
+	inProgressJobs, err := newUnpackJobs(testCtx, config.ParallelPullUnpack{}, disk)
+	if err != nil {
+		t.Fatalf("Expected no setup error, got %v", err)
+	}
+	createEphemeralInProgressImageUnpackJob(t, inProgressJobs)
+
+	ephemeralJob, err := inProgressJobs.Claim(helloWorldImageDigest, helloWorldLayerDigest)
+	if err != nil {
+		t.Fatalf("Failed to claim ephemeral job: %v", err)
+	}
+	if ephemeralJob == nil {
+		t.Fatalf("Expected to claim ephemeral job, but did not")
+	}
+	if status := ephemeralJob.status.Load(); status != LayerUnpackJobClaimed {
+		t.Fatalf("Expected job to be claimed, but was %v", status)
+	}
+
+	path, err := disk.GetJobPath(ephemeralJob.layerUnpackID)
+	if err != nil {
+		t.Fatalf("Failed to fetch job path: %v", err)
+	}
+
+	expectedIngestPath := filepath.Join(path, helloWorldLayerDigest)
+	ingestPath := ephemeralJob.GetIngestLocation()
+	if ingestPath != expectedIngestPath {
+		t.Fatalf("Expected ingest path to be %s, but got %s", expectedIngestPath, ingestPath)
+	}
+
+	expectedUnpackUpperPath := filepath.Join(path, "fs")
+	upperPath := ephemeralJob.GetUnpackUpperPath()
+	if upperPath != expectedUnpackUpperPath {
+		t.Fatalf("Expected unpack upper path to be %s, but got %s", expectedUnpackUpperPath, upperPath)
+	}
+}

--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -30,6 +30,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/awslabs/soci-snapshotter/util/ioutils"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/log"
@@ -202,7 +203,7 @@ func (f *artifactFetcher) resolve(ctx context.Context, desc ocispec.Descriptor) 
 // Store takes in an descriptor and io.Reader and stores it in the local store.
 func (f *artifactFetcher) Store(ctx context.Context, desc ocispec.Descriptor, reader io.Reader) error {
 	err := f.localStore.Push(ctx, desc, reader)
-	if err != nil {
+	if err != nil && !errdefs.IsAlreadyExists(err) && !errors.Is(err, errdef.ErrAlreadyExists) {
 		return fmt.Errorf("unable to push to local store: %w", err)
 	}
 	return nil

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -364,6 +364,10 @@ type filesystem struct {
 	pullModes                   config.PullModes
 }
 
+func (fs *filesystem) MountParallel(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
+	return fs.MountLocal(ctx, mountpoint, labels, mounts)
+}
+
 func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
 	imageRef, ok := labels[ctdsnapshotters.TargetRefLabel]
 	if !ok {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -423,30 +423,7 @@ func (fs *filesystem) MountParallel(ctx context.Context, mountpoint string, labe
 	if err != nil {
 		return fmt.Errorf("cannot parse image ref (%s): %w", imageRef, err)
 	}
-	remoteStore, err := newRemoteBlobStore(refspec, client)
-	if err != nil {
-		return fmt.Errorf("cannot create remote store: %w", err)
-	}
-	if err != nil {
-		return fmt.Errorf("cannot create fetcher: %w", err)
-	}
 	desc := s.Target
-
-	// If the descriptor size is zero, the artifact fetcher will resolve it.
-	// However, it never returns this resolved descriptor.
-	// Since the unpacker is also in charge of storing the content and the
-	// ORAS store requires an expected size, we need to resolve here.
-	if desc.Size == 0 {
-		// In remoteStore.Reference, Registry and Target should be correct.
-		// However, we need Reference to point to the current layer.
-		blobRef := remoteStore.Reference
-		blobRef.Reference = s.Target.Digest.String()
-		desc, err = remoteStore.Resolve(ctx, blobRef.String())
-		if err != nil {
-			return fmt.Errorf("cannot resolve size of layer (%s): %w", blobRef.String(), err)
-		}
-	}
-
 	imageDigest, ok := labels[ctdsnapshotters.TargetManifestDigestLabel]
 	if !ok {
 		return errors.New("layer has no image manifest attached")

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -436,7 +436,7 @@ func (fs *filesystem) MountParallel(ctx context.Context, mountpoint string, labe
 		}
 	}
 
-	err = fs.rebase(ctx, desc, imageDigest, mountpoint)
+	err = fs.rebase(ctx, desc.Digest, imageDigest, mountpoint)
 	if err != nil {
 		return fmt.Errorf("failed to rebase layer %s: %w", desc.Digest, err)
 	}
@@ -561,8 +561,8 @@ func (fs *filesystem) premount(ctx context.Context, desc ocispec.Descriptor, ref
 	return err
 }
 
-func (fs *filesystem) rebase(ctx context.Context, desc ocispec.Descriptor, imageDigest, mountpoint string) error {
-	layerJob, err := fs.inProgressImageUnpacks.Claim(imageDigest, desc.Digest.String())
+func (fs *filesystem) rebase(ctx context.Context, dgst digest.Digest, imageDigest, mountpoint string) error {
+	layerJob, err := fs.inProgressImageUnpacks.Claim(imageDigest, dgst.String())
 	if err != nil {
 		return fmt.Errorf("error attempting to claim job to rebase: %w", err)
 	}
@@ -575,7 +575,7 @@ func (fs *filesystem) rebase(ctx context.Context, desc ocispec.Descriptor, image
 		}
 	}()
 
-	log.G(ctx).WithField("digest", desc.Digest).Debug("claimed layer")
+	log.G(ctx).WithField("digest", dgst).Debug("claimed layer")
 
 	select {
 	case <-ctx.Done():

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -527,8 +527,8 @@ func (fs *filesystem) premount(ctx context.Context, desc ocispec.Descriptor, ref
 	}()
 
 	archive := NewLayerArchive()
-
-	fetcher, err := newArtifactFetcher(refspec, fs.contentStore, remoteStore)
+	chunkSize := fs.pullModes.ParallelPullUnpack.ConcurrentDownloadChunkSize
+	fetcher, err := newParallelArtifactFetcher(refspec, fs.contentStore, remoteStore, layerJob, chunkSize)
 	if err != nil {
 		log.G(ctx).WithError(err).Error("cannot create fetcher")
 		return err

--- a/fs/parallel_artifact_fetcher.go
+++ b/fs/parallel_artifact_fetcher.go
@@ -1,0 +1,287 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/awslabs/soci-snapshotter/soci/store"
+	"github.com/containerd/containerd/reference"
+	"github.com/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/errgroup"
+)
+
+// artifactFetcher is responsible for fetching and storing artifacts in the provided artifact store.
+type parallelArtifactFetcher struct {
+	*artifactFetcher
+	layerUnpackJob *layerUnpackJob
+	chunkSize      int64
+}
+
+// Constructs a new artifact fetcher
+// Takes in the image reference, the local store and the resolver
+func newParallelArtifactFetcher(refspec reference.Spec, localStore store.BasicStore, remoteStore resolverStorage, layerUnpackJob *layerUnpackJob, chunkSize int64) (*parallelArtifactFetcher, error) {
+	if chunkSize <= 0 {
+		chunkSize = unlimited
+	}
+	return &parallelArtifactFetcher{
+		artifactFetcher: &artifactFetcher{
+			localStore:  localStore,
+			remoteStore: remoteStore,
+			refspec:     refspec,
+		},
+		layerUnpackJob: layerUnpackJob,
+		chunkSize:      chunkSize,
+	}, nil
+}
+
+// Fetches the artifact identified by the descriptor.
+// It first checks the local store for the artifact.
+// If not found, if constructs the ref and writes to a temporary file on disk,
+// then returns the readcloser for that file.
+func (f *parallelArtifactFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser, bool, error) {
+
+	// Check local store first
+	rc, err := f.localStore.Fetch(ctx, desc)
+	if err == nil {
+		return rc, true, nil
+	}
+
+	log.G(ctx).WithField("digest", desc.Digest.String()).Infof("fetching artifact from remote")
+	if desc.Size == 0 {
+		// Digest verification fails is desc.Size == 0
+		// Therefore, we try to use the resolver to resolve the descriptor
+		// and hopefully get the size.
+		// Note that the resolve would fail for size > 4MiB, since that's the limit
+		// for the manifest size when using the Docker resolver.
+		log.G(ctx).WithField("digest", desc.Digest).Warnf("size of descriptor is 0, trying to resolve it...")
+		desc, err = f.resolve(ctx, desc)
+		if err != nil {
+			return nil, false, fmt.Errorf("size of descriptor is 0; unable to resolve: %w", err)
+		}
+	}
+
+	// If it doesn't exist locally, pull concurrently in chunks and write to temporary file
+	rc, err = f.fetchFromRemoteAndWriteToTempDir(ctx, desc)
+	if err != nil {
+		return nil, false, fmt.Errorf("unable to fetch descriptor (%v) from remote store: %w", desc.Digest, err)
+	}
+
+	return rc, false, nil
+}
+
+// Returns [lower, upper] of the content we want to read.
+func (f *parallelArtifactFetcher) getRange(i, descSize int64) (int64, int64) {
+	if f.chunkSize <= unlimited {
+		return 0, descSize - 1
+	}
+
+	lower := i * f.chunkSize
+	upper := min(lower+f.chunkSize, descSize)
+	upper-- // Range is inclusive
+	return lower, upper
+}
+
+// Returns the number of loops needed to fetch a resource
+// given a descriptor and the artifactFetcher's chunk size
+func (f *parallelArtifactFetcher) calcNumLoops(size int64) int64 {
+	if f.chunkSize <= 0 {
+		return 1
+	}
+
+	// Return ceiling of size / f.chunkSize
+	numLoops := size / f.chunkSize
+	if size%f.chunkSize != 0 {
+		numLoops++
+	}
+	return numLoops
+}
+
+// fetchFromRemoteAndWriteToTempDir pulls the artifact from the remote repository,
+// writes it to a file on disk, and returns a ReadCloser for the new file.
+// This way we can control when exactly the content is being fetched,
+// and any further reads to this content will be fetched from disk,
+// not from upstream.
+func (f *parallelArtifactFetcher) fetchFromRemoteAndWriteToTempDir(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser, error) {
+	ingestPath := f.layerUnpackJob.GetIngestLocation()
+
+	// Refuse to unpack if file already exists
+	_, err := os.Stat(ingestPath)
+	if err == nil {
+		err = fs.ErrExist
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("error setting up temporary file: %w", err)
+	}
+
+	file, err := os.Create(ingestPath)
+	if err != nil {
+		return nil, fmt.Errorf("error creating temp ingest file at %s: %w", ingestPath, err)
+	}
+
+	// We want to close this file descriptor as soon as we run into an error.
+	// This can either be during the goroutine or if the context is cancelled.
+	// Closing a file descriptor multiple times is undefined behavior,
+	// so this will enforce that the file is only closed once.
+	closeFileOnce := sync.OnceFunc(func() {
+		file.Close()
+	})
+	defer func() {
+		if err != nil {
+			closeFileOnce()
+		}
+	}()
+
+	err = file.Truncate(desc.Size)
+	if err != nil {
+		return nil, fmt.Errorf("error truncating temp ingest file at %s: %w", ingestPath, err)
+	}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	var isSeekable atomic.Bool
+	isSeekable.Store(true)
+	numLoops := f.calcNumLoops(desc.Size)
+
+	for i := range numLoops {
+		if !isSeekable.Load() {
+			// This val only gets set after the whole readcloser has been
+			// written to file, so safe to stop attempting this again.
+			break
+		}
+
+		err := f.layerUnpackJob.AcquireDownload(ctx, 1)
+		if err != nil {
+			return nil, fmt.Errorf("error acquiring semaphore: %w", err)
+		}
+
+		eg.Go(func() error {
+			defer f.layerUnpackJob.ReleaseDownload(1)
+
+			var err error
+			defer func() {
+				if err != nil {
+					closeFileOnce()
+				}
+			}()
+
+			rc, err := f.remoteStore.Fetch(egCtx, desc)
+			if err != nil {
+				return err
+			}
+
+			errCh := make(chan error, 1)
+			defer close(errCh)
+			var copyFunc func() <-chan error
+
+			rsc, ok := rc.(io.ReadSeekCloser)
+			if numLoops == 1 {
+				copyFunc = func() <-chan error {
+					defer rc.Close()
+					errCh <- writeToEntireFile(file, rc)
+					return errCh
+				}
+			} else if !ok { // Upstream reader is not seekable
+				log.G(egCtx).Debug("upstream reader is not seekable, reading entire descriptor")
+				copyFunc = func() <-chan error {
+					defer rc.Close()
+					if !isSeekable.CompareAndSwap(true, false) {
+						errCh <- nil
+					} else {
+						errCh <- writeToEntireFile(file, rc)
+					}
+					return errCh
+				}
+			} else {
+				copyFunc = func() <-chan error {
+					defer rsc.Close()
+
+					lower, upper := f.getRange(i, desc.Size)
+					errCh <- writeToFileRange(file, rsc, lower, upper)
+					return errCh
+				}
+			}
+
+			select {
+			case <-egCtx.Done():
+				err = egCtx.Err()
+			case err = <-copyFunc():
+			}
+			return err
+		})
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- eg.Wait()
+		close(errCh)
+	}()
+
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+	case err = <-errCh:
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("error writing to temp ingest file at %s: %w", ingestPath, err)
+	}
+
+	n, err := file.Seek(0, io.SeekStart)
+	if n != 0 {
+		err = errors.Join(err, errors.New("seek position != zero"))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error reopening file at %s after writing: %w", ingestPath, err)
+	}
+	return file, nil
+}
+
+func writeToEntireFile(file *os.File, rc io.ReadCloser) error {
+	_, err := io.Copy(file, rc)
+	if err != nil {
+		return fmt.Errorf("failed to write to temp file %s: %w", file.Name(), err)
+	}
+
+	return nil
+}
+
+func writeToFileRange(file *os.File, rsc io.ReadSeekCloser, lower, upper int64) error {
+	w := io.NewOffsetWriter(file, lower)
+
+	_, err := rsc.Seek(lower, io.SeekStart)
+	if err != nil {
+		return fmt.Errorf("failed to seek readcloser: %w", err)
+	}
+
+	readSize := upper - lower + 1
+	// Reading any more or less will result in an incorrect file being created,
+	// so use io.CopyN to guarantee we read exactly lower - upper + 1 bytes.
+	_, err = io.CopyN(w, rsc, readSize)
+	if err != nil {
+		return fmt.Errorf("failed to write to temp file %s at offset %d: %w", file.Name(), lower, err)
+	}
+
+	return nil
+}

--- a/fs/parallel_artifact_fetcher.go
+++ b/fs/parallel_artifact_fetcher.go
@@ -176,6 +176,14 @@ func (f *parallelArtifactFetcher) fetchFromRemoteAndWriteToTempDir(ctx context.C
 			return nil, fmt.Errorf("error acquiring semaphore: %w", err)
 		}
 
+		// Do initial fetch call to cache the redirected URL
+		if i == 0 && numLoops > 1 {
+			err = doInitialFetch(ctx, f.remoteStore, f.refspec, desc)
+			if err != nil {
+				return nil, fmt.Errorf("error doing initial authorization for layer: %w", err)
+			}
+		}
+
 		eg.Go(func() error {
 			defer f.layerUnpackJob.ReleaseDownload(1)
 

--- a/fs/parallel_artifact_fetcher.go
+++ b/fs/parallel_artifact_fetcher.go
@@ -184,10 +184,13 @@ func (f *parallelArtifactFetcher) fetchFromRemoteAndWriteToTempDir(ctx context.C
 		}
 
 		// Do initial fetch call to cache the redirected URL
+		// as long as we're using our blob store implementation.
 		if i == 0 && numLoops > 1 {
-			err = doInitialFetch(ctx, f.remoteStore, f.refspec, desc)
-			if err != nil {
-				return nil, fmt.Errorf("error doing initial authorization for layer: %w", err)
+			if rs, ok := f.remoteStore.(*orasBlobStore); ok {
+				err = rs.doInitialFetch(ctx, f.constructRef(desc))
+				if err != nil {
+					return nil, fmt.Errorf("error doing initial authorization for layer: %w", err)
+				}
 			}
 		}
 

--- a/fs/parallel_unpacker.go
+++ b/fs/parallel_unpacker.go
@@ -19,6 +19,7 @@ package fs
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/mount"
@@ -77,6 +78,7 @@ func (lu *parallelLayerUnpacker) Unpack(ctx context.Context, desc ocispec.Descri
 		})
 	}
 
+	startTime := time.Now()
 	opts := []archive.ApplyOpt{
 		archive.WithConvertWhiteout(archive.OverlayConvertWhiteout),
 	}
@@ -98,6 +100,7 @@ func (lu *parallelLayerUnpacker) Unpack(ctx context.Context, desc ocispec.Descri
 		return fmt.Errorf("cannot apply layer: %w", err)
 	}
 
-	log.G(ctx).WithField("digest", desc.Digest).WithField("mountpoint", mountpoint).Debug("Layer successfully unpacked")
+	log.G(ctx).WithFields(log.Fields{"digest": desc.Digest.String(), "size": desc.Size,
+		"mountpoint": mountpoint, "latency_ms": time.Since(startTime).Milliseconds()}).Debug("Layer successfully unpacked")
 	return errGroup.Wait()
 }

--- a/fs/parallel_unpacker.go
+++ b/fs/parallel_unpacker.go
@@ -1,0 +1,103 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd/archive"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/errgroup"
+)
+
+type parallelLayerUnpacker struct {
+	*layerUnpacker
+	controller            LayerUnpackResourceController
+	discardUnpackedLayers bool
+}
+
+//nolint:revive
+func NewParallelLayerUnpacker(fetcher Fetcher, archive Archive, controller LayerUnpackResourceController, discardUnpackedLayers bool) *parallelLayerUnpacker {
+	return &parallelLayerUnpacker{
+		layerUnpacker: &layerUnpacker{
+			fetcher: fetcher,
+			archive: archive,
+		},
+		controller:            controller,
+		discardUnpackedLayers: discardUnpackedLayers,
+	}
+}
+
+func (lu *parallelLayerUnpacker) Unpack(ctx context.Context, desc ocispec.Descriptor, mountpoint string, mounts []mount.Mount) error {
+	rc, local, err := lu.fetcher.Fetch(ctx, desc)
+	if err != nil {
+		return fmt.Errorf("cannot fetch layer: %w", err)
+	}
+	defer rc.Close()
+
+	release, err := lu.controller.AcquireUnpackLease(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	var errGroup errgroup.Group
+	if !local && !lu.discardUnpackedLayers {
+		ingestReader, err := lu.controller.GetUnpackIngestReader()
+		if err != nil {
+			return fmt.Errorf("cannot get layer ingest: %w", err)
+		}
+		defer ingestReader.Close()
+
+		errGroup.Go(func() error {
+			// containerd Push should handle IsUnavailable error
+			err := lu.fetcher.Store(ctx, desc, ingestReader)
+			if err != nil {
+				return fmt.Errorf("cannot store layer at %s: %w", mountpoint, err)
+			}
+			log.G(ctx).WithField("digest", desc.Digest).WithField("mountpoint", mountpoint).Debug("Layer stored")
+			return nil
+		})
+	}
+
+	opts := []archive.ApplyOpt{
+		archive.WithConvertWhiteout(archive.OverlayConvertWhiteout),
+	}
+
+	if len(mounts) > 0 {
+		if parents := getLayerParents(mounts[0].Options); len(parents) > 0 {
+			opts = append(opts, archive.WithParents(parents))
+		}
+	}
+
+	// Fail-fast if unpack destination does not exist or has any pre-existing content.
+	// Pre-existing content could be a possible poisoning attack attempt.
+	if err := lu.controller.VerifyUnpackDestinationIsReady(); err != nil {
+		return fmt.Errorf("cannot unpack layer %s: %w", desc.Digest, err)
+	}
+
+	_, err = lu.archive.Apply(ctx, mountpoint, rc, opts...)
+	if err != nil {
+		return fmt.Errorf("cannot apply layer: %w", err)
+	}
+
+	log.G(ctx).WithField("digest", desc.Digest).WithField("mountpoint", mountpoint).Debug("Layer successfully unpacked")
+	return errGroup.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	go.etcd.io/bbolt v1.4.1
+	go.uber.org/goleak v1.1.12
 	golang.org/x/crypto v0.39.0
 	golang.org/x/sync v0.15.0
 	golang.org/x/sys v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,7 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -256,6 +257,7 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.4.1 h1:5mOV+HWjIPLEAlUGMsveaUvK2+byZMFOzojoi7bh7uI=
 go.etcd.io/bbolt v1.4.1/go.mod h1:c8zu2BnXWTu2XM4XcICtbGSl9cFwsXtcf9zLt2OncM8=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
@@ -268,6 +270,8 @@ go.opentelemetry.io/otel/metric v1.21.0 h1:tlYWfeo+Bocx5kLEloTjbcDwBuELRrIFxwdQ3
 go.opentelemetry.io/otel/metric v1.21.0/go.mod h1:o1p3CA8nNHW8j5yuQLdc1eeqEaPfzug24uvsyIEJRWM=
 go.opentelemetry.io/otel/trace v1.21.0 h1:WD9i5gzvoUPuXIXH24ZNBudiarZDKuekPqi/E8fpfLc=
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
+go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -278,8 +282,11 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -291,6 +298,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -302,6 +310,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
 golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -311,10 +320,14 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
 golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -332,6 +345,7 @@ golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.33.0 h1:4qz2S3zmRxbGIhDIAgjxvFutSvH5EfnsYrRBj0UI0bc=
 golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -372,6 +386,7 @@ google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwl
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/integration/log_test.go
+++ b/integration/log_test.go
@@ -1,0 +1,132 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"regexp"
+	"testing"
+	"time"
+)
+
+const sensitiveInfoMonitorKey = "sensitive-info-monitor"
+
+// TestSnapshotterDoesNotLogSensitiveInformation verifies that the snapshotter
+// doesn't log sensitive information during various operations.
+func TestSnapshotterDoesNotLogSensitiveInformation(t *testing.T) {
+	image := rabbitmqImage
+
+	disableLazyLoading := `
+	 [snapshotter]
+	 disable_lazy_loading = true
+	 `
+
+	testCases := []struct {
+		name                     string
+		getSnapshotterConfigToml func(*testing.T, bool) string
+	}{
+		{
+			name: "basic image pull",
+			getSnapshotterConfigToml: func(t *testing.T, disableVerification bool) string {
+				return getSnapshotterConfigToml(t, disableVerification)
+			},
+		},
+		{
+			name: "default parallel image pull",
+			getSnapshotterConfigToml: func(t *testing.T, disableVerification bool) string {
+				cfg := getDefaultImagePullConfig()
+				return getSnapshotterConfigToml(t, disableVerification, disableLazyLoading, getImagePullToml(t, cfg))
+			},
+		},
+		{
+			name: "unbounded parallel image pull",
+			getSnapshotterConfigToml: func(t *testing.T, disableVerification bool) string {
+				cfg := getUnboundedImagePullConfig()
+				return getSnapshotterConfigToml(t, disableVerification, disableLazyLoading, getImagePullToml(t, cfg))
+			},
+		},
+		{
+			name: "discard unpacked layers",
+			getSnapshotterConfigToml: func(t *testing.T, disableVerification bool) string {
+				cfg := getDefaultImagePullConfig()
+				cfg.DiscardUnpackedLayers = true
+				return getSnapshotterConfigToml(t, disableVerification, disableLazyLoading, getImagePullToml(t, cfg))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			regConfig := newRegistryConfig()
+			sh, done := newShellWithRegistry(t, regConfig)
+			t.Cleanup(func() {
+				done()
+			})
+
+			logMonitor := rebootContainerd(t, sh, getContainerdConfigToml(t, false), tc.getSnapshotterConfigToml(t, false))
+			logMonitor.Add(sensitiveInfoMonitorKey, sensitiveInfoMonitor(t, sensitivePatterns...))
+			t.Cleanup(func() {
+				logMonitor.Remove(sensitiveInfoMonitorKey)
+			})
+
+			copyImage(sh, dockerhub(image), regConfig.mirror(image))
+			imageRef := regConfig.mirror(image).ref
+
+			sh.X(append(imagePullCmd, imageRef)...)
+
+			// Give some time for logs to be flushed
+			time.Sleep(5 * time.Second)
+		})
+	}
+}
+
+// Patterns that should never appear in logs.
+var sensitivePatterns = []*regexp.Regexp{
+	// Authentication credentials
+	regexp.MustCompile(`(?i)password`),
+	regexp.MustCompile(`(?i)passwd`),
+	regexp.MustCompile(`(?i)secret`),
+	regexp.MustCompile(`(?i)credential`),
+	regexp.MustCompile(`(?i)token`),
+	regexp.MustCompile(`(?i)api[_-]?key`),
+
+	// AWS specific
+	regexp.MustCompile(`AKIA[0-9A-Z]{16}`), // AWS Access Key ID
+	regexp.MustCompile(`(?i)aws[_-]?access[_-]?key`),
+	regexp.MustCompile(`(?i)aws[_-]?secret[_-]?key`),
+
+	// Private keys and certificates
+	regexp.MustCompile(`-----BEGIN (?:RSA )?PRIVATE KEY-----`),
+	regexp.MustCompile(`-----BEGIN CERTIFICATE-----`),
+
+	// OAuth tokens
+	regexp.MustCompile(`(?i)oauth`),
+	regexp.MustCompile(`(?i)bearer`),
+
+	// Common sensitive environment variables
+	regexp.MustCompile(`(?i)basic auth`),
+	regexp.MustCompile(`(?i)authorization: basic`),
+}
+
+func sensitiveInfoMonitor(t *testing.T, patterns ...*regexp.Regexp) func(string) {
+	return func(log string) {
+		for _, pattern := range patterns {
+			if pattern.MatchString(log) {
+				t.Errorf("Found sensitive information in log: %s", log)
+			}
+		}
+	}
+}

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -469,3 +469,23 @@ func checkMetricExists(output, metric string) bool {
 	}
 	return false
 }
+
+// checkLocalMountFailureMetrics checks if the local mount failure metric is emitted the specified number of times
+func checkLocalMountFailureMetrics(t *testing.T, output string, expectedCount int) {
+	metricCountSum := 0
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, commonmetrics.LocalMountFailureCount) {
+			parts := strings.Split(line, " ")
+			if metricCount, err := strconv.Atoi(parts[len(parts)-1]); err == nil && metricCount != 0 {
+				metricCountSum += metricCount
+				break
+			}
+		}
+	}
+
+	if metricCountSum != expectedCount {
+		t.Fatalf("incorrect local mount failure metric count: expected %v; got %v", expectedCount, metricCountSum)
+	}
+}

--- a/integration/pull_modes_test.go
+++ b/integration/pull_modes_test.go
@@ -165,7 +165,7 @@ func testPullModes(t *testing.T, imgName string) {
 				SOCIv2: config.V2{
 					Enable: false,
 				},
-				ParallelPullUnpack: config.ParallelPullUnpack{
+				Parallel: config.Parallel{
 					Enable: true,
 				},
 			},
@@ -220,7 +220,7 @@ func testPullModes(t *testing.T, imgName string) {
 			sh.X(args...)
 			if test.expectedDigest != "" {
 				rsm.CheckAllRemoteSnapshots(t)
-			} else if test.pullModes.ParallelPullUnpack.Enable {
+			} else if test.pullModes.Parallel.Enable {
 				rsm.CheckAllLocalSnapshots(t)
 			} else {
 				rsm.CheckAllDeferredSnapshots(t)

--- a/integration/pull_modes_test.go
+++ b/integration/pull_modes_test.go
@@ -220,8 +220,10 @@ func testPullModes(t *testing.T, imgName string) {
 			sh.X(args...)
 			if test.expectedDigest != "" {
 				rsm.CheckAllRemoteSnapshots(t)
-			} else {
+			} else if test.pullModes.ParallelPullUnpack.Enable {
 				rsm.CheckAllLocalSnapshots(t)
+			} else {
+				rsm.CheckAllDeferredSnapshots(t)
 			}
 			if indexDigestUsed != test.expectedDigest {
 				t.Fatalf("expected digest %s, got %s", test.expectedDigest, indexDigestUsed)
@@ -265,7 +267,7 @@ func testV1IsNotUsedWhenDisabled(t *testing.T, imgName string) {
 	idm := testutil.NewIndexDigestMonitor(m)
 	defer idm.Close()
 	sh.X("nerdctl", "pull", "--snapshotter", "soci", dstInfo.ref)
-	rsm.CheckAllLocalSnapshots(t)
+	rsm.CheckAllDeferredSnapshots(t)
 	if idm.IndexDigest != "" {
 		t.Fatalf("expected no digest, got %s", idm.IndexDigest)
 	}
@@ -355,7 +357,7 @@ func testDanglingV2Annotation(t *testing.T, imgName string) {
 		}
 	})
 	sh.X("nerdctl", "pull", "--snapshotter", "soci", danglingRef.String())
-	rsm.CheckAllLocalSnapshots(t)
+	rsm.CheckAllDeferredSnapshots(t)
 	if !foundNoIndexMessage {
 		t.Fatalf("did not find the message that no index was found")
 	}

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -887,7 +887,7 @@ func TestPullWithParallelism(t *testing.T) {
 			name: "set chunk size",
 			opts: []snapshotterConfigOpt{
 				func(cfg *config.Config) {
-					cfg.PullModes.ParallelPullUnpack.ConcurrentDownloadChunkSize = 1_000_000
+					cfg.PullModes.Parallel.ConcurrentDownloadChunkSize = 1_000_000
 				},
 			},
 		},
@@ -904,7 +904,7 @@ func TestPullWithParallelism(t *testing.T) {
 			name: "parallel unpacking",
 			opts: []snapshotterConfigOpt{
 				func(cfg *config.Config) {
-					cfg.PullModes.ParallelPullUnpack.MaxConcurrentUnpacks = 3
+					cfg.PullModes.Parallel.MaxConcurrentUnpacks = 3
 				},
 			},
 		},
@@ -950,8 +950,8 @@ func TestPullWithDecompressStreams(t *testing.T) {
 			name: "rapidgzip",
 			opts: []snapshotterConfigOpt{
 				func(cfg *config.Config) {
-					cfg.PullModes.ParallelPullUnpack.DecompressStreams = make(map[string]config.DecompressStream, 1)
-					cfg.PullModes.ParallelPullUnpack.DecompressStreams["gzip"] = config.DecompressStream{
+					cfg.PullModes.Parallel.DecompressStreams = make(map[string]config.DecompressStream, 1)
+					cfg.PullModes.Parallel.DecompressStreams["gzip"] = config.DecompressStream{
 						Path: "/usr/local/bin/rapidgzip",
 						Args: []string{"-d", "-c"},
 					}
@@ -962,8 +962,8 @@ func TestPullWithDecompressStreams(t *testing.T) {
 			name: "igzip",
 			opts: []snapshotterConfigOpt{
 				func(cfg *config.Config) {
-					cfg.PullModes.ParallelPullUnpack.DecompressStreams = make(map[string]config.DecompressStream, 1)
-					cfg.PullModes.ParallelPullUnpack.DecompressStreams["gzip"] = config.DecompressStream{
+					cfg.PullModes.Parallel.DecompressStreams = make(map[string]config.DecompressStream, 1)
+					cfg.PullModes.Parallel.DecompressStreams["gzip"] = config.DecompressStream{
 						Path: "/usr/local/bin/igzip",
 						Args: []string{"-d", "-c"},
 					}
@@ -974,8 +974,8 @@ func TestPullWithDecompressStreams(t *testing.T) {
 			name: "pigz",
 			opts: []snapshotterConfigOpt{
 				func(cfg *config.Config) {
-					cfg.PullModes.ParallelPullUnpack.DecompressStreams = make(map[string]config.DecompressStream, 1)
-					cfg.PullModes.ParallelPullUnpack.DecompressStreams["gzip"] = config.DecompressStream{
+					cfg.PullModes.Parallel.DecompressStreams = make(map[string]config.DecompressStream, 1)
+					cfg.PullModes.Parallel.DecompressStreams["gzip"] = config.DecompressStream{
 						Path: "/usr/bin/unpigz",
 						Args: []string{"-d", "-c"},
 					}

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -353,6 +353,37 @@ func withPullModes(pullModes config.PullModes) snapshotterConfigOpt {
 	}
 }
 
+func withParallelPullMode() snapshotterConfigOpt {
+	return withPullModes(config.PullModes{
+		SOCIv1: config.V1{
+			Enable: false,
+		},
+		SOCIv2: config.V2{
+			Enable: false,
+		},
+
+		ParallelPullUnpack: config.ParallelPullUnpack{
+			Enable: true,
+		},
+	})
+}
+
+func withUnboundedPullUnpack() snapshotterConfigOpt {
+	return func(c *config.Config) {
+		c.PullModes.ParallelPullUnpack.MaxConcurrentDownloads = -1
+		c.PullModes.ParallelPullUnpack.MaxConcurrentDownloadsPerImage = -1
+		c.PullModes.ParallelPullUnpack.ConcurrentDownloadChunkSize = 8 * 1024 * 1024 // 8 MiB
+		c.PullModes.ParallelPullUnpack.MaxConcurrentUnpacks = -1
+		c.PullModes.ParallelPullUnpack.MaxConcurrentUnpacksPerImage = -1
+	}
+}
+
+func withDiscardUnpackedLayers() snapshotterConfigOpt {
+	return func(c *config.Config) {
+		c.PullModes.ParallelPullUnpack.DiscardUnpackedLayers = true
+	}
+}
+
 func withContainerdContentStore() snapshotterConfigOpt {
 	return func(c *config.Config) {
 		c.ContentStoreConfig.Type = store.ContainerdContentStoreType

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -361,8 +361,7 @@ func withParallelPullMode() snapshotterConfigOpt {
 		SOCIv2: config.V2{
 			Enable: false,
 		},
-
-		ParallelPullUnpack: config.ParallelPullUnpack{
+		Parallel: config.Parallel{
 			Enable: true,
 		},
 	})
@@ -370,17 +369,17 @@ func withParallelPullMode() snapshotterConfigOpt {
 
 func withUnboundedPullUnpack() snapshotterConfigOpt {
 	return func(c *config.Config) {
-		c.PullModes.ParallelPullUnpack.MaxConcurrentDownloads = -1
-		c.PullModes.ParallelPullUnpack.MaxConcurrentDownloadsPerImage = -1
-		c.PullModes.ParallelPullUnpack.ConcurrentDownloadChunkSize = 8 * 1024 * 1024 // 8 MiB
-		c.PullModes.ParallelPullUnpack.MaxConcurrentUnpacks = -1
-		c.PullModes.ParallelPullUnpack.MaxConcurrentUnpacksPerImage = -1
+		c.PullModes.Parallel.MaxConcurrentDownloads = -1
+		c.PullModes.Parallel.MaxConcurrentDownloadsPerImage = -1
+		c.PullModes.Parallel.ConcurrentDownloadChunkSize = 8 * 1024 * 1024 // 8 MiB
+		c.PullModes.Parallel.MaxConcurrentUnpacks = -1
+		c.PullModes.Parallel.MaxConcurrentUnpacksPerImage = -1
 	}
 }
 
 func withDiscardUnpackedLayers() snapshotterConfigOpt {
 	return func(c *config.Config) {
-		c.PullModes.ParallelPullUnpack.DiscardUnpackedLayers = true
+		c.PullModes.Parallel.DiscardUnpackedLayers = true
 	}
 }
 

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -981,6 +981,6 @@ func FetchContentByDigest(sh *shell.Shell, contentStoreType store.ContentStoreTy
 
 func withContentStoreConfig(opts ...store.Option) snapshotterConfigOpt {
 	return func(c *config.Config) {
-		c.ServiceConfig.FSConfig.ContentStoreConfig = store.NewStoreConfig(opts...)
+		c.ServiceConfig.FSConfig.ContentStoreConfig = store.NewStoreConfig(opts...).ContentStoreConfig
 	}
 }

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -353,6 +353,12 @@ func withPullModes(pullModes config.PullModes) snapshotterConfigOpt {
 	}
 }
 
+func withContainerdContentStore() snapshotterConfigOpt {
+	return func(c *config.Config) {
+		c.ContentStoreConfig.Type = store.ContainerdContentStoreType
+	}
+}
+
 func getSnapshotterConfigToml(t *testing.T, opts ...snapshotterConfigOpt) string {
 	// For integ tests, we intentionally don't initialize the config to simulate
 	// a partially filled config like you might find in a real /etc/soci-snapshotter-grpc/config.toml

--- a/internal/archive/compression/compression.go
+++ b/internal/archive/compression/compression.go
@@ -1,0 +1,244 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// The following code was copied from https://github.com/containerd/containerd/blob/bcc810d6b9066471b0b6fa75f557a15a1cbf31bb/archive/compression/compression.go
+// and modified to allow for configurable decompression streams.
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compression
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	intos "github.com/awslabs/soci-snapshotter/internal/os"
+	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/log"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	gzipCompression = "gzip"
+	zstdCompression = "zstd"
+)
+
+var (
+	initDecompressorsErr error
+	initDecompressors    = sync.Once{}
+	decompressStreams    = map[decompressionKey]DecompressStream{}
+)
+
+type decompressionKey string
+
+const (
+	// dockerGzipDecompression represents gzip compressed container image layers in Docker images.
+	// It is copied from https://github.com/distribution/distribution/blob/e827ce2772e08f38884e5774846ffb1610965a0d/manifest/schema2/manifest.go#L27
+	dockerGzipDecompression decompressionKey = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+
+	ociGzipDecompression decompressionKey = ocispec.MediaTypeImageLayerGzip
+	ociZstdDecompression decompressionKey = ocispec.MediaTypeImageLayerZstd
+)
+
+// DecompressStream is any function which decompresses an archive.
+//
+// It is defined to match [github.com/containerd/containerd/archive/compression.DecompressStream] for easier swapping
+// of decompress stream functionality.
+type DecompressStream func(io.Reader) (compression.DecompressReadCloser, error)
+
+// InitializeDecompressStreams initializes the snapshotter's decompress stream functions.
+//
+// This function is a singleton function; after the first call follow on calls will
+// produce the same result.
+func InitializeDecompressStreams(streams map[string]config.DecompressStream) error {
+	initDecompressors.Do(func() {
+		for alg, c := range streams {
+			// Sanitize and validate the path
+			sanitizedPath, err := intos.SanitizeExecutablePath(c.Path)
+			if err != nil {
+				initDecompressorsErr = fmt.Errorf("%s decompressor path validation failed: %w", alg, err)
+				return
+			}
+
+			// Create a copy of the config with the sanitized path
+			sanitizedConfig := config.DecompressStream{
+				Path: sanitizedPath,
+				Args: c.Args,
+			}
+
+			switch alg {
+			case gzipCompression:
+				decompressStreams[ociGzipDecompression] = decompress(newGzipDecompressor(sanitizedConfig))
+				decompressStreams[dockerGzipDecompression] = decompressStreams[ociGzipDecompression]
+			case zstdCompression:
+				decompressStreams[ociZstdDecompression] = decompress(newZstdDecompressor(sanitizedConfig))
+			default:
+				log.L.WithField("algorithm", alg).Warn("Unsupported compression algorithm")
+			}
+		}
+	})
+
+	return initDecompressorsErr
+}
+
+// GetDecompressStream returns the decompress stream function for a provided layer media type
+// if the snapshotter has been configured to decompress it.
+//
+// If no decompression stream is found, then return false.
+func GetDecompressStream(layerMediaType string) (DecompressStream, bool) {
+	dec, ok := decompressStreams[decompressionKey(layerMediaType)]
+	return dec, ok
+}
+
+type readCloserWrapper struct {
+	io.Reader
+	compression compression.Compression
+	closer      func() error
+}
+
+func (r *readCloserWrapper) Close() error {
+	if r.closer != nil {
+		return r.closer()
+	}
+	return nil
+}
+
+func (r *readCloserWrapper) GetCompression() compression.Compression {
+	return r.compression
+}
+
+type decompressor interface {
+	Compression() compression.Compression
+	Path() string
+	Args() []string
+}
+
+type gzipDecompressor struct {
+	path string
+	args []string
+}
+
+func newGzipDecompressor(c config.DecompressStream) decompressor {
+	return &gzipDecompressor{
+		path: c.Path,
+		args: c.Args,
+	}
+}
+
+func (gz gzipDecompressor) Compression() compression.Compression {
+	return compression.Gzip
+}
+
+func (gz gzipDecompressor) Path() string {
+	return gz.path
+}
+
+func (gz gzipDecompressor) Args() []string {
+	return gz.args
+}
+
+type zstdDecompressor struct {
+	path string
+	args []string
+}
+
+func newZstdDecompressor(c config.DecompressStream) decompressor {
+	return &zstdDecompressor{
+		path: c.Path,
+		args: c.Args,
+	}
+}
+
+func (z zstdDecompressor) Compression() compression.Compression {
+	return compression.Zstd
+}
+
+func (z zstdDecompressor) Path() string {
+	return z.path
+}
+
+func (z zstdDecompressor) Args() []string {
+	return z.args
+}
+
+func decompress(decompressor decompressor) DecompressStream {
+	return func(r io.Reader) (compression.DecompressReadCloser, error) {
+		switch decompressor.Compression() {
+		case compression.Gzip:
+			fallthrough
+		case compression.Zstd:
+			ctx, cancel := context.WithCancel(context.Background())
+			r, err := cmdStream(exec.CommandContext(ctx, decompressor.Path(), decompressor.Args()...), r)
+			if err != nil {
+				cancel()
+				return nil, err
+			}
+			return &readCloserWrapper{
+				Reader:      r,
+				compression: decompressor.Compression(),
+				closer: func() error {
+					cancel()
+					return r.Close()
+				},
+			}, nil
+		default:
+			return nil, fmt.Errorf("unsupported compression algorithm: %v", decompressor.Compression())
+		}
+	}
+}
+
+func cmdStream(cmd *exec.Cmd, in io.Reader) (io.ReadCloser, error) {
+	reader, writer := io.Pipe()
+
+	cmd.Stdin = in
+	cmd.Stdout = writer
+
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			writer.CloseWithError(fmt.Errorf("%s: %s", err, errBuf.String()))
+		} else {
+			writer.Close()
+		}
+	}()
+
+	return reader, nil
+}

--- a/internal/archive/compression/compression_test.go
+++ b/internal/archive/compression/compression_test.go
@@ -1,0 +1,283 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// The following code was copied from https://github.com/containerd/containerd/blob/bcc810d6b9066471b0b6fa75f557a15a1cbf31bb/archive/compression/compression_test.go
+// and modified to allow for configurable decompression streams.
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compression
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func resetDecompressStreams() {
+	decompressStreams = make(map[decompressionKey]DecompressStream)
+	initDecompressors = sync.Once{}
+}
+
+// TestInitializeDecompressStreams asserts the snapshotters decompress streams can be initialized from configuration.
+func TestInitializeDecompressStreams(t *testing.T) {
+	tests := []struct {
+		name                    string
+		decompressStreamsConfig map[string]config.DecompressStream
+		assert                  func(t *testing.T, err error)
+	}{
+		{
+			name:                    "NoDecompressStreamsByDefault",
+			decompressStreamsConfig: map[string]config.DecompressStream{},
+			assert: func(t *testing.T, err error) {
+				if len(decompressStreams) != 0 {
+					t.Fatalf("expected no decompress streams, got %d", len(decompressStreams))
+				}
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "GzipDecompressStream",
+			decompressStreamsConfig: map[string]config.DecompressStream{
+				"gzip": {
+					Path: "/usr/bin/gzip",
+					Args: []string{
+						"-d",
+						"-c",
+					},
+				},
+			},
+			assert: func(t *testing.T, err error) {
+				// Both docker and OCI image layers supports gzip compression.
+				// See https://github.com/opencontainers/image-spec/blob/c05acf7eb327dae4704a4efe01253a0e60af6b34/media-types.md#applicationvndociimagelayerv1targzip
+				if len(decompressStreams) != 2 {
+					t.Fatalf("expected two decompress streams, got %d", len(decompressStreams))
+				}
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				ds, ok := decompressStreams[ociGzipDecompression]
+				if !ok {
+					t.Fatal("expected gzip decompression stream for OCI layers")
+				}
+				if ds == nil {
+					t.Fatal("expected non-nil gzip decompression stream for OCI layers")
+				}
+				ds, ok = decompressStreams[dockerGzipDecompression]
+				if !ok {
+					t.Fatal("expected gzip decompression stream for Docker layers")
+				}
+				if ds == nil {
+					t.Fatal("expected non-nil gzip decompression stream for Docker layers")
+				}
+			},
+		},
+		{
+			name: "IgnoreInvalidDecompressStream",
+			decompressStreamsConfig: map[string]config.DecompressStream{
+				"supercompress": {
+					Path: "/usr/bin/gzip",
+					Args: []string{
+						"-d",
+						"-c",
+					},
+				},
+			},
+			assert: func(t *testing.T, err error) {
+				if len(decompressStreams) != 0 {
+					t.Fatalf("expected no decompress streams, got %d", len(decompressStreams))
+				}
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			},
+		},
+		{
+			name: "GzipDecompressStreamNotFound",
+			decompressStreamsConfig: map[string]config.DecompressStream{
+				"gzip": {
+					Path: "/usr/bin/superfastgzip",
+					Args: []string{
+						"-d",
+						"-c",
+					},
+				},
+			},
+			assert: func(t *testing.T, err error) {
+				if len(decompressStreams) != 0 {
+					t.Fatalf("expected no decompress streams, got %d", len(decompressStreams))
+				}
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+			},
+		},
+		{
+			name: "ZstdDecompressStreamNotFound",
+			decompressStreamsConfig: map[string]config.DecompressStream{
+				"zstd": {
+					Path: "/usr/bin/superfastzstd",
+					Args: []string{
+						"-d",
+						"-c",
+					},
+				},
+			},
+			assert: func(t *testing.T, err error) {
+				if len(decompressStreams) != 0 {
+					t.Fatalf("expected no decompress streams, got %d", len(decompressStreams))
+				}
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resetDecompressStreams()
+
+			err := InitializeDecompressStreams(test.decompressStreamsConfig)
+			test.assert(t, err)
+		})
+	}
+}
+
+// TestGetDecompressStream asserts decompress streams for a media type can be retrieved.
+func TestGetDecompressStream(t *testing.T) {
+	resetDecompressStreams()
+
+	tests := []struct {
+		name           string
+		layerMediaType string
+	}{
+		{
+			name:           "DockerGzipCompressedLayer",
+			layerMediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		},
+		{
+			name:           "OCIGzipCompressedLayer",
+			layerMediaType: ocispec.MediaTypeImageLayerGzip,
+		},
+		{
+			name:           "OCIZstdCompressLayer",
+			layerMediaType: ocispec.MediaTypeImageLayerZstd,
+		},
+		{
+			name:           "EmptyMediaType",
+			layerMediaType: "",
+		},
+		{
+			name:           "UnsupportedMediaType",
+			layerMediaType: "application/vnd.oci.image.layer.v1.tar+unknown",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("no streams initialized[%s]", test.name), func(t *testing.T) {
+			ds, ok := GetDecompressStream(test.layerMediaType)
+			if ok || ds != nil {
+				t.Fatalf("expected no decompress stream for media type %s", test.layerMediaType)
+			}
+		})
+	}
+
+	InitializeDecompressStreams(map[string]config.DecompressStream{
+		"gzip": {
+			Path: "/usr/bin/gzip",
+			Args: []string{
+				"-d",
+				"-c",
+			},
+		},
+	})
+
+	tests = []struct {
+		name           string
+		layerMediaType string
+	}{
+		{
+			name:           "DockerGzipCompressedLayer",
+			layerMediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+		},
+		{
+			name:           "OCIGzipCompressedLayer",
+			layerMediaType: ocispec.MediaTypeImageLayerGzip,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("streams initialized[%s]", test.name), func(t *testing.T) {
+			ds, ok := GetDecompressStream(test.layerMediaType)
+			if !ok || ds == nil {
+				t.Fatalf("expected decompress stream for media type %s", test.layerMediaType)
+			}
+		})
+	}
+}
+
+func TestCmdStream(t *testing.T) {
+	out, err := cmdStream(exec.Command("sh", "-c", "echo hello; exit 0"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf, err := io.ReadAll(out)
+	if err != nil {
+		t.Fatalf("failed to read from stdout: %s", err)
+	}
+
+	if string(buf) != "hello\n" {
+		t.Fatalf("unexpected command output ('%s' != '%s')", string(buf), "hello\n")
+	}
+}
+
+func TestCmdStreamBad(t *testing.T) {
+	out, err := cmdStream(exec.Command("sh", "-c", "echo hello; echo >&2 bad result; exit 1"), nil)
+	if err != nil {
+		t.Fatalf("failed to start command: %v", err)
+	}
+
+	if buf, err := io.ReadAll(out); err == nil {
+		t.Fatal("command should have failed")
+	} else if err.Error() != "exit status 1: bad result\n" {
+		t.Fatalf("wrong error: %s", err.Error())
+	} else if string(buf) != "hello\n" {
+		t.Fatalf("wrong output: %s", string(buf))
+	}
+}

--- a/internal/archive/compression/doc.go
+++ b/internal/archive/compression/doc.go
@@ -1,0 +1,21 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package compression defines the mechanism for configuring decompress streams
+// used to unpack image layer tarballs.
+//
+// Copied and modified from https://github.com/containerd/containerd/blob/bcc810d6b9066471b0b6fa75f557a15a1cbf31bb/archive/compression
+package compression // import "github.com/awslabs/soci-snapshotter/internal/archive/compression"

--- a/internal/http/util.go
+++ b/internal/http/util.go
@@ -71,6 +71,8 @@ func Drain(body io.ReadCloser) {
 
 	// We want to consume response bodies to maintain HTTP connections,
 	// but also want to limit the size read. 4KiB is arbitrary but reasonable.
+	// Anything bigger would likely get better performance from
+	// just closing the connection and establishing a new one.
 	const responseReadLimit = int64(4096)
 	_, _ = io.Copy(io.Discard, io.LimitReader(body, responseReadLimit))
 }

--- a/internal/os/doc.go
+++ b/internal/os/doc.go
@@ -1,0 +1,18 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package os defines shared os utility functions.
+package os // import "github.com/awslabs/soci-snapshotter/internal/os"

--- a/internal/os/filepath.go
+++ b/internal/os/filepath.go
@@ -1,0 +1,68 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package os
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	errFilePathContainsInvalidCharacters = errors.New("path contains invalid characters")
+	errFilePathIsADirectory              = errors.New("path is a directory, not an executable file")
+	errFilePathIsNotExecutable           = errors.New("file is not executable")
+)
+
+// SanitizeExecutablePath cleans and validates a file path to prevent command injection
+func SanitizeExecutablePath(path string) (string, error) {
+	// Check if the path contains any suspicious characters
+	if strings.ContainsAny(path, "#%{}\\|;&$<>") {
+		return "", errFilePathContainsInvalidCharacters
+	}
+
+	// Clean the path to resolve any ".." or "." components
+	cleanPath := filepath.Clean(path)
+	resolvedPath, err := filepath.EvalSymlinks(cleanPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+
+	// Get absolute path to ensure we're working with a full path
+	absPath, err := filepath.Abs(resolvedPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return "", fmt.Errorf("path validation failed: %w", err)
+	}
+
+	if info.IsDir() {
+		return "", errFilePathIsADirectory
+	}
+
+	// Check if the file is executable
+	if info.Mode().Perm()&0111 == 0 {
+		return "", errFilePathIsNotExecutable
+	}
+
+	return resolvedPath, nil
+}

--- a/internal/os/filepath_test.go
+++ b/internal/os/filepath_test.go
@@ -1,0 +1,149 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package os
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestSanitizeExecutablePath(t *testing.T) {
+	testCases := []struct {
+		name         string
+		path         func(string) string
+		expectedPath func(string) string
+		expectedErr  error
+	}{
+		{
+			name: "Valid Path",
+			path: func(root string) string {
+				filepath := fmt.Sprintf("%s/gzip", root)
+				f, err := os.OpenFile(filepath, os.O_CREATE|os.O_EXCL, 0o755)
+				if err != nil {
+					t.Fatal(err)
+				}
+				f.Close()
+				return filepath
+			},
+			expectedPath: func(root string) string {
+				return fmt.Sprintf("%s/gzip", root)
+			},
+		},
+		{
+			name: "SymlinkIsResolved",
+			path: func(root string) string {
+				targetPath := fmt.Sprintf("%s/gzip", root)
+				f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL, 0o755)
+				if err != nil {
+					t.Fatal(err)
+				}
+				f.Close()
+
+				symlinkPath := fmt.Sprintf("%s/symlink-to-executable", root)
+				if err := os.Symlink(targetPath, symlinkPath); err != nil {
+					t.Fatal(err)
+				}
+
+				return symlinkPath
+			},
+			expectedPath: func(root string) string {
+				return fmt.Sprintf("%s/gzip", root)
+			},
+		},
+		{
+			name: "PathContainsInvalidCharacters",
+			path: func(root string) string {
+				return fmt.Sprintf("%s/\\gzip", root)
+			},
+			expectedPath: func(_ string) string {
+				return ""
+			},
+			expectedErr: errFilePathContainsInvalidCharacters,
+		},
+		{
+			name: "PathDoesNotExist",
+			path: func(root string) string {
+				return fmt.Sprintf("%s/does-not-exist", root)
+			},
+			expectedPath: func(_ string) string {
+				return ""
+			},
+			expectedErr: os.ErrNotExist,
+		},
+		{
+			name: "SymlinkToPathDoesNotExist",
+			path: func(root string) string {
+				targetPath := fmt.Sprintf("%s/gzip", root)
+
+				symlinkPath := fmt.Sprintf("%s/symlink-to-executable", root)
+				if err := os.Symlink(targetPath, symlinkPath); err != nil {
+					t.Fatal(err)
+				}
+
+				return symlinkPath
+			},
+			expectedPath: func(_ string) string {
+				return ""
+			},
+			expectedErr: os.ErrNotExist,
+		},
+		{
+			name: "PathIsADirectory",
+			path: func(root string) string {
+				return root
+			},
+			expectedPath: func(_ string) string {
+				return ""
+			},
+			expectedErr: errFilePathIsADirectory,
+		},
+		{
+			name: "PathIsNotExecutable",
+			path: func(root string) string {
+				filepath := fmt.Sprintf("%s/gzip", root)
+				f, err := os.OpenFile(filepath, os.O_CREATE, 0o644)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer f.Close()
+				return filepath
+			},
+			expectedPath: func(_ string) string {
+				return ""
+			},
+			expectedErr: errFilePathIsNotExecutable,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			actualPath, actualErr := SanitizeExecutablePath(testCase.path(tmpDir))
+			if !errors.Is(actualErr, testCase.expectedErr) {
+				t.Errorf("Expected error %v, got %v", testCase.expectedErr, actualErr)
+			}
+
+			expectedPath := testCase.expectedPath(tmpDir)
+			if actualPath != expectedPath {
+				t.Errorf("Expected path %q, got %q", expectedPath, actualPath)
+			}
+		})
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -121,6 +121,9 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	if serviceCfg.SnapshotterConfig.AllowInvalidMountsOnRestart {
 		snOpts = append(snOpts, snbase.AllowInvalidMountsOnRestart)
 	}
+	if serviceCfg.PullModes.ParallelPullUnpack.Enable {
+		snOpts = append(snOpts, snbase.ParallelPullUnpack)
+	}
 
 	snapshotter, err = snbase.NewSnapshotter(ctx, snapshotterRoot(root), fs, snOpts...)
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -121,7 +121,7 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	if serviceCfg.SnapshotterConfig.AllowInvalidMountsOnRestart {
 		snOpts = append(snOpts, snbase.AllowInvalidMountsOnRestart)
 	}
-	if serviceCfg.PullModes.ParallelPullUnpack.Enable {
+	if serviceCfg.PullModes.Parallel.Enable {
 		snOpts = append(snOpts, snbase.ParallelPullUnpack)
 	}
 

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -465,6 +465,11 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 		return nil, err
 	}
 	log.G(lCtx).WithField(remoteSnapshotLogKey, prepareFailed).WithError(err).Debug("skipped preparing remote snapshot")
+	if o.parallelPullUnpack {
+		// If parallel pull/unpack fails, then we should not defer to the container runtime
+		// and just return the error.
+		return nil, err
+	}
 
 	// Local snapshot setup failed. Generally means something critical has gone wrong.
 	log.G(lCtx).WithField(deferredSnapshotLogKey, prepareSucceeded).

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -431,6 +431,10 @@ func (fs *bindFs) IDMapMountLocal(ctx context.Context, mountpoint, activeLayerID
 	return mountpoint, nil
 }
 
+func (fs *bindFs) CleanImage(ctx context.Context, digest string) error {
+	return nil
+}
+
 func dummyFileSystem() FileSystem { return &dummyFs{} }
 
 type dummyFs struct{}
@@ -461,6 +465,10 @@ func (fs *dummyFs) IDMapMount(ctx context.Context, mountpoint, activeLayerID str
 
 func (fs *dummyFs) IDMapMountLocal(ctx context.Context, mountpoint, activeLayerID string, idmap idtools.IDMap) (string, error) {
 	return "", fmt.Errorf("dummy")
+}
+
+func (fs *dummyFs) CleanImage(ctx context.Context, digest string) error {
+	return nil
 }
 
 // =============================================================================

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -419,6 +419,10 @@ func (fs *bindFs) MountLocal(ctx context.Context, mountpoint string, labels map[
 	return nil
 }
 
+func (fs *bindFs) MountParallel(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
+	return fs.MountLocal(ctx, mountpoint, labels, mounts)
+}
+
 func (fs *bindFs) IDMapMount(ctx context.Context, mountpoint, activeLayerID string, idmap idtools.IDMap) (string, error) {
 	return mountpoint, nil
 }
@@ -444,6 +448,10 @@ func (fs *dummyFs) Unmount(ctx context.Context, mountpoint string) error {
 }
 
 func (fs *dummyFs) MountLocal(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
+	return fmt.Errorf("dummy")
+}
+
+func (fs *dummyFs) MountParallel(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
 	return fmt.Errorf("dummy")
 }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
TL;DR this adds a new non-lazy-loaded pull mode that allows for layers to be pulled and unpacked in chunks instead of one chunk per layer.

SOCI has always had a code path for layers that do not have a zTOC, effectively mimicking overlay in its code path. This means that the layer is first fetched, stored if not found in the content store, and then unpacked, all sequentially, and given remote snapshotters' limitations, only one layer at a time can go through these operations. This change adds a new pull mode, `parallel_pull_unpack` which leverages this codepath and modifies it to unpack layers in parallel, and pull in parallel within layers.

An example config is as follows (note this is not necessarily the settings you would want to use for your system):
```
[pull_modes.parallel_pull_unpack]
enable=false # Required to enable this
max_concurrent_downloads=-1 # unlimited across images
max_concurrent_downloads_per_image=20 # 20 chunks fetched per image
concurrent_download_chunk_size="8MiB" # Max chunk size requested from upstream repo
max_concurrent_unpacks=-1 # unlimtetd across images
max_concurrent_unpacks_per_image=5 # Unpack 5 layers at a time
discard_unpacked_layers=false # Skip content store ingestion when true, which can improve performance on IOPS-constrained systems
```

The problem with many similar approaches are often the in-memory buffer which makes it very difficult to get meaningful performance gains. This approach instead uses a temporary file as a buffer, offloading the memory to the file and writing to the file in chunks at specified offsets to avoid having to buffer much in memory.

Decompression of each layer is still done sequentially, but the pulls are all done in parallel, thus the decompression process can start sooner for each layer, resulting in large performance gains.

This approach of course has its downsides, particularly for disk-constrained environments, as all writes are buffered to a file. There's room for improvement so this runs better on less-powerful systems, but more powerful systems should expect large performance gains over traditional overlay. (Notably, containerd 2.1 does implement parallel fetching within a layer, but unpacking is still done sequentially, so this approach theoretically should be faster as unpacking also becomes parallelized in this approach.)

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
