### PR TITLE
Use own fetcher for ranged GETs

### DIFF
--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -126,40 +126,98 @@ func (r *orasBlobStore) Resolve(ctx context.Context, reference string) (ocispec.
 func (r *orasBlobStore) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
 	rc, err := r.Repository.Fetch(ctx, target)
 	if err != nil {
-		switch retErr := err.(type) {
-		// Redact URLs from ORAS errors, as they might have sensitive info cached
-		case *errcode.ErrorResponse:
-			socihttp.RedactHTTPQueryValuesFromURL(retErr.URL)
-			return nil, retErr
-		// Eat URL errors as a malformed URL might still have credentials.
-		case *url.Error:
-			return nil, errors.New("URL error during fetch")
-		// Otherwise it should be safe to print
-		default:
-			return nil, err
-		}
+		return nil, cleanFetchErrors(err)
 	}
 	return rc, nil
+}
+
+// GetContentWithRange gets the requested content in the byte range [lower, upper]
+func GetContentWithRange(ctx context.Context, realURL string, rt http.RoundTripper, lower, upper int64) (*http.Response, error) {
+	if lower < 0 || upper < lower {
+		return nil, fmt.Errorf("illogical content range [%d, %d]", lower, upper)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, realURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	r := fmt.Sprintf("bytes=%d-%d", lower, upper)
+	req.Header.Set("Range", r)
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusPartialContent {
+		return resp, nil
+	}
+	return nil, fmt.Errorf("error getting range: %v", err)
+}
+
+// FetchRange returns the response body of the range requested.
+// This assumes the upstream repo supports ranged GET calls.
+// If it does not, return an error.
+// TODO: Unify this with the artifact fetching done in fs/remote/resolver.go
+func (r *orasBlobStore) FetchRange(ctx context.Context, reference string, lower, upper int64) (io.ReadCloser, error) {
+	ref, err := registry.ParseReference(reference)
+	if err != nil {
+		return nil, err
+	}
+
+	tr := &clientWrapper{r.Client}
+	realURL := sociremote.CraftBlobURL(reference, ref)
+	resp, err := GetContentWithRange(ctx, realURL, tr, lower, upper)
+	if err != nil {
+		return nil, cleanFetchErrors(err)
+	}
+
+	// Check if upstream allows for ranged GET requests
+	if rangeUnit := resp.Header.Get("Accept-Ranges"); rangeUnit != "bytes" {
+		resp.Body.Close()
+		return nil, fmt.Errorf("upstream repo does not support ranged GET requests")
+	}
+	return resp.Body, nil
+}
+
+func cleanFetchErrors(err error) error {
+	switch retErr := err.(type) {
+	// Redact URLs from ORAS errors, as they might have sensitive info cached
+	case *errcode.ErrorResponse:
+		socihttp.RedactHTTPQueryValuesFromURL(retErr.URL)
+		return retErr
+	// Eat URL errors as a malformed URL might still have credentials.
+	case *url.Error:
+		return errors.New("URL error during fetch")
+	// Otherwise it should be safe to print
+	default:
+		return err
+	}
 }
 
 // doInitialFetch makes a dummy call to the specified content, allowing the authClient
 // to make a single request to pre-populate fields for future requests for the same content.
 // This is only called in the ParallelPull path as sparse index cases will only ever call each layer sequentially.
-func (r *orasBlobStore) doInitialFetch(ctx context.Context, reference string) error {
+func (r *orasBlobStore) doInitialFetch(ctx context.Context, reference string) (bool, error) {
 	ref, err := registry.ParseReference(reference)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	tr := &clientWrapper{r.Client}
 	url := sociremote.CraftBlobURL(reference, ref)
-	rc, err := sociremote.GetHeaderWithGet(ctx, url, tr)
+	resp, err := sociremote.GetHeaderWithGet(ctx, url, tr)
 	if err != nil {
-		return fmt.Errorf("error getting header info: %v", err)
-	}
-	socihttp.Drain(rc.Body)
+		return false, fmt.Errorf("error getting header info: %v", err)
 
-	return nil
+	}
+	socihttp.Drain(resp.Body)
+
+	// Check if upstream allows for ranged GET requests
+	if rangeUnit := resp.Header.Get("Accept-Ranges"); rangeUnit == "bytes" {
+		return true, nil
+	}
+	return false, nil
 }
 
 // This wrapper is to allow a [remote.Client] to implement the

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -489,7 +489,7 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 
 				// We don't have to preauthorize if we only do one request at a time
 				if fs.inProgressImageUnpacks.imagePullCfg.MaxConcurrentDownloadsPerImage != 1 {
-					err = remoteStore.doInitialFetch(ctx, constructRef(refspec, desc))
+					_, err = remoteStore.doInitialFetch(ctx, constructRef(refspec, desc))
 					if err != nil {
 						return fmt.Errorf("error doing initial client fetch: %w", err)
 					}

--- a/fs/parallel_artifact_fetcher.go
+++ b/fs/parallel_artifact_fetcher.go
@@ -24,7 +24,6 @@ import (
 	"io/fs"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/awslabs/soci-snapshotter/soci/store"
@@ -167,14 +166,14 @@ func (f *parallelArtifactFetcher) fetchFromRemoteAndWriteToTempDir(ctx context.C
 	}
 
 	eg, egCtx := errgroup.WithContext(ctx)
-	var isSeekable atomic.Bool
-	isSeekable.Store(true)
+	supportRangeGet := true
 	numLoops := f.calcNumLoops(desc.Size)
+	reference := f.constructRef(desc)
 
 	for i := range numLoops {
-		if !isSeekable.Load() {
-			// This val only gets set after the whole readcloser has been
-			// written to file, so safe to stop attempting this again.
+		// If upstream repo does not support ranged GET request,
+		// we can break after just one iteration of the loop
+		if i > 0 && !supportRangeGet {
 			break
 		}
 
@@ -185,18 +184,22 @@ func (f *parallelArtifactFetcher) fetchFromRemoteAndWriteToTempDir(ctx context.C
 
 		// Do initial fetch call to cache the redirected URL
 		// as long as we're using our blob store implementation.
-		if i == 0 && numLoops > 1 {
+		if i == 0 && supportRangeGet {
 			if rs, ok := f.remoteStore.(*orasBlobStore); ok {
-				err = rs.doInitialFetch(ctx, f.constructRef(desc))
+				var err error
+				// If this layer does not support ranged GET, it is very likely
+				// all other layers of this image do not either.
+				supportRangeGet, err = rs.doInitialFetch(ctx, f.constructRef(desc))
 				if err != nil {
 					return nil, fmt.Errorf("error doing initial authorization for layer: %w", err)
 				}
+			} else {
+				supportRangeGet = false
 			}
 		}
 
 		eg.Go(func() error {
 			defer f.layerUnpackJob.ReleaseDownload(1)
-
 			var err error
 			defer func() {
 				if err != nil {
@@ -204,39 +207,38 @@ func (f *parallelArtifactFetcher) fetchFromRemoteAndWriteToTempDir(ctx context.C
 				}
 			}()
 
-			rc, err := f.remoteStore.Fetch(egCtx, desc)
-			if err != nil {
-				return err
+			var rc io.ReadCloser
+			lower, upper := f.getRange(i, desc.Size)
+			if !supportRangeGet {
+				rc, err = f.remoteStore.Fetch(ctx, desc)
+				if err != nil {
+					return err
+				}
+			} else {
+				// We can only be here if we are using our blob store
+				blobStore := f.remoteStore.(*orasBlobStore)
+				rc, err = blobStore.FetchRange(egCtx, reference, lower, upper)
+				if err != nil {
+					return err
+				}
 			}
 
 			errCh := make(chan error, 1)
 			defer close(errCh)
 			var copyFunc func() <-chan error
 
-			rsc, ok := rc.(io.ReadSeekCloser)
-			if numLoops == 1 {
+			if numLoops == 1 || !supportRangeGet {
 				copyFunc = func() <-chan error {
 					defer rc.Close()
+
 					errCh <- writeToEntireFile(file, rc)
-					return errCh
-				}
-			} else if !ok { // Upstream reader is not seekable
-				log.G(egCtx).Debug("upstream reader is not seekable, reading entire descriptor")
-				copyFunc = func() <-chan error {
-					defer rc.Close()
-					if !isSeekable.CompareAndSwap(true, false) {
-						errCh <- nil
-					} else {
-						errCh <- writeToEntireFile(file, rc)
-					}
 					return errCh
 				}
 			} else {
 				copyFunc = func() <-chan error {
-					defer rsc.Close()
+					defer rc.Close()
 
-					lower, upper := f.getRange(i, desc.Size)
-					errCh <- writeToFileRange(file, rsc, lower, upper)
+					errCh <- writeToFileRange(file, rc, lower, upper)
 					return errCh
 				}
 			}
@@ -285,18 +287,13 @@ func writeToEntireFile(file *os.File, rc io.ReadCloser) error {
 	return nil
 }
 
-func writeToFileRange(file *os.File, rsc io.ReadSeekCloser, lower, upper int64) error {
+func writeToFileRange(file *os.File, rsc io.ReadCloser, lower, upper int64) error {
 	w := io.NewOffsetWriter(file, lower)
-
-	_, err := rsc.Seek(lower, io.SeekStart)
-	if err != nil {
-		return fmt.Errorf("failed to seek readcloser: %w", err)
-	}
 
 	readSize := upper - lower + 1
 	// Reading any more or less will result in an incorrect file being created,
 	// so use io.CopyN to guarantee we read exactly lower - upper + 1 bytes.
-	_, err = io.CopyN(w, rsc, readSize)
+	_, err := io.CopyN(w, rsc, readSize)
 	if err != nil {
 		return fmt.Errorf("failed to write to temp file %s at offset %d: %w", file.Name(), lower, err)
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
To avoid creating our own fetcher, we have been using the oras-go Repository implementation, which handles a lot of the logic of fetching. The parallel pull mode that was introduced additionally leveraged its Seek call to seek the file at a specific offset, however its implementation will close the http.Response body, which is both an extra round trip and also closes the connection for HTTP 1.1 connections, forcing a lot of extra overhead.

By using our own ranged fetch (which we already have, just abstracted away into the lazy-loaded path, which we should really unify...) we can reduce the overhead for ahead-of-time pulls.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
