### PR TITLE
feat: skip existing ztoc generation

### DIFF
--- a/cmd/soci/commands/convert.go
+++ b/cmd/soci/commands/convert.go
@@ -77,6 +77,11 @@ var ConvertCommand = &cli.Command{
 			Name:  optimizationFlag,
 			Usage: fmt.Sprintf("(Experimental) Enable optional optimizations. Valid values are %v", soci.Optimizations),
 		},
+		&cli.BoolFlag{
+			Name:  skipExistingZtocCheckFlag,
+			Usage: "Skip checking if zTOCs already exist for layers or not. Defaults to false.",
+			Value: false,
+		},
 	),
 	Action: func(ctx context.Context, cmd *cli.Command) error {
 		srcRef := cmd.Args().Get(0)
@@ -118,6 +123,7 @@ var ConvertCommand = &cli.Command{
 
 		spanSize := cmd.Int64(spanSizeFlag)
 		minLayerSize := cmd.Int64(minLayerSizeFlag)
+		skipExistingZtocCheck := cmd.Bool(skipExistingZtocCheckFlag)
 
 		blobStore, err := store.NewContentStore(internal.ContentStoreOptions(ctx, cmd)...)
 		if err != nil {
@@ -135,6 +141,7 @@ var ConvertCommand = &cli.Command{
 			soci.WithBuildToolIdentifier(buildToolIdentifier),
 			soci.WithOptimizations(optimizations),
 			soci.WithArtifactsDb(artifactsDb),
+			soci.WithSkipExistingZtocCheck(skipExistingZtocCheck),
 		}
 
 		builder, err := soci.NewIndexBuilder(cs, blobStore, builderOpts...)

--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -31,11 +31,12 @@ import (
 const (
 	// buildToolIdentifier is placed in annotations of the SOCI index
 	// to help identify how a SOCI index was created
-	buildToolIdentifier = "AWS SOCI CLI v0.2"
-	spanSizeFlag        = "span-size"
-	minLayerSizeFlag    = "min-layer-size"
-	optimizationFlag    = "optimizations"
-	sociIndexGCLabel    = "containerd.io/gc.ref.content.soci-index"
+	buildToolIdentifier       = "AWS SOCI CLI v0.2"
+	spanSizeFlag              = "span-size"
+	minLayerSizeFlag          = "min-layer-size"
+	optimizationFlag          = "optimizations"
+	skipExistingZtocCheckFlag = "skip-existing-ztoc-check"
+	sociIndexGCLabel          = "containerd.io/gc.ref.content.soci-index"
 )
 
 // CreateCommand creates SOCI index for an image
@@ -61,6 +62,11 @@ var CreateCommand = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:  optimizationFlag,
 			Usage: fmt.Sprintf("(Experimental) Enable optional optimizations. Valid values are %v", soci.Optimizations),
+		},
+		&cli.BoolFlag{
+			Name:  skipExistingZtocCheckFlag,
+			Usage: "Skip checking if zTOCs already exist for layers or not. Defaults to false.",
+			Value: false,
 		},
 	),
 	Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -93,6 +99,7 @@ var CreateCommand = &cli.Command{
 
 		spanSize := cmd.Int64(spanSizeFlag)
 		minLayerSize := cmd.Int64(minLayerSizeFlag)
+		skipExistingZtocCheck := cmd.Bool(skipExistingZtocCheckFlag)
 
 		blobStore, err := store.NewContentStore(internal.ContentStoreOptions(ctx, cmd)...)
 		if err != nil {
@@ -118,6 +125,7 @@ var CreateCommand = &cli.Command{
 			soci.WithBuildToolIdentifier(buildToolIdentifier),
 			soci.WithOptimizations(optimizations),
 			soci.WithArtifactsDb(artifactsDb),
+			soci.WithSkipExistingZtocCheck(skipExistingZtocCheck),
 		}
 
 		builder, err := soci.NewIndexBuilder(cs, blobStore, builderOpts...)

--- a/integration/convert_test.go
+++ b/integration/convert_test.go
@@ -17,21 +17,86 @@
 package integration
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci"
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
+	"github.com/awslabs/soci-snapshotter/util/testutil"
 	"github.com/containerd/platforms"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (
 	convertImages = []string{nginxImage, rabbitmqImage, drupalImage, ubuntuImage}
 )
+
+func TestConvertWithExistingZtocCheck(t *testing.T) {
+	sh, done := newSnapshotterBaseShell(t)
+	defer done()
+	rebootContainerd(t, sh, "", "")
+
+	// if we build an index for the image first and then convert it
+	// without the --skip-existing-ztoc-check flag, all ztoc's should be skipped
+	image := dockerhub(nginxAlpineImage)
+	indexDigest := buildIndex(sh, image)
+	if indexDigest == "" {
+		t.Fatal("failed to get soci index for test image")
+	}
+	contentStoreBlobPath, _ := testutil.GetContentStoreBlobPath(config.DefaultContentStoreType)
+	parsedDigest, err := digest.Parse(indexDigest)
+	if err != nil {
+		t.Fatalf("cannot parse digest: %v", err)
+	}
+	checkpoints := fetchContentFromPath(sh, filepath.Join(contentStoreBlobPath, parsedDigest.Encoded()))
+	var index soci.Index
+	err = soci.DecodeIndex(bytes.NewReader(checkpoints), &index)
+	if err != nil {
+		t.Fatalf("cannot get index data: %v", err)
+	}
+
+	testCases := []struct {
+		name                      string
+		skipExistingZtocCheckFlag bool
+		numZtocSkipped            int
+	}{
+		{
+			name:                      "test soci convert without --skip-existing-ztoc-check flag",
+			skipExistingZtocCheckFlag: false,
+			numZtocSkipped:            len(index.Blobs),
+		},
+		{
+			name:                      "test soci convert with --skip-existing-ztoc-check flag",
+			skipExistingZtocCheckFlag: true,
+			numZtocSkipped:            0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{"soci", "convert", "--min-layer-size=0", "--platform", platforms.Format(image.platform)}
+			if tc.skipExistingZtocCheckFlag {
+				args = append(args, "--skip-existing-ztoc-check")
+			}
+			args = append(args, image.ref, image.ref+"-soci")
+			b, err := sh.CombinedOLog(args...)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			numSkipped := strings.Count(string(b), "already exists")
+			if numSkipped != tc.numZtocSkipped {
+				t.Fatalf("expected %v ztoc to be skipped, got %v", tc.numZtocSkipped, numSkipped)
+			}
+		})
+	}
+}
 
 func validateConversion(t *testing.T, sh *shell.Shell, originalDigest, convertedDigest string) {
 	t.Helper()

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -34,6 +34,66 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+func TestCreateWithExistingZtocCheck(t *testing.T) {
+	sh, done := newSnapshotterBaseShell(t)
+	defer done()
+	rebootContainerd(t, sh, "", "")
+
+	// if we build an index for the image first and then create it again
+	// without the --skip-existing-ztoc-check flag, all ztoc's should be skipped
+	image := dockerhub(nginxAlpineImage)
+	indexDigest := buildIndex(sh, image)
+	if indexDigest == "" {
+		t.Fatal("failed to get soci index for test image")
+	}
+	contentStoreBlobPath, _ := testutil.GetContentStoreBlobPath(config.DefaultContentStoreType)
+	parsedDigest, err := digest.Parse(indexDigest)
+	if err != nil {
+		t.Fatalf("cannot parse digest: %v", err)
+	}
+	checkpoints := fetchContentFromPath(sh, filepath.Join(contentStoreBlobPath, parsedDigest.Encoded()))
+	var index soci.Index
+	err = soci.DecodeIndex(bytes.NewReader(checkpoints), &index)
+	if err != nil {
+		t.Fatalf("cannot get index data: %v", err)
+	}
+
+	testCases := []struct {
+		name                      string
+		skipExistingZtocCheckFlag bool
+		numZtocSkipped            int
+	}{
+		{
+			name:                      "test soci create without --skip-existing-ztoc-check flag",
+			skipExistingZtocCheckFlag: false,
+			numZtocSkipped:            len(index.Blobs),
+		},
+		{
+			name:                      "test soci create with --skip-existing-ztoc-check flag",
+			skipExistingZtocCheckFlag: true,
+			numZtocSkipped:            0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{"soci", "create", "--min-layer-size=0", "--platform", platforms.Format(image.platform)}
+			if tc.skipExistingZtocCheckFlag {
+				args = append(args, "--skip-existing-ztoc-check")
+			}
+			args = append(args, image.ref)
+			b, err := sh.CombinedOLog(args...)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			numSkipped := strings.Count(string(b), "already exists")
+			if numSkipped != tc.numZtocSkipped {
+				t.Fatalf("expected %v ztoc to be skipped, got %v", tc.numZtocSkipped, numSkipped)
+			}
+		})
+	}
+}
+
 func TestCreateConvertParameterValidation(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -74,6 +75,7 @@ var (
 	bucketKeyMediaType      = []byte("media_type")
 	bucketKeyArtifactType   = []byte("artifact_type")
 	bucketKeyCreatedAt      = []byte("created_at")
+	bucketKeySpanSize       = []byte("span_size")
 
 	// ArtifactEntryTypeIndex indicates that an ArtifactEntry is a SOCI index artifact
 	ArtifactEntryTypeIndex ArtifactEntryType = "soci_index"
@@ -120,6 +122,8 @@ type ArtifactEntry struct {
 	ArtifactType string
 	// Creation time of SOCI artifact.
 	CreatedAt time.Time
+	// Span Size used to generate the SOCI artifact.
+	SpanSize int64
 }
 
 // NewDB returns an instance of an ArtifactsDB
@@ -303,6 +307,15 @@ func (db *ArtifactsDb) addNewArtifacts(ctx context.Context, blobStorePath string
 				return err
 			}
 			for _, zt := range sociIndex.Blobs {
+				var spanSize int64
+				spanSizeStr, ok := zt.Annotations[IndexAnnotationSociSpanSize]
+				if ok {
+					parsedSpanSize, err := strconv.ParseInt(spanSizeStr, 10, 64)
+					if err != nil {
+						return fmt.Errorf("failed to parse span size from annotations for layer  %s: %w", zt.Digest.String(), err)
+					}
+					spanSize = parsedSpanSize
+				}
 				ztocEntry := &ArtifactEntry{
 					Size:           zt.Size,
 					Digest:         zt.Digest.String(),
@@ -311,6 +324,7 @@ func (db *ArtifactsDb) addNewArtifacts(ctx context.Context, blobStorePath string
 					Location:       zt.Annotations[IndexAnnotationImageLayerDigest],
 					MediaType:      SociLayerMediaType,
 					CreatedAt:      time.Now(),
+					SpanSize:       spanSize,
 				}
 				if err := db.WriteArtifactEntry(ztocEntry); err != nil {
 					return err
@@ -461,6 +475,11 @@ func loadArtifact(artifactBkt *bolt.Bucket, digest string) (*ArtifactEntry, erro
 	if err != nil {
 		return nil, err
 	}
+	encodedSpanSize := artifactBkt.Get(bucketKeySpanSize)
+	spanSize, err := dbutil.DecodeInt(encodedSpanSize)
+	if err != nil {
+		return nil, err
+	}
 	createdAt := time.Time{}
 	createdAtBytes := artifactBkt.Get(bucketKeyCreatedAt)
 	if createdAtBytes != nil {
@@ -478,6 +497,7 @@ func loadArtifact(artifactBkt *bolt.Bucket, digest string) (*ArtifactEntry, erro
 	ae.MediaType = string(artifactBkt.Get(bucketKeyMediaType))
 	ae.ArtifactType = string(artifactBkt.Get(bucketKeyArtifactType))
 	ae.CreatedAt = createdAt
+	ae.SpanSize = spanSize
 	return &ae, nil
 }
 
@@ -492,6 +512,11 @@ func putArtifactEntry(artifacts *bolt.Bucket, ae *ArtifactEntry) error {
 	}
 
 	sizeInBytes, err := dbutil.EncodeInt(ae.Size)
+	if err != nil {
+		return err
+	}
+
+	spanSizeInBytes, err := dbutil.EncodeInt(ae.SpanSize)
 	if err != nil {
 		return err
 	}
@@ -514,6 +539,7 @@ func putArtifactEntry(artifacts *bolt.Bucket, ae *ArtifactEntry) error {
 		{bucketKeyMediaType, []byte(ae.MediaType)},
 		{bucketKeyArtifactType, []byte(ae.ArtifactType)},
 		{bucketKeyCreatedAt, createdAt},
+		{bucketKeySpanSize, spanSizeInBytes},
 	}
 
 	for _, update := range updates {

--- a/soci/artifacts_test.go
+++ b/soci/artifacts_test.go
@@ -157,6 +157,7 @@ func TestArtifactEntry_ReadWrite_Using_ArtifactsDb(t *testing.T) {
 		Type:           ArtifactEntryTypeIndex,
 		ImageDigest:    imageDigest,
 		Platform:       platform,
+		SpanSize:       10,
 	}
 	err = db.WriteArtifactEntry(ae)
 	if err != nil {
@@ -189,6 +190,7 @@ func TestArtifactEntry_ReadWrite_AtomicDbOperations(t *testing.T) {
 		Location:       "/var/soci-snapshotter/test",
 		ImageDigest:    imageDigest,
 		Platform:       platform,
+		SpanSize:       10,
 	}
 	err = db.db.Update(func(tx *bolt.Tx) error {
 		root, err := getArtifactsBucket(tx)

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -58,6 +58,8 @@ const (
 	IndexAnnotationImageLayerMediaType = "com.amazon.soci.image-layer-mediaType"
 	// IndexAnnotationImageLayerDigest is the index annotation for image layer digest
 	IndexAnnotationImageLayerDigest = "com.amazon.soci.image-layer-digest"
+	// IndexAnnotationSpanSize is the span size used to generate a soci artifact
+	IndexAnnotationSociSpanSize = "com.amazon.soci.span-size"
 	// IndexAnnotationBuildToolIdentifier is the index annotation for build tool identifier
 	IndexAnnotationBuildToolIdentifier = "com.amazon.soci.build-tool-identifier"
 	// IndexAnnotationDisableXAttrs is the index annotation if the layer has
@@ -285,11 +287,12 @@ func GetIndexDescriptorCollection(ctx context.Context, cs content.Store, artifac
 }
 
 type builderConfig struct {
-	spanSize            int64
-	minLayerSize        int64
-	buildToolIdentifier string
-	artifactsDb         *ArtifactsDb
-	optimizations       []Optimization
+	spanSize              int64
+	minLayerSize          int64
+	buildToolIdentifier   string
+	artifactsDb           *ArtifactsDb
+	optimizations         []Optimization
+	skipExistingZtocCheck bool
 }
 
 func (b *builderConfig) hasOptimization(o Optimization) bool {
@@ -327,6 +330,13 @@ func ParseOptimization(s string) (Optimization, error) {
 // BuilderOption is a functional argument that affects a SOCI index builder
 // and all indexes built with that builder.
 type BuilderOption func(c *builderConfig) error
+
+func WithSkipExistingZtocCheck(skipExistingZtocCheck bool) BuilderOption {
+	return func(c *builderConfig) error {
+		c.skipExistingZtocCheck = skipExistingZtocCheck
+		return nil
+	}
+}
 
 // WithSpanSize specifies span size.
 func WithSpanSize(spanSize int64) BuilderOption {
@@ -620,6 +630,22 @@ func (b *IndexBuilder) buildSociLayer(ctx context.Context, desc ocispec.Descript
 		return nil, errUnsupportedLayerFormat
 	}
 
+	existingZtoc := getExistingZtocForLayer(desc, b.config)
+	if existingZtoc != nil {
+		reader, err := b.blobStore.Fetch(ctx, *existingZtoc)
+		if err != nil {
+			return nil, fmt.Errorf("cannot fetch existing ztoc: %w", err)
+		}
+		toc, err := ztoc.Unmarshal(reader)
+		if err != nil {
+			return nil, fmt.Errorf("cannot unmarshal existing ztoc: %w", err)
+		}
+
+		fmt.Printf("layer %s -> ztoc %s (already exists)\n", desc.Digest, existingZtoc.Digest)
+		b.addSociLayerAnnotations(&desc, existingZtoc, toc)
+		return existingZtoc, err
+	}
+
 	ra, err := b.contentStore.ReaderAt(ctx, desc)
 	if err != nil {
 		return nil, err
@@ -665,6 +691,7 @@ func (b *IndexBuilder) buildSociLayer(ctx context.Context, desc ocispec.Descript
 		Location:       desc.Digest.String(),
 		MediaType:      SociLayerMediaType,
 		CreatedAt:      time.Now(),
+		SpanSize:       b.config.spanSize,
 	}
 	err = b.config.artifactsDb.WriteArtifactEntry(entry)
 	if err != nil {
@@ -672,14 +699,38 @@ func (b *IndexBuilder) buildSociLayer(ctx context.Context, desc ocispec.Descript
 	}
 
 	fmt.Printf("layer %s -> ztoc %s\n", desc.Digest, ztocDesc.Digest)
+	b.addSociLayerAnnotations(&desc, &ztocDesc, toc)
+	return &ztocDesc, err
+}
 
+func (b *IndexBuilder) addSociLayerAnnotations(layerDesc *ocispec.Descriptor, ztocDesc *ocispec.Descriptor, toc *ztoc.Ztoc) {
 	ztocDesc.MediaType = SociLayerMediaType
 	ztocDesc.Annotations = map[string]string{
-		IndexAnnotationImageLayerMediaType: desc.MediaType,
-		IndexAnnotationImageLayerDigest:    desc.Digest.String(),
+		IndexAnnotationImageLayerMediaType: layerDesc.MediaType,
+		IndexAnnotationImageLayerDigest:    layerDesc.Digest.String(),
+		IndexAnnotationSociSpanSize:        fmt.Sprintf("%d", b.config.spanSize),
 	}
-	b.maybeAddDisableXattrAnnotation(&ztocDesc, toc)
-	return &ztocDesc, err
+	b.maybeAddDisableXattrAnnotation(ztocDesc, toc)
+}
+
+// getExistingZtocForLayer returns a ztoc descriptor for the provided layer if an entry corresponding to the
+// layer already exists in the artifact store.
+func getExistingZtocForLayer(layerDesc ocispec.Descriptor, cfg *builderConfig) *ocispec.Descriptor {
+	if cfg.skipExistingZtocCheck || cfg.artifactsDb == nil {
+		return nil
+	}
+	var existingZtoc *ocispec.Descriptor
+	cfg.artifactsDb.Walk(func(ae *ArtifactEntry) error {
+		if ae.Type == ArtifactEntryTypeLayer && ae.OriginalDigest == layerDesc.Digest.String() && ae.SpanSize == cfg.spanSize {
+			existingZtoc = &ocispec.Descriptor{
+				Digest: digest.Digest(ae.Digest),
+				Size:   ae.Size,
+			}
+			return fmt.Errorf("found existing ztoc for layer %s", layerDesc.Digest)
+		}
+		return nil
+	})
+	return existingZtoc
 }
 
 // NewIndex returns a new index.

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -30,6 +30,95 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+func TestGetExistingZtocForLayer(t *testing.T) {
+	const (
+		layerDigest1 = "sha256:1236aec48c0a74635a5f3dc666628c1673afaa21ed6e1270a9a44de66e811111"
+		ztocDigest1  = "sha256:10d6aec48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		layerDigest2 = "sha256:bbbbbbb48c0a74635a5f3dc666628c1673afaa21ed6e1270a9a44de66e811111"
+		spanSize     = 10
+		size         = 10
+	)
+	artifactsDb, err := newTestableDb()
+	if err != nil {
+		t.Fatalf("can't create a test db")
+	}
+	err = artifactsDb.WriteArtifactEntry(&ArtifactEntry{
+		Digest:         ztocDigest1,
+		OriginalDigest: layerDigest1,
+		Type:           ArtifactEntryTypeLayer,
+		Size:           size,
+		SpanSize:       spanSize,
+		Location:       layerDigest1,
+		MediaType:      SociLayerMediaType,
+	})
+	if err != nil {
+		t.Fatalf("can't write an entry to the db")
+	}
+
+	testCases := []struct {
+		name          string
+		layerDesc     ocispec.Descriptor
+		builderConfig *builderConfig
+		existingZtoc  *ocispec.Descriptor
+	}{
+		{
+			name: "Should return an existing ztoc if a corresponding entry exists in the artifacts db",
+			layerDesc: ocispec.Descriptor{
+				Digest: digest.Digest(layerDigest1),
+				Size:   size,
+			},
+			builderConfig: &builderConfig{
+				spanSize:    spanSize,
+				artifactsDb: artifactsDb,
+			},
+			existingZtoc: &ocispec.Descriptor{
+				Digest: ztocDigest1,
+				Size:   size,
+			},
+		},
+		{
+			name: "Should not return an existing ztoc if a corresponding entry does not exist in the artifacts db",
+			layerDesc: ocispec.Descriptor{
+				Digest: digest.Digest(layerDigest2),
+				Size:   100,
+			},
+			builderConfig: &builderConfig{
+				spanSize:    spanSize,
+				artifactsDb: artifactsDb,
+			},
+			existingZtoc: nil,
+		},
+		{
+			name: "Should skip existing ztoc check if skipExistingZtocCheck flag is set",
+			layerDesc: ocispec.Descriptor{
+				Digest: digest.Digest(layerDigest2),
+				Size:   size,
+			},
+			builderConfig: &builderConfig{
+				spanSize:              spanSize,
+				artifactsDb:           artifactsDb,
+				skipExistingZtocCheck: true,
+			},
+			existingZtoc: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			existingZtoc := getExistingZtocForLayer(tc.layerDesc, tc.builderConfig)
+			if existingZtoc == nil && tc.existingZtoc == nil {
+				return
+			}
+			if existingZtoc == nil || tc.existingZtoc == nil {
+				t.Fatalf(
+					"mismatch between expected and returned ztoc descriptor. expected: %v, returned: %v", tc.existingZtoc, existingZtoc)
+			}
+			if existingZtoc.Digest != tc.existingZtoc.Digest || existingZtoc.Size != tc.existingZtoc.Size {
+				t.Fatalf("returned ztoc descriptor is invalid")
+			}
+		})
+	}
+}
+
 func TestSkipBuildingZtoc(t *testing.T) {
 	testcases := []struct {
 		name        string


### PR DESCRIPTION
**Issue #, if available:**
Closes https://github.com/awslabs/soci-snapshotter/issues/1669

**Description of changes:**
If a ztoc for a layer already exists in the blob store and a corresponding entry exists in the artifacts store, soci will now skip regenerating the ztoc for subsequent `soci create` or `soci convert` calls. To do this, the `span-size` used to generate the ztoc is now being written to the artifact store and also in the layer annotations, so that `rebuild-db` can regenerate the artifact entries properly and take advantage of this feature.  To fall back to the previous behavior `-skip-existing-ztoc-check` flag can be used during `soci create` or `soci convert`.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
