### PR TITLE
Use common IsErrAlreadyExists for Push errors

### DIFF
--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -32,7 +32,6 @@ import (
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/awslabs/soci-snapshotter/util/ioutils"
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/log"
@@ -250,7 +249,7 @@ func (f *artifactFetcher) resolve(ctx context.Context, desc ocispec.Descriptor) 
 // Store takes in an descriptor and io.Reader and stores it in the local store.
 func (f *artifactFetcher) Store(ctx context.Context, desc ocispec.Descriptor, reader io.Reader) error {
 	err := f.localStore.Push(ctx, desc, reader)
-	if err != nil && !errdefs.IsAlreadyExists(err) && !errors.Is(err, errdef.ErrAlreadyExists) {
+	if err != nil && !store.IsErrAlreadyExists(err) {
 		return fmt.Errorf("unable to push to local store: %w", err)
 	}
 	return nil
@@ -297,7 +296,7 @@ func FetchSociArtifacts(ctx context.Context, refspec reference.Spec, indexDesc o
 		}
 
 		err = localStore.Push(ctx, desc, bytes.NewReader(b))
-		if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		if err != nil && !store.IsErrAlreadyExists(err) {
 			return nil, fmt.Errorf("unable to store index in local store: %w", err)
 		}
 

--- a/soci/soci_convert.go
+++ b/soci/soci_convert.go
@@ -33,7 +33,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras-go/v2/errdef"
 )
 
 type ConvertOption func(*convertConfig) error
@@ -353,7 +352,7 @@ func (b *IndexBuilder) pushOCIObject(ctx context.Context, obj any) (ocispec.Desc
 		Size:   int64(len(bs)),
 	}
 	err = b.blobStore.Push(ctx, desc, bytes.NewReader(bs))
-	if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+	if err != nil && !store.IsErrAlreadyExists(err) {
 		return ocispec.Descriptor{}, err
 	}
 	return desc, nil

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -652,7 +652,7 @@ func (b *IndexBuilder) buildSociLayer(ctx context.Context, desc ocispec.Descript
 	}
 
 	err = b.blobStore.Push(ctx, ztocDesc, ztocReader)
-	if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+	if err != nil && !store.IsErrAlreadyExists(err) {
 		return nil, fmt.Errorf("cannot push ztoc to local store: %w", err)
 	}
 
@@ -754,7 +754,7 @@ func (b *IndexBuilder) writeSociIndex(ctx context.Context, indexWithMetadata *In
 	// registry later.
 	if indexWithMetadata.Index.MediaType == ocispec.MediaTypeImageManifest {
 		err = b.blobStore.Push(ctx, indexWithMetadata.Index.Config, bytes.NewReader(defaultConfigContent))
-		if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		if err != nil && !store.IsErrAlreadyExists(err) {
 			return ocispec.Descriptor{}, fmt.Errorf("error creating OCI 1.0 empty config: %w", err)
 		}
 	}
@@ -769,7 +769,7 @@ func (b *IndexBuilder) writeSociIndex(ctx context.Context, indexWithMetadata *In
 	}
 
 	err = b.blobStore.Push(ctx, desc, bytes.NewReader(manifest))
-	if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+	if err != nil && !store.IsErrAlreadyExists(err) {
 		return ocispec.Descriptor{}, fmt.Errorf("cannot write SOCI index to local store: %w", err)
 	}
 


### PR DESCRIPTION
**Issue #, if available:**
Closes #1647 

**Description of changes:**
containerd and ORAS both return a var named ErrAlreadyExists when pushing to their respective local content stores. This leads to some pretty cumbersome error checking cases. This change should make it a little easier to work with.

This also changes the push behavior to return an error if content already exists. This is to match the ORAS behavior for if content already exists and relies on the caller to catch this error.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
