### PR TITLE
Add soci-snapshotter-grpc config default command

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -75,3 +75,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: shellcheck ./**/*.sh
+
+  config:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - run: make && ./scripts/check-config.sh

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ NERDCTL_REPO = https://github.com/containerd/nerdctl.git
 NERDCTL_TAG = v1.7.7
 NERDCTL_PATCH = $(SOCI_SNAPSHOTTER_PROJECT_ROOT)/integration/config/nerdctl.patch
 
-.PHONY: all build check flatc add-ltag install uninstall tidy vendor clean clean-coverage \
+.PHONY: all build check flatc add-ltag install uninstall tidy vendor gen-config clean clean-coverage \
 	clean-integration test test-with-coverage show-test-coverage show-test-coverage-html nerdctl-with-idmapping \
 	integration integration-with-coverage show-integration-coverage show-integration-coverage-html \
 	release benchmarks build-benchmarks benchmarks-perf-test benchmarks-comparison-test
@@ -139,6 +139,9 @@ tidy:
 vendor:
 	@GO111MODULE=$(GO111MODULE_VALUE) go mod vendor
 	@cd ./cmd ; GO111MODULE=$(GO111MODULE_VALUE) go mod vendor
+
+gen-config: build
+	@$(OUTDIR)/soci-snapshotter-grpc config default > $(SOCI_SNAPSHOTTER_PROJECT_ROOT)/config/config.toml
 
 test:
 	@echo "$@"

--- a/cmd/soci-snapshotter-grpc/config.go
+++ b/cmd/soci-snapshotter-grpc/config.go
@@ -39,8 +39,7 @@ var ConfigCommand = &cli.Command{
 					log.G(ctx).WithError(err).Fatal(err)
 				}
 
-				toml.NewEncoder(os.Stdout).SetIndentTables(true).Encode(cfg)
-				return nil
+				return toml.NewEncoder(os.Stdout).SetIndentTables(true).Encode(cfg)
 			},
 		},
 	},

--- a/cmd/soci-snapshotter-grpc/config.go
+++ b/cmd/soci-snapshotter-grpc/config.go
@@ -42,5 +42,13 @@ var ConfigCommand = &cli.Command{
 				return toml.NewEncoder(os.Stdout).SetIndentTables(true).Encode(cfg)
 			},
 		},
+		{
+			Name:  "default",
+			Usage: "Print default configuration",
+			Action: func(ctx context.Context, cmd *cli.Command) error {
+				cfg := config.NewConfig()
+				return toml.NewEncoder(os.Stdout).SetIndentTables(true).Encode(cfg)
+			},
+		},
 	},
 }

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,59 +1,59 @@
-# An example config showing all of the toml variables used.
-
-# Copy to /etc/soci-snapshotter-grpc/config.toml
-# to use on your system.
-
-# NOTE: Many variables set to zero are just an indicator
-# to use the built-in default. These values may change over time,
-# which is why the config uses zeroes.
-# Please see docs/config.md for more info on what these variables do.
-
-# TODO: Can we put these inside dedicated TOML vars to refer to them?
-
-# config/fs.go FSConfig
-http_cache_type=""
-filesystem_cache_type=""
-resolve_result_entry=0
-debug=false
-disable_verification=false
-max_concurrency=0  # Actually zero
-no_prometheus=false
-mount_timeout_sec=0
-fuse_metrics_emit_wait_duration_sec=0
-
-## config/config.go Config
-
-metrics_address=""
-metrics_network="" # Uses default metrics network
-# no_prometheus=true # Defined above, can't be redeclared
-debug_address=""
-metadata_store="db"
-skip_check_snapshotter_supported=false
-
-[pull_modes.parallel_pull_unpack]
-enable=false
-max_concurrent_downloads=-1
-max_concurrent_downloads_per_image=3
-concurrent_download_chunk_size=""
-max_concurrent_unpacks=-1
-max_concurrent_unpacks_per_image=1
-discard_unpacked_layers=false
-
-[pull_modes.parallel_pull_unpack.decompress_streams."gzip"]
-path = "/usr/bin/gzip"
-args = ["-d", "-c"]
+http_cache_type = ''
+filesystem_cache_type = ''
+resolve_result_entry = 0
+debug = false
+disable_verification = false
+max_concurrency = 100
+no_prometheus = false
+mount_timeout_sec = 30
+fuse_metrics_emit_wait_duration_sec = 60
+metrics_address = ''
+metrics_network = 'tcp'
+debug_address = ''
+metadata_store = 'db'
+skip_check_snapshotter_supported = false
 
 [http]
