### PR TITLE
Do not allow parallel pull mode with lazy-loading

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -114,15 +114,12 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 
 	var snapshotter snapshots.Snapshotter
 
-	snOpts := []snbase.Opt{snbase.WithAsynchronousRemove}
+	snOpts := []snbase.Opt{snbase.WithAsynchronousRemove, snbase.WithPullModes(&serviceCfg.PullModes)}
 	if serviceCfg.MinLayerSize > -1 {
 		snOpts = append(snOpts, snbase.WithMinLayerSize(serviceCfg.MinLayerSize))
 	}
 	if serviceCfg.SnapshotterConfig.AllowInvalidMountsOnRestart {
 		snOpts = append(snOpts, snbase.AllowInvalidMountsOnRestart)
-	}
-	if serviceCfg.PullModes.Parallel.Enable {
-		snOpts = append(snOpts, snbase.ParallelPullUnpack)
 	}
 
 	snapshotter, err = snbase.NewSnapshotter(ctx, snapshotterRoot(root), fs, snOpts...)


### PR DESCRIPTION
**NOTE:** This is potentially a breaking change as users may be expecting the old order of precedence when pulling images.

**Issue #, if available:**

**Description of changes:**
Previously, the order of precedence would be parallel pull -> SOCI v2 -> SOCI v1, which was not the intended order of precedence. This change makes it so that the lazy-loading modes take precedence over parallel pull modes.

To further avoid confusion/ambiguous behavior, this change also enforces that parallel pull mode will never be used if any lazy-loaded mode is enabled. We can revisit this in the future, but for now it is probably best for clarity's sake to ensure that only one path or the other can be taken.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
