### PR TITLE
Fix race condition in rebuild-db

### DIFF
--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -253,7 +253,12 @@ func (db *ArtifactsDb) addNewArtifacts(ctx context.Context, blobStorePath string
 			return nil
 		}
 		f, err := os.Open(path)
-		if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// This check attempts to mitigate a race between finding content and getting said content.
+			// If content is provided there's no guarantee it will still be there by the time we want to fetch it.
+			// Returning should be safe as it's effectively a no-op.
+			return nil
+		} else if err != nil {
 			return err
 		}
 		defer f.Close()


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The containerd content store (and likely other content stores) implement Walk() by going through the content laid out on disk and running the provided function on each artifact found. However, as the content store has no lock on it while walking, there is a gap between finding content and fetching said content in which the content may disappear.

Fixing this is simple — do a no-op if the content is not found in the content store. This effectively mirrors the behavior of not finding said content in the store to begin with, which more accurately reflects the state of the disk.

This change also simplifies addNewArtifacts by using the native Walk() function, instead of walking through the disk ourselves. (containerd's content store does the same thing under the hood anyway.)

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
