### PR TITLE
Use cancellable contexts when possible

### DIFF
--- a/fs/adaptive_fetch_image_layers.go
+++ b/fs/adaptive_fetch_image_layers.go
@@ -300,7 +300,7 @@ func newLayerUnpackDiskStorage(root string) (LayerUnpackJobStorage, error) {
 		if err := os.RemoveAll(directory); err != nil {
 			return nil, fmt.Errorf("failed to remove existing unpack directory: %w", err)
 		}
-		log.G(context.Background()).WithField("dir", directory).Debug("removed existing unpack directory")
+		log.L.WithField("dir", directory).Debug("removed existing unpack directory")
 	}
 
 	// Create a fresh unpack directory
@@ -333,7 +333,7 @@ func (disk LayerUnpackDiskStorage) generateUniqueKey() (string, error) {
 		if len(key) > 0 && !disk.contains(key) {
 			return key, nil
 		}
-		log.G(context.Background()).WithField("id", key).WithField("attempt", attempt+1).Debug("randomly generated id already exists in storage")
+		log.L.WithField("id", key).WithField("attempt", attempt+1).Debug("randomly generated id already exists in storage")
 	}
 	return "", errUniqueJobIDGenFailure
 }

--- a/fs/artifact_fetcher_test.go
+++ b/fs/artifact_fetcher_test.go
@@ -88,6 +88,8 @@ func TestArtifactFetcherFetch(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			fetcher, err := newFakeArtifactFetcher(imageRef, tc.contents)
 			if err != nil {
 				t.Fatalf("could not create artifact fetcher: %v", err)
@@ -98,7 +100,7 @@ func TestArtifactFetcherFetch(t *testing.T) {
 				Size:   tc.size,
 			}
 
-			reader, _, err := fetcher.Fetch(context.Background(), desc)
+			reader, _, err := fetcher.Fetch(ctx, desc)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -142,7 +144,8 @@ func TestArtifactFetcherResolve(t *testing.T) {
 			desc := ocispec.Descriptor{
 				Digest: dgst,
 			}
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			desc2, err := fetcher.resolve(ctx, desc)
 			if err != nil {
@@ -180,7 +183,8 @@ func TestArtifactFetcherFetchOnlyOnce(t *testing.T) {
 				Digest: dgst,
 				Size:   int64(size),
 			}
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			reader, local, err := fetcher.Fetch(ctx, desc)
 			if err != nil {
@@ -249,7 +253,8 @@ func TestArtifactFetcherStore(t *testing.T) {
 				Digest: tc.digest,
 				Size:   int64(size),
 			}
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			err = fetcher.Store(ctx, desc, bytes.NewReader(tc.contents))
 			if !errors.Is(err, tc.expectedError) {
@@ -365,7 +370,8 @@ func TestFetchSociArtifacts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			_, err = FetchSociArtifacts(ctx, reference.Spec{}, sociIndexDesc, newFakeLocalStore(), newFakeRemoteStoreWithContents(test.remoteContents))
 			if !errors.Is(err, test.expectedError) {
 				t.Fatalf("unexpected error, got: %v. expected: %v", err, test.expectedError)

--- a/fs/backgroundfetcher/background_fetcher_test.go
+++ b/fs/backgroundfetcher/background_fetcher_test.go
@@ -49,12 +49,14 @@ func (c *countingPauser) pause(time.Duration) {
 }
 
 func TestBackgroundFetcherPause(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	p := &countingPauser{}
 	bf, err := NewBackgroundFetcher(WithSilencePeriod(0), withPauser(p), WithEmitMetricPeriod(time.Second))
 	if err != nil {
 		t.Fatal(err)
 	}
-	go bf.Run(context.Background())
+	go bf.Run(ctx)
 	defer bf.Close()
 	bf.Pause()
 
@@ -99,6 +101,8 @@ func TestBackgroundFetcherRun(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			type testInfo struct {
 				sm    *spanmanager.SpanManager
@@ -122,7 +126,7 @@ func TestBackgroundFetcherRun(t *testing.T) {
 				t.Fatalf("unable to construct background fetcher: %v", err)
 			}
 
-			go bf.Run(context.Background())
+			go bf.Run(ctx)
 			defer bf.Close()
 
 			for _, info := range infos {

--- a/fs/backgroundfetcher/resolver_test.go
+++ b/fs/backgroundfetcher/resolver_test.go
@@ -44,6 +44,8 @@ func TestSequentialResolver(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			ztoc, sr, err := ztoc.BuildZtocReader(t, tc.entries, gzip.DefaultCompression, 1000000)
 			if err != nil {
 				t.Fatalf("error build ztoc and section reader: %v", err)
@@ -54,7 +56,7 @@ func TestSequentialResolver(t *testing.T) {
 			var resolvedSpans []int
 			for {
 				resolvedSpans = append(resolvedSpans, int(sequentialResolver.(*sequentialLayerResolver).nextSpanFetchID))
-				more, err := sequentialResolver.Resolve(context.Background())
+				more, err := sequentialResolver.Resolve(ctx)
 				if !more {
 					break
 				}

--- a/fs/client_test.go
+++ b/fs/client_test.go
@@ -90,10 +90,12 @@ func TestOCIArtifactClientSelectReferrer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			inner := newFakeInner(tc.descs)
 			client := NewOCIArtifactClient(inner)
 
-			desc, err := client.SelectReferrer(context.Background(), ocispec.Descriptor{}, tc.selectionPolicy)
+			desc, err := client.SelectReferrer(ctx, ocispec.Descriptor{}, tc.selectionPolicy)
 			if err != nil && !errors.Is(err, tc.expectedErr) {
 				t.Fatalf("unexpected error getting descriptor: %v", err)
 			}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -258,7 +258,7 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 	var bgFetcher *bf.BackgroundFetcher
 
 	if !cfg.BackgroundFetchConfig.Disable {
-		log.G(context.Background()).WithFields(logrus.Fields{
+		log.G(ctx).WithFields(logrus.Fields{
 			"fetchPeriod":      bgFetchPeriod,
 			"silencePeriod":    bgSilencePeriod,
 			"maxQueueSize":     bgMaxQueueSize,
@@ -273,9 +273,9 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 		if err != nil {
 			return nil, fmt.Errorf("cannot create background fetcher: %w", err)
 		}
-		go bgFetcher.Run(context.Background())
+		go bgFetcher.Run(ctx)
 	} else {
-		log.G(context.Background()).Info("background fetch is disabled")
+		log.G(ctx).Info("background fetch is disabled")
 	}
 
 	r, err := layer.NewResolver(root, cfg, fsOpts.resolveHandlers, metadataStore, store, fsOpts.overlayOpaqueType, bgFetcher)

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -55,6 +55,8 @@ import (
 )
 
 func TestCheck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	bl := &breakableLayer{}
 	fs := &filesystem{
 		layer: map[string]layer.Layer{
@@ -65,12 +67,12 @@ func TestCheck(t *testing.T) {
 		}),
 	}
 	bl.success = true
-	if err := fs.Check(context.TODO(), "test", nil); err != nil {
+	if err := fs.Check(ctx, "test", nil); err != nil {
 		t.Errorf("connection failed; wanted to succeed: %v", err)
 	}
 
 	bl.success = false
-	if err := fs.Check(context.TODO(), "test", nil); err == nil {
+	if err := fs.Check(ctx, "test", nil); err == nil {
 		t.Errorf("connection succeeded; wanted to fail")
 	}
 }

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -300,7 +300,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, ref
 	}
 
 	// log ztoc info
-	log.G(context.Background()).WithFields(logrus.Fields{
+	log.G(ctx).WithFields(logrus.Fields{
 		"layer_sha":      desc.Digest,
 		"files_in_layer": len(ztoc.FileMetadata),
 	}).Debugf("[Resolver.Resolve] downloaded layer ZTOC")

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -763,8 +763,7 @@ func (sf *statFile) Statfs(ctx context.Context, out *fuse.StatfsOut) syscall.Err
 // to keep that information accessible for troubleshooting.
 // The entries naming is kept to be consistend with the field naming in statJSON.
 func (sf *statFile) logContents() {
-	ctx := context.Background()
-	log.G(ctx).WithFields(logrus.Fields{
+	log.L.WithFields(logrus.Fields{
 		"digest": sf.statJSON.Digest, "size": sf.statJSON.Size,
 		"fetchedSize": sf.statJSON.FetchedSize, "fetchedPercent": sf.statJSON.FetchedPercent,
 	}).WithError(errors.New(sf.statJSON.Error)).Error("statFile error")

--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -221,7 +221,8 @@ func (b *blob) fetchRegion(reg region, w io.Writer, fetched bool, opts *options)
 	fr := b.fetcher
 	b.fetcherMu.Unlock()
 
-	fetchCtx := context.Background()
+	fetchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	var req []region
 	req = append(req, reg)

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -363,7 +363,8 @@ func (f *httpFetcher) fetch(ctx context.Context, rs []region, retry bool) (multi
 }
 
 func (f *httpFetcher) check() error {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	f.urlMu.Lock()
 	url := f.realURL
 	f.urlMu.Unlock()
@@ -382,7 +383,8 @@ func (f *httpFetcher) check() error {
 		return nil
 	case http.StatusForbidden:
 		// Try to re-redirect this blob
-		rCtx := context.Background()
+		rCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		if err := f.refreshURL(rCtx); err == nil {
 			return nil
 		}

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -162,11 +162,13 @@ func (m *SpanManager) resolveSpan(spanID compression.SpanID) error {
 // GetContents returns a reader for the requested contents. The contents may be
 // across multiple spans.
 func (m *SpanManager) GetContents(startUncompOffset, endUncompOffset compression.Offset) (io.ReadCloser, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	si := m.getSpanInfo(startUncompOffset, endUncompOffset)
 	numSpans := si.spanEnd - si.spanStart + 1
 	spanReaders := make([]io.ReadCloser, numSpans)
 
-	eg, _ := errgroup.WithContext(context.Background())
+	eg, _ := errgroup.WithContext(ctx)
 	var i compression.SpanID
 	for i = 0; i < numSpans; i++ {
 		j := i

--- a/fs/unpacker_test.go
+++ b/fs/unpacker_test.go
@@ -66,11 +66,13 @@ func TestFailureModes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			fetcher := newFakeFetcher(false, tc.storeFails, tc.fetchFails)
 			archive := newFakeArchive(tc.unpackedSize, tc.applyFails)
 			unpacker := NewLayerUnpacker(fetcher, archive)
 			mounts := getFakeMounts()
-			err := unpacker.Unpack(context.Background(), tc.desc, tc.mountpoint, mounts)
+			err := unpacker.Unpack(ctx, tc.desc, tc.mountpoint, mounts)
 			if err == nil {
 				t.Fatalf("%v: there should've been an error due to the following cases: fetch=%v, store=%v, apply=%v",
 					tc.name, tc.fetchFails, tc.storeFails, tc.applyFails)
@@ -113,11 +115,13 @@ func TestUnpackHappyPath(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			fetcher := newFakeFetcher(tc.hasLocal, false, false)
 			archive := newFakeArchive(tc.unpackedSize, false)
 			unpacker := NewLayerUnpacker(fetcher, archive)
 			mounts := getFakeMounts()
-			err := unpacker.Unpack(context.Background(), tc.desc, tc.mountpoint, mounts)
+			err := unpacker.Unpack(ctx, tc.desc, tc.mountpoint, mounts)
 			if err != nil {
 				t.Fatalf("%v: failed to unpack layer", tc.name)
 			}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -978,7 +978,8 @@ func (o *snapshotter) Close() error {
 	log.L.Debug("close")
 	// unmount all mounts including Committed
 	const cleanupCommitted = true
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	if err := o.unmountAllSnapshots(ctx, cleanupCommitted); err != nil {
 		log.G(ctx).WithError(err).Warn("failed to unmount snapshots on close")
 	}

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -58,7 +58,8 @@ const (
 )
 
 func prepareWithTarget(t *testing.T, sn snapshots.Snapshotter, target, key, parent string, labels map[string]string) string {
-	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	if labels == nil {
 		labels = make(map[string]string)
 	}
@@ -71,9 +72,10 @@ func prepareWithTarget(t *testing.T, sn snapshots.Snapshotter, target, key, pare
 
 func TestRemotePrepare(t *testing.T) {
 	testutil.RequiresRoot(t)
-	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	root := t.TempDir()
-	sn, err := NewSnapshotter(context.TODO(), root, bindFileSystem(t))
+	sn, err := NewSnapshotter(ctx, root, bindFileSystem(t))
 	if err != nil {
 		t.Fatalf("failed to make new remote snapshotter: %q", err)
 	}
@@ -118,9 +120,10 @@ func TestRemotePrepare(t *testing.T) {
 
 func TestRemoteOverlay(t *testing.T) {
 	testutil.RequiresRoot(t)
-	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	root := t.TempDir()
-	sn, err := NewSnapshotter(context.TODO(), root, bindFileSystem(t))
+	sn, err := NewSnapshotter(ctx, root, bindFileSystem(t))
 	if err != nil {
 		t.Fatalf("failed to make new remote snapshotter: %q", err)
 	}
@@ -173,9 +176,10 @@ func TestRemoteOverlay(t *testing.T) {
 
 func TestRemoteCommit(t *testing.T) {
 	testutil.RequiresRoot(t)
-	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	root := t.TempDir()
-	sn, err := NewSnapshotter(context.TODO(), root, bindFileSystem(t))
+	sn, err := NewSnapshotter(ctx, root, bindFileSystem(t))
 	if err != nil {
 		t.Fatalf("failed to make new remote snapshotter: %q", err)
 	}
@@ -303,10 +307,11 @@ func TestFailureDetection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			root := t.TempDir()
 			fi := bindFileSystem(t)
-			sn, err := NewSnapshotter(context.TODO(), root, fi)
+			sn, err := NewSnapshotter(ctx, root, fi)
 			if err != nil {
 				t.Fatalf("failed to make new Snapshotter: %q", err)
 			}
@@ -475,7 +480,7 @@ func (fs *dummyFs) CleanImage(ctx context.Context, digest string) error {
 // Tests backword-comaptibility of overlayfs snapshotter.
 
 func newSnapshotter(ctx context.Context, root string) (snapshots.Snapshotter, func() error, error) {
-	snapshotter, err := NewSnapshotter(context.TODO(), root, dummyFileSystem())
+	snapshotter, err := NewSnapshotter(ctx, root, dummyFileSystem())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -489,7 +494,8 @@ func TestOverlay(t *testing.T) {
 }
 
 func TestOverlayMounts(t *testing.T) {
-	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	root := t.TempDir()
 	o, _, err := newSnapshotter(ctx, root)
 	if err != nil {
@@ -519,7 +525,8 @@ func TestOverlayMounts(t *testing.T) {
 }
 
 func TestOverlayCommit(t *testing.T) {
-	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	root := t.TempDir()
 	o, _, err := newSnapshotter(ctx, root)
 	if err != nil {
@@ -540,7 +547,8 @@ func TestOverlayCommit(t *testing.T) {
 }
 
 func TestOverlayOverlayMount(t *testing.T) {
-	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	root := t.TempDir()
 	o, _, err := newSnapshotter(ctx, root)
 	if err != nil {
@@ -620,7 +628,8 @@ func getParents(ctx context.Context, sn snapshots.Snapshotter, root, key string)
 
 func TestOverlayOverlayRead(t *testing.T) {
 	testutil.RequiresRoot(t)
-	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	root := t.TempDir()
 	o, _, err := newSnapshotter(ctx, root)
 	if err != nil {
@@ -659,7 +668,8 @@ func TestOverlayOverlayRead(t *testing.T) {
 }
 
 func TestOverlayView(t *testing.T) {
-	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	root := t.TempDir()
 	o, _, err := newSnapshotter(ctx, root)
 	if err != nil {

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -127,13 +127,13 @@ func NewDB(path string) (*ArtifactsDb, error) {
 	once.Do(func() {
 		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 		if err != nil {
-			log.G(context.Background()).WithError(err).WithField("path", path).Error("Cannot create or open file")
+			log.L.WithError(err).WithField("path", path).Error("Cannot create or open file")
 			return
 		}
 		defer f.Close()
 		database, err := bolt.Open(f.Name(), 0600, nil)
 		if err != nil {
-			log.G(context.Background()).WithError(err).Error("Cannot open the db")
+			log.L.WithError(err).Error("Cannot open the db")
 			return
 		}
 		db = &ArtifactsDb{db: database}

--- a/soci/soci_convert_test.go
+++ b/soci/soci_convert_test.go
@@ -136,13 +136,15 @@ func TestAddSociIndexes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			builder := IndexBuilder{}
 			actual := test.ociIndex
 			var indexes []*IndexWithMetadata
 			for _, index := range test.sociIndexes {
 				indexes = append(indexes, &index)
 			}
-			err := builder.addSociIndexes(context.Background(), &actual, indexes)
+			err := builder.addSociIndexes(ctx, &actual, indexes)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -133,7 +133,6 @@ func TestBuildSociIndexNotLayer(t *testing.T) {
 	}
 
 	spanSize := int64(65535)
-	ctx := context.Background()
 	cs := newFakeContentStore()
 	blobStore := NewOrasMemoryStore()
 
@@ -148,6 +147,8 @@ func TestBuildSociIndexNotLayer(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			desc := ocispec.Descriptor{
 				MediaType: tc.mediaType,
 				Digest:    "layerdigest",
@@ -201,7 +202,8 @@ func TestBuildSociIndexWithLimits(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			cs := newFakeContentStore()
 			desc := ocispec.Descriptor{
 				MediaType: "application/vnd.oci.image.layer.",

--- a/soci/store/store_test.go
+++ b/soci/store/store_test.go
@@ -154,7 +154,9 @@ func (s *fakeStore) BatchOpen(ctx context.Context) (context.Context, CleanupFunc
 func TestStoreLabelGCRoot(t *testing.T) {
 	store := newFakeStore()
 	testTarget, _ := digest.Parse("sha256:7b236f6c6ca259a4497e98c204bc1dcf3e653438e74af17bfe39da5329789f4a")
-	LabelGCRoot(context.Background(), store, ocispec.Descriptor{Digest: testTarget})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	LabelGCRoot(ctx, store, ocispec.Descriptor{Digest: testTarget})
 	if len(store.Labels) != 1 {
 		t.Fatalf("wrong number of labels applied, expected 1, got %d", len(store.Labels))
 	}
@@ -171,7 +173,9 @@ func TestStoreLabelGCRefContent(t *testing.T) {
 	testTarget, _ := digest.Parse("sha256:7b236f6c6ca259a4497e98c204bc1dcf3e653438e74af17bfe39da5329789f4a")
 	testRef := "testRef"
 	testDigest, _ := digest.Parse("sha256:4452aadba3e99771ff3559735dab16279c5a352359d79f38737c6fdca941c6e5")
-	LabelGCRefContent(context.Background(), store, ocispec.Descriptor{Digest: testTarget}, testRef, testDigest.String())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	LabelGCRefContent(ctx, store, ocispec.Descriptor{Digest: testTarget}, testRef, testDigest.String())
 	if len(store.Labels) != 1 {
 		t.Fatalf("wrong number of labels applied, expected 1, got %d", len(store.Labels))
 	}

--- a/ztoc/ztoc.go
+++ b/ztoc/ztoc.go
@@ -18,7 +18,6 @@ package ztoc
 
 import (
 	"archive/tar"
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -195,7 +194,7 @@ func (zt Ztoc) ExtractFile(r *io.SectionReader, filename string) ([]byte, error)
 
 	bufSize := checkpoints[len(checkpoints)-1] - checkpoints[0]
 	buf := make([]byte, bufSize)
-	eg, _ := errgroup.WithContext(context.Background())
+	var eg errgroup.Group
 
 	// Fetch all span data in parallel
 	for i := compression.SpanID(0); i < numSpans; i++ {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Functionally this shouldn't change much if anything, it just ensures that we are passing meaningful contexts to more function calls. This mostly affects our tests where we were very liberal with using context.Background when we should ensure that all functions terminate by the end of the test case.

This also includes changes to use log.L instead of log.G with context.Background, which shouldn't make a difference since log.G with an empty context works the same as log.L (I think...)

**Testing performed:**
`make test` and ran a couple of integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
