### PR TITLE
Add soci-snapshotter-grpc config dump command

### DIFF
--- a/cmd/soci-snapshotter-grpc/config.go
+++ b/cmd/soci-snapshotter-grpc/config.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/containerd/log"
+	"github.com/pelletier/go-toml/v2"
+	"github.com/urfave/cli/v3"
+)
+
+var ConfigCommand = &cli.Command{
+	Name:  "config",
+	Usage: "Manage configuration",
+	Commands: []*cli.Command{
+		{
+			Name:  "dump",
+			Usage: "Dump configuration",
+			Action: func(ctx context.Context, cmd *cli.Command) error {
+				cfg, err := config.NewConfigFromToml(cmd.String("config"))
+				if err != nil {
+					log.G(ctx).WithError(err).Fatal(err)
+				}
+
+				toml.NewEncoder(os.Stdout).SetIndentTables(true).Encode(cfg)
+				return nil
+			},
+		},
+	},
+}

--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -112,6 +112,9 @@ func main() {
 			},
 		},
 		Version: fmt.Sprintf("%s %s", version.Version, version.Revision),
+		Commands: []*cli.Command{
+			ConfigCommand,
+		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			lvl, err := logrus.ParseLevel(cmd.String("log-level"))
 			if err != nil {


### PR DESCRIPTION
**Issue #, if available:**
Closes https://github.com/awslabs/soci-snapshotter/pull/1579

I rewrote that PR now that we support urfave in the snapshotter and go-toml/v2 everywhere.

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
