### PR TITLE
Fix snapshotter startup when config is missing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,9 @@ func NewConfig() *Config {
 func NewConfigFromToml(cfgPath string) (*Config, error) {
 	f, err := os.Open(cfgPath)
 	if err != nil {
+		if os.IsNotExist(err) && cfgPath == DefaultConfigPath {
+			return NewConfig(), nil
+		}
 		return nil, fmt.Errorf("failed to open config file %q: %w", cfgPath, err)
 	}
 	defer f.Close()


### PR DESCRIPTION
**Issue #, if available:**
Fixes #1621 

**Description of changes:**
If the default config file is missing, the snapshotter should start up and use the default parsed config file. If the user explicitly passes a config file with `--config` that's different than the default, then that snapshotter will not start if it is missing.

Note: this should be backported to v0.11 and v0.10

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
