### PR TITLE
Actually check the download's sha256 checksum in parallel-mode-install.sh

### DIFF
--- a/scripts/parallel-mode-install.sh
+++ b/scripts/parallel-mode-install.sh
@@ -18,7 +18,7 @@ ARCHIVE=soci-snapshotter-${soci_version}-linux-${ARCH}.tar.gz
 pushd /tmp
 curl --silent --location --fail --output "${ARCHIVE}" https://github.com/awslabs/soci-snapshotter/releases/download/v"${soci_version}"/"${ARCHIVE}"
 curl --silent --location --fail --output "${ARCHIVE}".sha256sum https://github.com/awslabs/soci-snapshotter/releases/download/v"${soci_version}"/"${ARCHIVE}".sha256sum
-sha256sum ./"${ARCHIVE}".sha256sum
+sha256sum --check ./"${ARCHIVE}".sha256sum
 tar xzvf ./"${ARCHIVE}" -C /usr/local/bin soci-snapshotter-grpc
 rm ./"${ARCHIVE}"
 rm ./"${ARCHIVE}".sha256sum


### PR DESCRIPTION
**Description of changes:**

The script was mistakingly _calculating_ the sha256 hash of the checksum, instead of _using_ the checksum to check against the downloaded file.

**Testing performed: manual**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
