### PR TITLE
ci: Properly check if Docker Compose is installed

### DIFF
--- a/util/dockershell/compose/compose.go
+++ b/util/dockershell/compose/compose.go
@@ -52,7 +52,13 @@ const (
 
 // Supported checks if this pkg can run on the current system.
 func Supported() error {
-	return exec.Command("docker", "--version").Run()
+	if err := exec.Command("docker", "--version").Run(); err != nil {
+		return err
+	}
+	if err := exec.Command("docker", "compose", "version").Run(); err != nil {
+		return fmt.Errorf("compose version check failed (is Docker Compose installed?); %v", err)
+	}
+	return nil
 }
 
 // Compose represents a set of container execution environment (i.e. a set of *dexec.Exec) that


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The `compose.Supported()` only checks the Docker version, not the Docker Compose version. So, if a user did not have Docker Compose installed, it erroneously passed when it should not have, causing an unclear error message down the line (`unknown shorthand flag: 'f' in -f`) which was difficult to debug for unfamiliar users. So I changed the Supported check to make sure it caught this issue.

Additionally, `docker compose version` would only return `exit status 1` if Docker Compose was not installed, so I amended the error message to ensure it is a little more clear when it fails. (The previous check for docker version would say `executable file not found in $PATH` if it failed, which is descriptive enough for an error message, so that remained untouched.)

**Testing performed:**
Manually did `chmod -x ~/.docker/cli-plugins/docker-compose` and ensured that integration tests run with executable perms and do not without. Also verified the same with `/usr/bin/docker`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
