### PR TITLE
Reduce integration test log noise

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -129,12 +129,18 @@ func setup() ([]func() error, error) {
 	if err != nil {
 		return nil, err
 	}
+	stdout, stderr := testutil.BufferedTestingLogDest()
 	cOpts := []compose.Option{
 		compose.WithBuildArgs(buildArgs...),
-		compose.WithStdio(testutil.TestingLogDest()),
+		compose.WithStdio(stdout, stderr),
 	}
 
-	return compose.Build(composeYaml, cOpts...)
+	cleanup, err := compose.Build(composeYaml, cOpts...)
+	if err != nil {
+		stdout.Flush()
+		stderr.Flush()
+	}
+	return cleanup, err
 
 }
 

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -672,7 +672,7 @@ func TestMirror(t *testing.T) {
 	}
 	c, err := compose.Up(s,
 		compose.WithBuildArgs(buildArgs...),
-		compose.WithStdio(testutil.TestingLogDest()))
+		compose.WithStdio(reporter.Stdout(), reporter.Stderr()))
 	if err != nil {
 		t.Fatalf("failed to prepare compose: %v", err)
 	}

--- a/util/testutil/util.go
+++ b/util/testutil/util.go
@@ -33,6 +33,7 @@
 package testutil
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -40,6 +41,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"testing"
 )
 
 const (
@@ -49,24 +51,18 @@ const (
 )
 
 // TestingL is a Logger instance used during testing. This allows tests to prints logs in realtime.
+// This should only be used when there is no testing.TB available (e.g. TestMain). Other usecases
+// should use a TestingReporter.
 var TestingL = log.New(os.Stdout, "testing: ", log.Ldate|log.Ltime)
+
+func BufferedTestingLogDest() (*BufferedWriter, *BufferedWriter) {
+	stdout, stderr := TestingLogDest()
+	return NewBufferedWriter(stdout), NewBufferedWriter(stderr)
+}
 
 // TestingLogDest returns Writes of Testing.T.
 func TestingLogDest() (io.Writer, io.Writer) {
 	return TestingL.Writer(), TestingL.Writer()
-}
-
-// StreamTestingLogToFile allows TestingL to stream the logging output to the speicified file.
-func StreamTestingLogToFile(destPath string) (func() error, error) {
-	if !filepath.IsAbs(destPath) {
-		return nil, fmt.Errorf("log destination must be an absolute path: got %v", destPath)
-	}
-	f, err := os.Create(destPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create %v: %w", destPath, err)
-	}
-	TestingL.SetOutput(io.MultiWriter(f, os.Stdout))
-	return f.Close, nil
 }
 
 // GetProjectRoot returns the path to the directory where the source code of this project reside.
@@ -90,4 +86,42 @@ func GetProjectRoot() (string, error) {
 		return "", fmt.Errorf("no Dockerfile was found under project root")
 	}
 	return pRoot, nil
+}
+
+// TestWriter adapts a testing.TB into an io.Writer
+type TestWriter struct {
+	t testing.TB
+}
+
+func NewTestWriter(t testing.TB) *TestWriter {
+	return &TestWriter{t: t}
+}
+
+func (t *TestWriter) Write(p []byte) (n int, err error) {
+	t.t.Log(string(p))
+	return len(p), nil
+}
+
+// BufferedWriter is a writer that buffers all writes until Flush is called.
+// It is similar to a bufio.Writer except that it will never write to the underlying
+// writer unless Flush is called.
+type BufferedWriter struct {
+	b []byte
+	w io.Writer
+}
+
+func NewBufferedWriter(w io.Writer) *BufferedWriter {
+	return &BufferedWriter{w: w}
+}
+
+// Write writes a log into the buffer
+func (t *BufferedWriter) Write(p []byte) (n int, err error) {
+	t.b = append(t.b, p...)
+	return len(p), nil
+}
+
+// Flush flushes the buffer to the underlying writer
+func (t *BufferedWriter) Flush() {
+	io.Copy(t.w, bytes.NewReader(t.b))
+	t.b = nil
 }


### PR DESCRIPTION
**Issue #, if available:**


**Description of changes:**

This change reduces the integration test log volume by only printing logs when a test fails. Even when the tests are run with `go test -v`, the logs from docker compose, soci, and all the shell commands will be surpressed unless the test fails.

example output:

