### PR TITLE
Fix snapshotter startup when config is missing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,9 @@ func NewConfig() *Config {
 func NewConfigFromToml(cfgPath string) (*Config, error) {
 	f, err := os.Open(cfgPath)
 	if err != nil {
+		if os.IsNotExist(err) && cfgPath == DefaultConfigPath {
+			return NewConfig(), nil
+		}
 		return nil, fmt.Errorf("failed to open config file %q: %w", cfgPath, err)
 	}
 	defer f.Close()


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Cherry-pick #1622 into release/0.11

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
