### PR TITLE
Migrate soci to urfave/cli/v2

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/sirupsen/logrus v1.9.3
-	github.com/urfave/cli v1.22.17
+	github.com/urfave/cli/v2 v2.27.7
 	go.etcd.io/bbolt v1.4.2
 	golang.org/x/sys v0.34.0
 	google.golang.org/grpc v1.59.0
@@ -84,6 +84,7 @@ require (
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0 // indirect
 	go.opentelemetry.io/otel v1.21.0 // indirect

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -4,7 +4,7 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0 h1:59MxjQVfjXsBpLy+dbd2/ELV5ofnUkUZBvWSC85sheA=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20230306123547-8075edf89bb0/go.mod h1:OahwfttHWG6eJ0clwcfBAHoDI6X/LV/15hx/wlMZSrU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.7 h1:vl/nj3Bar/CvJSYo7gIQPyRWc9f3c6IeSNavBTSZNZQ=
@@ -42,6 +42,7 @@ github.com/containerd/typeurl/v2 v2.1.1 h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9Fqctt
 github.com/containerd/typeurl/v2 v2.1.1/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3HZj1hsSQlywkQ0=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -249,7 +250,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -257,11 +257,14 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
-github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
+github.com/urfave/cli v1.22.12 h1:igJgVw1JdKH+trcLWLeLwZjU9fEfPesQ+9/e4MQ44S8=
+github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
+github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
+github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
+github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.4.2 h1:IrUHp260R8c+zYx/Tm8QZr04CX+qWS5PGfPdevhdm1I=

--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -72,7 +72,7 @@ import (
 	sddaemon "github.com/coreos/go-systemd/v22/daemon"
 	metrics "github.com/docker/go-metrics"
 	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
@@ -90,22 +90,22 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "soci-snapshotter-grpc"
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "address",
 			Usage: "address for the snapshotter's GRPC server",
 			Value: defaultAddress,
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "config",
 			Usage: "path to the configuration file",
 			Value: config.DefaultConfigPath,
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "log-level",
 			Usage: "set the logging level [trace, debug, info, warn, error, fatal, panic]",
 			Value: defaultLogLevel.String(),
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "root",
 			Usage: "path to the root directory for this snapshotter",
 			Value: config.DefaultSociSnapshotterRootPath,

--- a/cmd/soci/commands/convert.go
+++ b/cmd/soci/commands/convert.go
@@ -27,7 +27,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/reference"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 var ErrInvalidDestRef = errors.New(`the destination image must be a tagged ref of the form "registry/repository:tag"`)
@@ -56,23 +56,23 @@ func verifyRef(r string) error {
 // ConvertCommand converts an image into a SOCI enabled image.
 // The new image is added to the containerd content store and can
 // be pushed and deployed like a normal image.
-var ConvertCommand = cli.Command{
+var ConvertCommand = &cli.Command{
 	Name:      "convert",
 	Usage:     "convert an OCI image to a SOCI enabled image",
 	ArgsUsage: "[flags] <image_ref> <dest_ref>",
 	Flags: append(
 		internal.PlatformFlags,
-		cli.Int64Flag{
+		&cli.Int64Flag{
 			Name:  spanSizeFlag,
 			Usage: "Span size that soci index uses to segment layer data. Default is 4 MiB",
 			Value: 1 << 22,
 		},
-		cli.Int64Flag{
+		&cli.Int64Flag{
 			Name:  minLayerSizeFlag,
 			Usage: "Minimum layer size to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10 MiB.",
 			Value: 10 << 20,
 		},
-		cli.StringSliceFlag{
+		&cli.StringSliceFlag{
 			Name:  optimizationFlag,
 			Usage: fmt.Sprintf("(Experimental) Enable optional optimizations. Valid values are %v", soci.Optimizations),
 		},
@@ -121,7 +121,7 @@ var ConvertCommand = cli.Command{
 			return err
 		}
 
-		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.String("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -24,7 +24,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/containerd/platforms"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 const (
@@ -41,23 +41,23 @@ const (
 // Output of this command is SOCI layers and SOCI index stored in a local directory
 // SOCI layer is named as <image-layer-digest>.soci.layer
 // SOCI index is named as <image-manifest-digest>.soci.index
-var CreateCommand = cli.Command{
+var CreateCommand = &cli.Command{
 	Name:      "create",
 	Usage:     "create SOCI index",
 	ArgsUsage: "[flags] <image_ref>",
 	Flags: append(
 		internal.PlatformFlags,
-		cli.Int64Flag{
+		&cli.Int64Flag{
 			Name:  spanSizeFlag,
 			Usage: "Span size that soci index uses to segment layer data. Default is 4 MiB",
 			Value: 1 << 22,
 		},
-		cli.Int64Flag{
+		&cli.Int64Flag{
 			Name:  minLayerSizeFlag,
 			Usage: "Minimum layer size to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10 MiB.",
 			Value: 10 << 20,
 		},
-		cli.StringSliceFlag{
+		&cli.StringSliceFlag{
 			Name:  optimizationFlag,
 			Usage: fmt.Sprintf("(Experimental) Enable optional optimizations. Valid values are %v", soci.Optimizations),
 		},
@@ -105,7 +105,7 @@ var CreateCommand = cli.Command{
 			ps = append(ps, platforms.DefaultSpec())
 		}
 
-		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.String("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/index.go
+++ b/cmd/soci/commands/index/index.go
@@ -17,13 +17,13 @@
 package index
 
 import (
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
-var Command = cli.Command{
+var Command = &cli.Command{
 	Name:  "index",
 	Usage: "manage indices",
-	Subcommands: []cli.Command{
+	Subcommands: []*cli.Command{
 		listCommand,
 		infoCommand,
 		rmCommand,

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -28,10 +28,10 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
-var infoCommand = cli.Command{
+var infoCommand = &cli.Command{
 	Name:        "info",
 	Usage:       "display an index",
 	Description: "get detailed info about an index",
@@ -44,7 +44,7 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.String("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/list.go
+++ b/cmd/soci/commands/index/list.go
@@ -31,7 +31,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/platforms"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 type filter func(ae *soci.ArtifactEntry) bool
@@ -63,22 +63,24 @@ func anyMatch(fns []filter) filter {
 	}
 }
 
-var listCommand = cli.Command{
+var listCommand = &cli.Command{
 	Name:    "list",
 	Usage:   "list indices",
 	Aliases: []string{"ls"},
 	Flags: []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "ref",
 			Usage: "filter indices to those that are associated with a specific image ref",
 		},
-		cli.BoolFlag{
-			Name:  "quiet, q",
-			Usage: "only display the index digests",
+		&cli.BoolFlag{
+			Name:    "quiet",
+			Aliases: []string{"q"},
+			Usage:   "only display the index digests",
 		},
-		cli.StringSliceFlag{
-			Name:  "platform, p",
-			Usage: "filter indices to a specific platform",
+		&cli.StringSliceFlag{
+			Name:    "platform",
+			Aliases: []string{"p"},
+			Usage:   "filter indices to a specific platform",
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
@@ -137,7 +139,7 @@ var listCommand = cli.Command{
 			f = anyMatch(filters)
 		}
 
-		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.String("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/rm.go
+++ b/cmd/soci/commands/index/rm.go
@@ -24,16 +24,16 @@ import (
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/opencontainers/go-digest"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
-var rmCommand = cli.Command{
+var rmCommand = &cli.Command{
 	Name:        "remove",
 	Aliases:     []string{"rm"},
 	Usage:       "remove indices",
 	Description: "remove an index from local db, and from content store if supported",
 	Flags: []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "ref",
 			Usage: "only remove indices that are associated with a specific image ref",
 		},
@@ -42,7 +42,7 @@ var rmCommand = cli.Command{
 		args := cliContext.Args()
 		ref := cliContext.String("ref")
 
-		if len(args) != 0 && ref != "" {
+		if args.Len() != 0 && ref != "" {
 			return fmt.Errorf("please provide either index digests or image ref, but not both")
 		}
 
@@ -51,7 +51,7 @@ var rmCommand = cli.Command{
 			return fmt.Errorf("cannot create local content store: %w", err)
 		}
 
-		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.String("root")))
 		if err != nil {
 			return err
 		}
@@ -59,8 +59,8 @@ var rmCommand = cli.Command{
 			ctx, cancel := internal.AppContext(cliContext)
 			defer cancel()
 
-			byteArgs := make([][]byte, len(args))
-			for i, arg := range args {
+			byteArgs := make([][]byte, args.Len())
+			for i, arg := range args.Slice() {
 				byteArgs[i] = []byte(arg)
 			}
 			err = removeArtifactsAndContent(ctx, db, contentStore, byteArgs)

--- a/cmd/soci/commands/internal/client.go
+++ b/cmd/soci/commands/internal/client.go
@@ -40,7 +40,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/pkg/epoch"
 	"github.com/containerd/log"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 // All CLI commands should call either [AppContext] or [NewClient]
@@ -56,8 +56,8 @@ import (
 func AppContext(context *cli.Context) (gocontext.Context, gocontext.CancelFunc) {
 	var (
 		ctx       = gocontext.Background()
-		timeout   = context.GlobalDuration("timeout")
-		namespace = context.GlobalString("namespace")
+		timeout   = context.Duration("timeout")
+		namespace = context.String("namespace")
 		cancel    gocontext.CancelFunc
 	)
 	ctx = namespaces.WithNamespace(ctx, namespace)
@@ -77,8 +77,8 @@ func AppContext(context *cli.Context) (gocontext.Context, gocontext.CancelFunc) 
 
 // NewClient returns a new containerd client
 func NewClient(context *cli.Context, opts ...containerd.ClientOpt) (*containerd.Client, gocontext.Context, gocontext.CancelFunc, error) {
-	opts = append(opts, containerd.WithTimeout(context.GlobalDuration("timeout")))
-	address := config.TrimSocketAddress(context.GlobalString("address"))
+	opts = append(opts, containerd.WithTimeout(context.Duration("timeout")))
+	address := config.TrimSocketAddress(context.String("address"))
 	client, err := containerd.New(address, opts...)
 	if err != nil {
 		return nil, nil, nil, err

--- a/cmd/soci/commands/internal/index.go
+++ b/cmd/soci/commands/internal/index.go
@@ -16,7 +16,7 @@
 
 package internal
 
-import "github.com/urfave/cli"
+import "github.com/urfave/cli/v2"
 
 const (
 	ExistingIndexFlagName = "existing-index"
@@ -27,7 +27,7 @@ const (
 
 var SupportedExistingIndexOptions = []string{Warn, Skip, Allow}
 
-var ExistingIndexFlag = cli.StringFlag{
+var ExistingIndexFlag = &cli.StringFlag{
 	Name:  ExistingIndexFlagName,
 	Value: Warn,
 	Usage: `Configure how to handle existing SOCI artifacts in remote when pushing indices

--- a/cmd/soci/commands/internal/label.go
+++ b/cmd/soci/commands/internal/label.go
@@ -33,10 +33,10 @@
 package internal
 
 import (
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
-var LabelFlag = cli.StringSliceFlag{
+var LabelFlag = &cli.StringSliceFlag{
 	Name:  "label",
 	Usage: "Labels to attach to the image",
 }

--- a/cmd/soci/commands/internal/platform.go
+++ b/cmd/soci/commands/internal/platform.go
@@ -24,7 +24,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 const (
@@ -33,13 +33,14 @@ const (
 )
 
 var PlatformFlags = []cli.Flag{
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  AllPlatformsFlagKey,
 		Usage: "",
 	},
-	cli.StringSliceFlag{
-		Name:  PlatformFlagKey + ", p",
-		Usage: "",
+	&cli.StringSliceFlag{
+		Name:    PlatformFlagKey,
+		Aliases: []string{"p"},
+		Usage:   "",
 	},
 }
 

--- a/cmd/soci/commands/internal/registry.go
+++ b/cmd/soci/commands/internal/registry.go
@@ -33,48 +33,50 @@
 package internal
 
 import (
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 var RegistryFlags = []cli.Flag{
-	cli.BoolFlag{
-		Name:  "skip-verify,k",
-		Usage: "Skip SSL certificate validation",
+	&cli.BoolFlag{
+		Name:    "skip-verify",
+		Aliases: []string{"k"},
+		Usage:   "Skip SSL certificate validation",
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  "plain-http",
 		Usage: "Allow connections using plain HTTP",
 	},
-	cli.StringFlag{
-		Name:  "user,u",
-		Usage: "User[:password] Registry user and password",
+	&cli.StringFlag{
+		Name:    "user",
+		Aliases: []string{"u"},
+		Usage:   "User[:password] Registry user and password",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "refresh",
 		Usage: "Refresh token for authorization server",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name: "hosts-dir",
 		// compatible with "/etc/docker/certs.d"
 		Usage: "Custom hosts configuration directory",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "tlscacert",
 		Usage: "Path to TLS root CA",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "tlscert",
 		Usage: "Path to TLS client certificate",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  "tlskey",
 		Usage: "Path to TLS client key",
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  "http-dump",
 		Usage: "Dump all HTTP request/responses when interacting with container registry",
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  "http-trace",
 		Usage: "Enable HTTP tracing for registry interactions",
 	},

--- a/cmd/soci/commands/internal/snapshotter.go
+++ b/cmd/soci/commands/internal/snapshotter.go
@@ -33,13 +33,13 @@
 package internal
 
 import (
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 var SnapshotterFlags = []cli.Flag{
-	cli.StringFlag{
-		Name:   "snapshotter",
-		Usage:  "Snapshotter name. Empty value stands for the default value.",
-		EnvVar: "CONTAINERD_SNAPSHOTTER",
+	&cli.StringFlag{
+		Name:    "snapshotter",
+		Usage:   "Snapshotter name. Empty value stands for the default value.",
+		EnvVars: []string{"CONTAINERD_SNAPSHOTTER"},
 	},
 }

--- a/cmd/soci/commands/internal/store.go
+++ b/cmd/soci/commands/internal/store.go
@@ -18,13 +18,13 @@ package internal
 
 import (
 	"github.com/awslabs/soci-snapshotter/soci/store"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 // ContentStoreOptions builds a list of content store options from a CLI context.
 func ContentStoreOptions(context *cli.Context) []store.Option {
 	return []store.Option{
-		store.WithType(store.ContentStoreType(context.GlobalString("content-store"))),
-		store.WithContainerdAddress(context.GlobalString("address")),
+		store.WithType(store.ContentStoreType(context.String("content-store"))),
+		store.WithContainerdAddress(context.String("address")),
 	}
 }

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -35,7 +35,7 @@ import (
 	"github.com/containerd/platforms"
 	dockercliconfig "github.com/docker/cli/cli/config"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	oraslib "oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -56,7 +56,7 @@ type pushDescs struct {
 }
 
 // PushCommand is a command to push an image artifacts from local content store to the remote repository
-var PushCommand = cli.Command{
+var PushCommand = &cli.Command{
 	Name:      "push",
 	Usage:     "push SOCI artifacts to a registry",
 	ArgsUsage: "[flags] <ref>",
@@ -71,14 +71,15 @@ if they are available in the snapshotter's local content store.
 		internal.SnapshotterFlags...),
 		internal.PlatformFlags...),
 		internal.ExistingIndexFlag,
-		cli.Uint64Flag{
+		&cli.Uint64Flag{
 			Name:  maxConcurrentUploadsFlag,
 			Usage: fmt.Sprintf("Max concurrent uploads. Default is %d", defaultMaxConcurrentUploads),
 			Value: defaultMaxConcurrentUploads,
 		},
-		cli.BoolFlag{
-			Name:  "quiet, q",
-			Usage: "quiet mode",
+		&cli.BoolFlag{
+			Name:    "quiet",
+			Aliases: []string{"q"},
+			Usage:   "quiet mode",
 		},
 	),
 	Action: func(cliContext *cli.Context) error {
@@ -109,7 +110,7 @@ if they are available in the snapshotter's local content store.
 			ps = append(ps, platforms.DefaultSpec())
 		}
 
-		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.String("root")))
 		if err != nil {
 			return err
 		}
@@ -158,7 +159,7 @@ if they are available in the snapshotter's local content store.
 		dst.Client = authClient
 		dst.PlainHTTP = cliContext.Bool("plain-http")
 
-		debug := cliContext.GlobalBool("debug")
+		debug := cliContext.Bool("debug")
 		if debug {
 			dst.Client = &debugClient{client: authClient}
 		} else {

--- a/cmd/soci/commands/rebuild_db.go
+++ b/cmd/soci/commands/rebuild_db.go
@@ -22,10 +22,10 @@ import (
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
-var RebuildDBCommand = cli.Command{
+var RebuildDBCommand = &cli.Command{
 	Name:  "rebuild-db",
 	Usage: "rebuilds the artifacts database",
 	UsageText: `
@@ -41,7 +41,7 @@ var RebuildDBCommand = cli.Command{
 		}
 		defer cancel()
 		containerdContentStore := client.ContentStore()
-		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.String("root")))
 		if err != nil {
 			return err
 		}
@@ -50,7 +50,7 @@ var RebuildDBCommand = cli.Command{
 			return err
 		}
 
-		contentStorePath, err := store.GetContentStorePath(store.ContentStoreType(cliContext.GlobalString("content-store")))
+		contentStorePath, err := store.GetContentStorePath(store.ContentStoreType(cliContext.String("content-store")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -30,29 +30,31 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
-var getFileCommand = cli.Command{
+var getFileCommand = &cli.Command{
 	Name:      "get-file",
 	Usage:     "retrieve a file from a local image layer using a specified ztoc",
 	ArgsUsage: "<digest> <file>",
 	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "output, o",
-			Usage: "the file to write the extracted content. Defaults to stdout",
+		&cli.StringFlag{
+			Name:    "output",
+			Aliases: []string{"o"},
+			Usage:   "the file to write the extracted content. Defaults to stdout",
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
-		if len(cliContext.Args()) != 2 {
+		args := cliContext.Args().Slice()
+		if len(args) != 2 {
 			return errors.New("please provide both a ztoc digest and a filename to extract")
 		}
 
-		ztocDigest, err := digest.Parse(cliContext.Args()[0])
+		ztocDigest, err := digest.Parse(args[0])
 		if err != nil {
 			return err
 		}
-		file := cliContext.Args()[1]
+		file := args[1]
 
 		client, ctx, cancel, err := internal.NewClient(cliContext)
 		if err != nil {
@@ -65,7 +67,7 @@ var getFileCommand = cli.Command{
 			return err
 		}
 
-		artifactsDB, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		artifactsDB, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.String("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -27,7 +27,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/ztoc/compression"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 type Info struct {
@@ -50,7 +50,7 @@ type FileInfo struct {
 	EndSpan   compression.SpanID `json:"end_span"`
 }
 
-var infoCommand = cli.Command{
+var infoCommand = &cli.Command{
 	Name:      "info",
 	Usage:     "get detailed info about a ztoc",
 	ArgsUsage: "<digest>",
@@ -59,7 +59,7 @@ var infoCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.String("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/list.go
+++ b/cmd/soci/commands/ztoc/list.go
@@ -26,33 +26,35 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
-var listCommand = cli.Command{
+var listCommand = &cli.Command{
 	Name:        "list",
 	Description: "list ztocs",
 	Aliases:     []string{"ls"},
 	Flags: []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "ztoc-digest",
 			Usage: "filter ztocs by digest",
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "image-ref",
 			Usage: "filter ztocs to those that are associated with a specific image",
 		},
-		cli.BoolFlag{
-			Name:  "verbose, v",
-			Usage: "display extra debugging messages",
+		&cli.BoolFlag{
+			Name:    "verbose",
+			Aliases: []string{"v"},
+			Usage:   "display extra debugging messages",
 		},
-		cli.BoolFlag{
-			Name:  "quiet, q",
-			Usage: "only display the index digests",
+		&cli.BoolFlag{
+			Name:    "quiet",
+			Aliases: []string{"q"},
+			Usage:   "only display the index digests",
 		},
 	},
 	Action: func(cliContext *cli.Context) error {
-		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.GlobalString("root")))
+		db, err := soci.NewDB(soci.ArtifactsDbPath(cliContext.String("root")))
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/ztoc/ztoc.go
+++ b/cmd/soci/commands/ztoc/ztoc.go
@@ -16,12 +16,12 @@
 
 package ztoc
 
-import "github.com/urfave/cli"
+import "github.com/urfave/cli/v2"
 
-var Command = cli.Command{
+var Command = &cli.Command{
 	Name:  "ztoc",
 	Usage: "manage ztocs",
-	Subcommands: []cli.Command{
+	Subcommands: []*cli.Command{
 		infoCommand,
 		getFileCommand,
 		listCommand,

--- a/cmd/soci/main.go
+++ b/cmd/soci/main.go
@@ -44,39 +44,41 @@ import (
 	"github.com/awslabs/soci-snapshotter/version"
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 func main() {
 	app := cli.NewApp()
 	app.Name = "soci"
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:   "address, a",
-			Usage:  "address for containerd's GRPC server",
-			Value:  defaults.DefaultAddress,
-			EnvVar: "CONTAINERD_ADDRESS",
+		&cli.StringFlag{
+			Name:    "address",
+			Aliases: []string{"a"},
+			Usage:   "address for containerd's GRPC server",
+			Value:   defaults.DefaultAddress,
+			EnvVars: []string{"CONTAINERD_ADDRESS"},
 		},
-		cli.StringFlag{
-			Name:   "namespace, n",
-			Usage:  "namespace to use with commands",
-			Value:  namespaces.Default,
-			EnvVar: namespaces.NamespaceEnvVar,
+		&cli.StringFlag{
+			Name:    "namespace",
+			Aliases: []string{"n"},
+			Usage:   "namespace to use with commands",
+			Value:   namespaces.Default,
+			EnvVars: []string{namespaces.NamespaceEnvVar},
 		},
-		cli.DurationFlag{
+		&cli.DurationFlag{
 			Name:  "timeout",
 			Usage: "timeout for commands",
 		},
-		cli.BoolFlag{
+		&cli.BoolFlag{
 			Name:  "debug",
 			Usage: "enable debug output",
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "content-store",
 			Usage: "use a specific content store (soci or containerd)",
 			Value: string(config.DefaultContentStoreType),
 		},
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "root",
 			Usage: "path to the root directory for this snapshotter",
 			Value: config.DefaultSociSnapshotterRootPath,
@@ -85,7 +87,7 @@ func main() {
 
 	app.Version = fmt.Sprintf("%s %s", version.Version, version.Revision)
 
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		index.Command,
 		ztoc.Command,
 		commands.CreateCommand,
@@ -95,7 +97,7 @@ func main() {
 	}
 
 	app.Before = func(context *cli.Context) error {
-		return soci.EnsureSnapshotterRootPath(context.GlobalString("root"))
+		return soci.EnsureSnapshotterRootPath(context.String("root"))
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -125,7 +125,7 @@ func TestPushAlwaysMostRecentlyCreatedIndex(t *testing.T) {
 			for _, opt := range tc.opts {
 				index := buildIndex(sh, imgInfo, withMinLayerSize(opt.minLayerSize), withSpanSize(opt.spanSize))
 				index = strings.Split(index, "\n")[0]
-				out := sh.O("soci", "push", "--existing-index", "allow", "--user", regConfig.creds(), imgInfo.ref, "-q")
+				out := sh.O("soci", "push", "--existing-index", "allow", "--user", regConfig.creds(), "-q", imgInfo.ref)
 				pushedIndex := strings.Trim(string(out), "\n")
 				if index != pushedIndex {
 					t.Fatalf("incorrect index pushed to remote registry; expected %s, got %s", index, pushedIndex)

--- a/integration/util_soci_test.go
+++ b/integration/util_soci_test.go
@@ -139,10 +139,11 @@ func buildIndex(sh *shell.Shell, src imageInfo, opt ...indexBuildOption) string 
 		"soci",
 		"--namespace", indexBuildConfig.namespace,
 		"--content-store", string(indexBuildConfig.contentStoreType),
-		"create", src.ref,
+		"create",
 		"--min-layer-size", fmt.Sprintf("%d", indexBuildConfig.minLayerSize),
 		"--span-size", fmt.Sprintf("%d", indexBuildConfig.spanSize),
 		"--platform", platforms.Format(src.platform),
+		src.ref,
 	}
 
 	shx := sh.X


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Partial carry of #1587 (thanks @austinvazquez!)

V2 and V3 both have a bunch of changes, so I want to split the original PR in 2 to make it easier to review. 

The migration guide is here: https://cli.urfave.org/migrate-v1-to-v2/

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
