### PR TITLE
Use DirectMountStrict if fusermount is missing

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -1131,7 +1131,7 @@ func (fs *filesystem) setupFuseServer(ctx context.Context, mountpoint string, no
 		mountOpts.Options = []string{"suid"} // option for fusermount; allow setuid inside container
 	} else {
 		log.G(ctx).WithField("binary", fusermountBin).WithError(err).Info("fusermount binary not installed; trying direct mount")
-		mountOpts.DirectMount = true
+		mountOpts.DirectMountStrict = true
 	}
 	server, err := fuse.NewServer(rawFS, mountpoint, mountOpts)
 	if err != nil {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When `fusermount` isn't found on the path, SOCI used to set `DirectMount = true` in the go-fuse options. This will try to direct mount, but if it fails, it will fall back to trying fusermount. This will never work if `fusermount` isn't on the path, but it also causes the mount error to log to the go-fuse logger which is connected to SOCI's trace log level so the error is lost.

This change switches to `DirectMountStrict` so that we will get the mount error and can debug if this happens.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
