### PR TITLE
fix: check if commit failed due to content already exists

### DIFF
--- a/soci/store/store.go
+++ b/soci/store/store.go
@@ -334,7 +334,11 @@ func (s *ContainerdStore) Push(ctx context.Context, expected ocispec.Descriptor,
 		return fmt.Errorf("unexpected copy size %d, expected %d: %w", totalWritten, expected.Size, errdefs.ErrFailedPrecondition)
 	}
 
-	return writer.Commit(ctx, expected.Size, expected.Digest)
+	err = writer.Commit(ctx, expected.Size, expected.Digest)
+	if err != nil && !errors.Is(err, errdefs.ErrAlreadyExists) {
+		return err
+	}
+	return nil
 }
 
 // LabelGCRoot labels the target resource to prevent garbage collection of itself.


### PR DESCRIPTION
**Issue #, if available:**
Building ztocs layers with containerd store might fail due to blobs already existing

```
INFO[0126] soci: soci: errors encountered while building soci layers; cannot push ztoc to local store: commit failed: blob with expected digest sha256:2fa07ddf9c428cdde1f8be966d338f74cd4ef1be4d2b5649804ff53b70b582a6 exists: already exists
FATA[0126] failed to convert image to SOCI format: exit status 1
```
Currently we only check for ORAS error type https://github.com/awslabs/soci-snapshotter/blob/main/soci/soci_index.go#L654-L657

**Description of changes:**

This PR checks for the containerd errdefs.ErrAlreadyExists when pushing blobs to the containerd store. Also, found that we do check if the content already exists before committing, but the current implementation can have a race condition, since a layer ztoc might be pushed after the check. So we need to validate the return error  writer.Commit()

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