-MaxRetries=0
-MinWaitMsec=0
-MaxWaitMsec=0
-DialTimeoutMsec=0
-ResponseHeaderTimeoutMsec=0
-RequestTimeoutMsec=0
+  DialTimeoutMsec = 3000
+  ResponseHeaderTimeoutMsec = 3000
+  RequestTimeoutMsec = 300000
+  MaxRetries = 8
+  MinWaitMsec = 30
+  MaxWaitMsec = 300000
 
-#
-## config/pull_modes.go
-#
+[blob]
+  valid_interval = 60
+  fetching_timeout_sec = 300
+  max_retries = 8
+  min_wait_msec = 30
+  max_wait_msec = 300000
+  check_always = false
+  force_single_range_mode = false
+  max_span_verification_retries = 0
+
+[directory_cache]
+  max_lru_cache_entry = 0
+  max_cache_fds = 0
+  sync_add = false
+  direct = true
+
+[fuse]
+  attr_timeout = 1
+  entry_timeout = 1
+  negative_timeout = 1
+  log_fuse_operations = false
+
+[background_fetch]
+  disable = false
+  silence_period_msec = 30000
+  fetch_period_msec = 500
+  max_queue_size = 100
+  emit_metric_period_sec = 10
+
+[content_store]
+  type = 'soci'
+  containerd_address = '/run/containerd/containerd.sock'
+
 [pull_modes]
   [pull_modes.soci_v1]
     enable = false
@@ -61,91 +61,25 @@ RequestTimeoutMsec=0
   [pull_modes.soci_v2]
     enable = true
 
-#
-## config/fs.go
-#
-
-[blob]
-valid_interval=0
-check_always=false
-fetching_timeout_sec=0
-force_single_range_mode=false
-# max_retries=0 # Set by http.
-# min_wait_msec=0 # Set by http.
-# max_wait_msec=0 # Set by http.
-max_span_verification_retries=0 # Actually zero
-
-[directory_cache]
-max_lru_cache_entry=0 # Actually zero
-max_cache_fds=0 # Actually zero
-sync_add=false
-direct=true
-
-[fuse]
-attr_timeout=0
-entry_timeout=0
-negative_timeout=0
-log_fuse_operations=false
-
-[background_fetch]
-disable=false
-silence_period_msec=0
-fetch_period_msec=0
-max_queue_size=0
-emit_metric_period_sec=0
-
-[content_store]
-type="" # will set to 'soci' by default
-# Socket address for containerd.
-# Defaults to '/run/containerd/containerd.sock'
-containerd_address=""
-namespace="" # will set to 'default' by default
-   
-#
-## config/resolver.go
-#
-
-[resolver]
-  [resolver.host]
-
-#
-## config/service.go
-#
+  [pull_modes.parallel_pull_unpack]
+    max_concurrent_downloads = -1
+    max_concurrent_downloads_per_image = 3
+    concurrent_download_chunk_size = ''
+    max_concurrent_unpacks = -1
+    max_concurrent_unpacks_per_image = 1
+    discard_unpacked_layers = false
+    enable = false
 
 [kubeconfig_keychain]
-enable_keychain=false
-kubeconfig_path=""
+  enable_keychain = false
+  kubeconfig_path = ''
 
 [cri_keychain]
-enable_keychain=false
-image_service_path="" # Uses default image service address
+  enable_keychain = false
+  image_service_path = '/run/containerd/containerd.sock'
+
+[resolver]
 
 [snapshotter]
