### PR TITLE
Revert "Update dependabot.yml and remove custom workflow"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,27 @@ updates:
 
   # Automatic upgrade for go modules.
   - package-ecosystem: "gomod"
-    directories: ["/", "/cmd"]
-    groups:
-      go:
-        # Group all of our updates in one PR.
-        # This is mostly because this is the best way we could find
-        # to group both go.mod and cmd/go.mod updates in one PR,
-        # but ideally we should have one PR per unique dependency.
-        patterns:
-          - '*'
+    directory: "/"
     schedule:
       interval: "daily"
     ignore:
       # skip grpc because the current latest not compatible with containerd 1.7
       # skip k8s deps since they use the latest go version/features that may
       # not be in the go version soci uses
+      # Also ignored in /scripts/bump-deps.sh
+      - dependency-name: "google.golang.org/grpc"
+      - dependency-name: "k8s.io/*"
+
+  # Automatic upgrade for go modules of cmd package.
+  - package-ecosystem: "gomod"
+    directory: "/cmd"
+    schedule:
+      interval: "daily"
+    ignore:
+      # skip grpc because the current latest not compatible with containerd 1.7
+      # skip k8s deps since they use the latest go version/features that may
+      # not be in the go version soci uses
+      # Also ignored in /scripts/bump-deps.sh
       - dependency-name: "github.com/awslabs/soci-snapshotter"
       - dependency-name: "google.golang.org/grpc"
       - dependency-name: "k8s.io/*"

--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -1,0 +1,41 @@
+# adapted based on
+# https://github.com/google/go-containerregistry/blob/main/.github/workflows/bump-deps.yaml
+name: Bump Deps
+
+on:
+  schedule:
+    - cron: '0 10 * * 2' # weekly at 10AM Tuesday
+  workflow_dispatch:
+
+env:
+  GO_VERSION: '1.24.4'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-deps:
+    name: Bump Deps
+
+    # Don't bother bumping deps on forks.
+    if: ${{ github.repository == 'awslabs/soci-snapshotter' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - run: ./scripts/bump-deps.sh
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          title: "Bump dependencies using scripts/bump-deps.sh"
+          commit-message: "Bump dependencies using scripts/bump-deps.sh"
+          body: "This PR created by [create-pull-request](https://github.com/peter-evans/create-pull-request) must be closed and reopened manually to trigger automated checks."
+          labels: dependencies
+          delete-branch: true
+          author: "GitHub <no-reply@github.com>"
+          signoff: true

--- a/scripts/bump-deps.sh
+++ b/scripts/bump-deps.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eux -o pipefail
+
+CUR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOCI_SNAPSHOTTER_PROJECT_ROOT="${CUR_DIR}/.."
+
+pushd "${SOCI_SNAPSHOTTER_PROJECT_ROOT}"
+
+# skip k8s deps since they use the latest go version/features that may not be in the go version soci uses
+# skip grpc because it's not compatible with containerd 1.7
+# Also ignored in /dependabot.yml
+# shellcheck disable=SC2046
+go get $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
+    grep -v "^google.golang.org/grpc" | \
+    grep -v "^k8s.io/")
+make tidy
+
+pushd ./cmd
+# skip k8s deps and soci-snapshotter itself
+# skip grpc because it's not compatible with containerd 1.7
+# Also ignored in /dependabot.yml
+# shellcheck disable=SC2046
+go get $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
+    grep -v "^github.com/awslabs/soci-snapshotter" | \
+    grep -v "^google.golang.org/grpc" | \
+    grep -v "^k8s.io/")
+popd
+make tidy
+
+popd


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This reverts commit a998022a174bc2ddc6c258c6d880f663c9664b2a.

Unfortunately dependabot does not recursively run go mod tidy for nested gomodules (e.g.: https://github.com/awslabs/soci-snapshotter/pull/1673)

There is currently an issue open for this, once it is resolved we can probably un-revert this.

Issue: https://github.com/dependabot/dependabot-core/issues/11046

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