```
=== RUN   TestPullWrongIndexDigest
    util.go:191: {"level":"info","msg":"starting soci-snapshotter-grpc","revision":"f9963931a08c612b22b19638118e68e7c57ab392.m","time":"2025-08-05T16:34:28.568257762Z","version":"f9963931.m"}
        {"level":"debug","msg":"snapshotter is supported","time":"2025-08-05T16:34:28.569072161Z"}
        {"level":"debug","msg":"initializing metadata store","root":"/var/lib/soci-snapshotter-grpc/","store_type":"db","time":"2025-08-05T16:34:28.569107445Z"}
        {"level":"debug","msg":"metadata store initialized","time":"2025-08-05T16:34:28.569186247Z"}
        {"emitMetricPeriod":10000000000,"fetchPeriod":500000000,"level":"info","maxQueueSize":100,"msg":"constructing background fetcher","silencePeriod":30000000000,"time":"2025-08-05T16:34:28.569424159Z"}
        {"level":"debug","msg":"walk","time":"2025-08-05T16:34:28.569641067Z"}
        {"address":"/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock","level":"info","msg":"soci-snapshotter-grpc successfully started","time":"2025-08-05T16:34:28.569874711Z"}
        {"key":"default/1/connectiontest-dummy-d293550r7tldd3jlmlv0","level":"debug","msg":"prepare","parent":"","time":"2025-08-05T16:34:28.602861587Z"}
        {"level":"info","msg":"Got interrupt","time":"2025-08-05T16:34:32.521197047Z"}
        {"level":"debug","msg":"Closing the snapshotter","time":"2025-08-05T16:34:32.521329233Z"}
        {"level":"debug","msg":"close","time":"2025-08-05T16:34:32.521342762Z"}
        {"level":"debug","msg":"unmount: dirs=[/var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1]","time":"2025-08-05T16:34:32.521417202Z"}
        {"level":"info","msg":"Exiting","time":"2025-08-05T16:34:32.521482894Z"}
        
    util.go:191:  Network soci-integration-compose-d29354gr7tldd3jlmlug555726379_default  Creating
         Network soci-integration-compose-d29354gr7tldd3jlmlug555726379_default  Created
         Container soci-integration-registry-d293548r7tldd3jlmlu0.test  Creating
         Container soci-integration-compose-d29354gr7tldd3jlmlug555726379-testing-1  Creating
         Container soci-integration-registry-d293548r7tldd3jlmlu0.test  Created
         Container soci-integration-compose-d29354gr7tldd3jlmlug555726379-testing-1  Created
         Container soci-integration-registry-d293548r7tldd3jlmlu0.test  Starting
         Container soci-integration-compose-d29354gr7tldd3jlmlug555726379-testing-1  Starting
         Container soci-integration-compose-d29354gr7tldd3jlmlug555726379-testing-1  Started
         Container soci-integration-registry-d293548r7tldd3jlmlu0.test  Started
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:698: >>> Running: [trust anchor /usr/local/share/ca-certificates/domain.crt]
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:699: >>> Running(0/100): [nerdctl login -u dummyuser -p dummypass soci-integration-registry-d293548r7tldd3jlmlu0.test]
        time="2025-08-05T16:34:28Z" level=warning msg="WARNING! Using --password via the CLI is insecure. Use --password-stdin."
        WARNING: Your password will be stored unencrypted in /root/.docker/config.json.
        Configure a credential helper to remove this warning. See
        https://docs.docker.com/engine/reference/commandline/login/#credentials-store
        
        Login Succeeded
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:922: >>> Running: [find /var/lib/containerd/. ! -name . -prune -exec rm -rf {} +]
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:922: >>> Running: [find /var/lib/soci-snapshotter-grpc/. ! -name . -prune -exec rm -rf {} +]
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:926: >>> Getting output of: [mktemp]
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:926: >>> Getting output of: [mktemp]
        /usr/local/go-1.24.4/src/runtime/asm_amd64.s:1700: >>> Running: [containerd --log-level warn --config /tmp/tmp.dvzxbpnto4]
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:898: >>> Running(returning reader): [/usr/local/bin/soci-snapshotter-grpc --log-level debug --address /run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock --config /tmp/tmp.mi04ivlTSl]
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:910: >>> Running(0/100): [ctr snapshots --snapshotter soci prepare connectiontest-dummy-d293550r7tldd3jlmlv0 ]
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:913: >>> Running: [containerd --version]
        containerd github.com/containerd/containerd v1.7.27 05044ec0a9a75232cad458027ca83437aae3f4da
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:502: >>> Running: [nerdctl pull -q --platform linux/amd64 public.ecr.aws/docker/library/alpine:3.17.1]
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:503: >>> Running: [ctr i tag public.ecr.aws/docker/library/alpine:3.17.1 soci-integration-registry-d293548r7tldd3jlmlu0.test/alpine:3.17.1]
        soci-integration-registry-d293548r7tldd3jlmlu0.test/alpine:3.17.1
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:504: >>> Running: [nerdctl push -q --platform linux/amd64 soci-integration-registry-d293548r7tldd3jlmlu0.test/alpine:3.17.1]
        time="2025-08-05T16:34:29Z" level=info msg="pushing as a reduced-platform image (application/vnd.docker.distribution.manifest.list.v2+json, sha256:b8c628ebeabe71102d6d889930d80a21ce2593c3ac17461b7a875220f2d876ab)"
        soci-integration-registry-d293548r7tldd3jlmlu0.test/alpine:3.17.1
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:502: >>> Running: [nerdctl pull -q --platform linux/amd64 public.ecr.aws/docker/library/ubuntu:23.04]
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:503: >>> Running: [ctr i tag public.ecr.aws/docker/library/ubuntu:23.04 soci-integration-registry-d293548r7tldd3jlmlu0.test/ubuntu:23.04]
        soci-integration-registry-d293548r7tldd3jlmlu0.test/ubuntu:23.04
        /home/ec2-user/projects/soci-snapshotter/integration/util_test.go:504: >>> Running: [nerdctl push -q --platform linux/amd64 soci-integration-registry-d293548r7tldd3jlmlu0.test/ubuntu:23.04]
        time="2025-08-05T16:34:31Z" level=info msg="pushing as a reduced-platform image (application/vnd.oci.image.index.v1+json, sha256:6e0ab7b630464a353a99d9943786ab0c078f9a371963c292144cb8313e85392d)"
        soci-integration-registry-d293548r7tldd3jlmlu0.test/ubuntu:23.04
        /home/ec2-user/projects/soci-snapshotter/integration/util_soci_test.go:153: >>> Running: [nerdctl --namespace default pull -q --platform linux/amd64 soci-integration-registry-d293548r7tldd3jlmlu0.test/alpine:3.17.1]
        /home/ec2-user/projects/soci-snapshotter/integration/util_soci_test.go:154: >>> Running: [soci --namespace default --content-store containerd create soci-integration-registry-d293548r7tldd3jlmlu0.test/alpine:3.17.1 --min-layer-size 0 --span-size 4194304 --platform linux/amd64]
        ztoc skipped - layer sha256:8921db27df2831fa6eaa85321205a2470c669b855f3ec95d5a3c2b46de0442c9 (application/vnd.docker.image.rootfs.diff.tar.gzip) size 3370628 is less than min-layer-size 10485760
        soci: no ztocs created, all layers either skipped or produced errors
        /home/ec2-user/projects/soci-snapshotter/util/dockershell/shell.go:129: failed to run [soci --namespace default --content-store containerd create soci-integration-registry-d293548r7tldd3jlmlu0.test/alpine:3.17.1 --min-layer-size 0 --span-size 4194304 --platform linux/amd64]: exit status 1/usr/local/go-1.24.4/src/runtime/asm_amd64.s:1700: command [containerd --log-level warn --config /tmp/tmp.dvzxbpnto4] exit: exit status 137
--- FAIL: TestPullWrongIndexDigest (8.57s)
=== RUN   TestPullWithMaxConcurrency
=== RUN   TestPullWithMaxConcurrency/Run_with_default_max_concurrency
=== RUN   TestPullWithMaxConcurrency/Run_with_max_concurrency_of_2
--- PASS: TestPullWithMaxConcurrency (25.19s)
    --- PASS: TestPullWithMaxConcurrency/Run_with_default_max_concurrency (12.82s)
    --- PASS: TestPullWithMaxConcurrency/Run_with_max_concurrency_of_2 (12.37s)
=== RUN   TestPullWithAribtraryBlobInvalidZtocFormat
=== RUN   TestPullWithAribtraryBlobInvalidZtocFormat/rabbitmq
--- PASS: TestPullWithAribtraryBlobInvalidZtocFormat (27.88s)
    --- PASS: TestPullWithAribtraryBlobInvalidZtocFormat/rabbitmq (23.15s)
=== RUN   TestPullWithParallelism
=== RUN   TestPullWithParallelism/run_fetch_with_no_parallel_fetching_run_unpack_with_no_parallel_unpacking
=== RUN   TestPullWithParallelism/run_fetch_with_no_parallel_fetching_run_unpack_with_parallel_unpacking
=== RUN   TestPullWithParallelism/run_fetch_with_set_chunk_size_run_unpack_with_no_parallel_unpacking
=== RUN   TestPullWithParallelism/run_fetch_with_set_chunk_size_run_unpack_with_parallel_unpacking
--- PASS: TestPullWithParallelism (36.91s)
    --- PASS: TestPullWithParallelism/run_fetch_with_no_parallel_fetching_run_unpack_with_no_parallel_unpacking (9.14s)
    --- PASS: TestPullWithParallelism/run_fetch_with_no_parallel_fetching_run_unpack_with_parallel_unpacking (8.83s)
    --- PASS: TestPullWithParallelism/run_fetch_with_set_chunk_size_run_unpack_with_no_parallel_unpacking (9.33s)
    --- PASS: TestPullWithParallelism/run_fetch_with_set_chunk_size_run_unpack_with_parallel_unpacking (9.61s)
=== RUN   TestPullWithDecompressStreams
=== RUN   TestPullWithDecompressStreams/no_decompression_streams
=== RUN   TestPullWithDecompressStreams/rapidgzip
=== RUN   TestPullWithDecompressStreams/igzip
=== RUN   TestPullWithDecompressStreams/pigz
--- PASS: TestPullWithDecompressStreams (37.04s)
    --- PASS: TestPullWithDecompressStreams/no_decompression_streams (9.26s)
    --- PASS: TestPullWithDecompressStreams/rapidgzip (9.09s)
    --- PASS: TestPullWithDecompressStreams/igzip (9.62s)
    --- PASS: TestPullWithDecompressStreams/pigz (9.07s)
FAIL
FAIL	github.com/awslabs/soci-snapshotter/integration	275.863s
FAIL
make: *** [Makefile:172: integration] Error 1
```


**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