-min_layer_size=0 # Actually zero
-allow_invalid_mounts_on_restart=false
-
-#
-## service/resolver/cri.go
-#
-
-[registry]
-config_path=""
-mirrors={}
-configs={}
-
-[Mirror]
-endpoint={}
-
-[RegistryConfig]
-
-[auth]
-username=""
-password=""
-auth=""
-identitytoken=""
-
-[tls]
-insecure_skip_verify=false
-ca_file=""
-cert_file=""
-key_file=""
+  min_layer_size = 0
+  allow_invalid_mounts_on_restart = false

--- a/scripts/check-config.sh
+++ b/scripts/check-config.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+#   Copyright The Soci Snapshotter Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eux -o pipefail
+
+cur_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+soci_snapshotter_project_root="$(cd -- "$cur_dir"/.. && pwd)"
+config_loc="${soci_snapshotter_project_root}"/config/config.toml
+out_dir="${soci_snapshotter_project_root}"/out
+soci_snapshotter_grpc="${out_dir}"/soci-snapshotter-grpc
+
+# Check if default config has changed.
+tmpdir=$(mktemp -d)
+tmpconfig="${tmpdir}"/config.toml
+"${soci_snapshotter_grpc}" config default > "${tmpconfig}"
+diff -q "${tmpconfig}" "${config_loc}" || (printf "\n\nThe default config seems to have changed. Please run 'make gen-config' to re-generate default config in %s.\n\n" "${config_loc}"; rm -rf "${tmpdir}"; exit 1)
+rm -rf "${tmpdir}"


### PR DESCRIPTION
**Issue #, if available:**
Closes #1570
Closes #568 

**Description of changes:**
Add `soci-snapshotter-grpc config default` command

**Testing performed:**
Just a manual visual verification that it looked correct. Seems to align with our defaults.
<details>
<summary>Output of "soci-snapshotter-grpc config default"</summary>

```
$ out/soci-snapshotter-grpc config default
http_cache_type = ''
filesystem_cache_type = ''
resolve_result_entry = 0
debug = false
disable_verification = false
max_concurrency = 100
no_prometheus = false
mount_timeout_sec = 30
fuse_metrics_emit_wait_duration_sec = 60
metrics_address = ''
metrics_network = 'tcp'
debug_address = ''
metadata_store = 'db'
skip_check_snapshotter_supported = false

[http]
  DialTimeoutMsec = 3000
  ResponseHeaderTimeoutMsec = 3000
  RequestTimeoutMsec = 300000
  MaxRetries = 8
  MinWaitMsec = 30
  MaxWaitMsec = 300000

[blob]
  valid_interval = 60
  fetching_timeout_sec = 300
  max_retries = 8
  min_wait_msec = 30
  max_wait_msec = 300000
  check_always = false
  force_single_range_mode = false
  max_span_verification_retries = 0

[directory_cache]
  max_lru_cache_entry = 0
  max_cache_fds = 0
  sync_add = false
  direct = true

[fuse]
  attr_timeout = 1
  entry_timeout = 1
  negative_timeout = 1
  log_fuse_operations = false

[background_fetch]
  disable = false
  silence_period_msec = 30000
  fetch_period_msec = 500
  max_queue_size = 100
  emit_metric_period_sec = 10

[content_store]
  type = 'soci'
  containerd_address = '/run/containerd/containerd.sock'

[pull_modes]
  [pull_modes.soci_v1]
    enable = false

  [pull_modes.soci_v2]
    enable = true

  [pull_modes.parallel_pull_unpack]
    max_concurrent_downloads = -1
    max_concurrent_downloads_per_image = 3
    concurrent_download_chunk_size = ''
    max_concurrent_unpacks = -1
    max_concurrent_unpacks_per_image = 1
    discard_unpacked_layers = false
    enable = false

[kubeconfig_keychain]
  enable_keychain = false
  kubeconfig_path = ''

[cri_keychain]
  enable_keychain = false
  image_service_path = '/run/containerd/containerd.sock'

[resolver]

[snapshotter]
  min_layer_size = 0
  allow_invalid_mounts_on_restart = false
```
</details>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
