### PR TITLE
Add blank config integ test

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -37,7 +37,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -51,23 +50,6 @@ import (
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
 	"github.com/awslabs/soci-snapshotter/util/testutil"
 )
-
-// example toml file
-const defaultConfigFileLocation = "../config/config.toml"
-
-func TestRunWithDefaultConfig(t *testing.T) {
-	defaultConfigToml, err := os.ReadFile(defaultConfigFileLocation)
-	if err != nil {
-		t.Fatalf("error fetching example toml")
-	}
-
-	sh, c := newSnapshotterBaseShell(t)
-	defer c()
-
-	rebootContainerd(t, sh, getContainerdConfigToml(t, false), string(defaultConfigToml))
-	// This will error internally if it fails to boot. If it boots successfully,
-	// the config was successfully parsed and snapshotter is running
-}
 
 // TestRunMultipleContainers runs multiple containers at the same time and performs a test in each
 func TestRunMultipleContainers(t *testing.T) {

--- a/integration/startup_test.go
+++ b/integration/startup_test.go
@@ -29,6 +29,9 @@ import (
 	"github.com/rs/xid"
 )
 
+// example toml file
+const defaultConfigFileLocation = "../config/config.toml"
+
 // Use a custom metrics config to test that the snapshotter
 // correctly starts up when the metrics address is next to the socket address.
 // This tests a regression with the first implementation of systemd socket activation
@@ -182,4 +185,18 @@ func TestSnapshotterStartupWithBadConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStartWithDefaultConfig(t *testing.T) {
+	defaultConfigToml, err := os.ReadFile(defaultConfigFileLocation)
+	if err != nil {
+		t.Fatalf("error fetching example toml: %w", err)
+	}
+
+	sh, c := newSnapshotterBaseShell(t)
+	defer c()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), string(defaultConfigToml))
+	// This will error internally if it fails to boot. If it boots successfully,
+	// the config was successfully parsed and snapshotter is running
 }


### PR DESCRIPTION
**Issue #, if available:**
Fixes #1623 

**Description of changes:**
Adding tests for behavior of snapshotter startup with `--config` flag present. In the process I also moved another startup test to this file (as a separate commit)

**Testing performed:**
`GO_TEST_FLAGS='-run TestStartWithConfigPath'  make integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
