### PR TITLE
fix build error with strict build flag

### DIFF
--- a/ztoc/compression/gzip_zinfo.c
+++ b/ztoc/compression/gzip_zinfo.c
@@ -57,19 +57,19 @@
    This is needed to keep zinfo consistent across multiple architectures,
    ensuring that all integer fields will be stored in little endian.
 */
-inline offset_t encode_offset(offset_t source) {
+static inline offset_t encode_offset(offset_t source) {
     return htole64(source);
 }
 
-inline offset_t decode_offset(offset_t source) {
+static inline offset_t decode_offset(offset_t source) {
     return le64toh(source);
 }
 
-inline int32_t encode_int32(int32_t source) {
+static inline int32_t encode_int32(int32_t source) {
     return htole32(source);
 }
 
-inline int32_t decode_int32(int32_t source) {
+static inline int32_t decode_int32(int32_t source) {
     return le32toh(source);
 }
 


### PR DESCRIPTION
this pr fix building soci-snapshotter fail with some strict build flag, like this:
```
/usr/lib/golang/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/gcc -m64 -Wl,-z,relro -pie -Wl,-z,now -Wl,-z,nocopyreloc -Wl,--build-id=0xe3c87c16ab47f3c2c735710dd45663eaf8e7439d -o $WORK/b001/exe/a.out -rdynamic /tmp/go-link-4207692161/go.o /tmp/go-link-4207692161/000000.o /tmp/go-link-4207692161/000001.o /tmp/go-link-4207692161/000002.o /tmp/go-link-4207692161/000003.o /tmp/go-link-4207692161/000004.o /tmp/go-link-4207692161/000005.o /tmp/go-link-4207692161/000006.o /tmp/go-link-4207692161/000007.o /tmp/go-link-4207692161/000008.o /tmp/go-link-4207692161/000009.o /tmp/go-link-4207692161/000010.o /tmp/go-link-4207692161/000011.o /tmp/go-link-4207692161/000012.o /tmp/go-link-4207692161/000013.o /tmp/go-link-4207692161/000014.o /tmp/go-link-4207692161/000015.o /tmp/go-link-4207692161/000016.o /tmp/go-link-4207692161/000017.o /tmp/go-link-4207692161/000018.o /tmp/go-link-4207692161/000019.o /tmp/go-link-4207692161/000020.o /tmp/go-link-4207692161/000021.o /tmp/go-link-4207692161/000022.o /tmp/go-link-4207692161/000023.o /tmp/go-link-4207692161/000024.o /tmp/go-link-4207692161/000025.o /tmp/go-link-4207692161/000026.o /tmp/go-link-4207692161/000027.o -O2 -g -lresolv -O2 -g -lpthread -O2 -g -L/root/build/BUILD/soci-snapshotter-0.11.1-7fd4815/_build/src/github.com/awslabs/soci-snapshotter/ztoc/compression/../out -l:libz.a -O2 -g -O2 -g -ldl -Wl,-z,relro -Wl,--as-needed -Wl,-z,now -specs=/usr/lib/rpm/OpenCloudOS/OpenCloudOS-hardened-ld -Wl,--build-id=sha1
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `pt_index_from_ucmp_offset':
gzip_zinfo.c:(.text+0xf6): undefined reference to `decode_int32'
/usr/bin/ld: gzip_zinfo.c:(.text+0x126): undefined reference to `decode_offset'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `get_ucomp_off':
gzip_zinfo.c:(.text+0x166): undefined reference to `decode_offset'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `get_comp_off':
gzip_zinfo.c:(.text+0x19e): undefined reference to `decode_offset'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `get_blob_size':
gzip_zinfo.c:(.text+0x1cc): undefined reference to `decode_int32'
/usr/bin/ld: gzip_zinfo.c:(.text+0x1dc): undefined reference to `decode_int32'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `get_max_span_id':
gzip_zinfo.c:(.text+0x21f): undefined reference to `decode_int32'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `has_bits':
gzip_zinfo.c:(.text+0x245): undefined reference to `decode_int32'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `add_checkpoint':
gzip_zinfo.c:(.text+0x3f0): undefined reference to `encode_offset'
/usr/bin/ld: gzip_zinfo.c:(.text+0x404): undefined reference to `encode_offset'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `generate_zinfo_from_fp':
gzip_zinfo.c:(.text+0x708): undefined reference to `encode_int32'
/usr/bin/ld: gzip_zinfo.c:(.text+0x727): undefined reference to `encode_int32'
/usr/bin/ld: gzip_zinfo.c:(.text+0x73d): undefined reference to `encode_offset'
/usr/bin/ld: gzip_zinfo.c:(.text+0x74f): undefined reference to `encode_int32'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `extract_data_from_fp':
gzip_zinfo.c:(.text+0x864): undefined reference to `decode_int32'
/usr/bin/ld: gzip_zinfo.c:(.text+0x890): undefined reference to `decode_offset'
/usr/bin/ld: gzip_zinfo.c:(.text+0x8ce): undefined reference to `decode_offset'
/usr/bin/ld: gzip_zinfo.c:(.text+0x9c0): undefined reference to `decode_offset'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `extract_data_from_buffer':
gzip_zinfo.c:(.text+0xd0e): undefined reference to `decode_offset'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `zinfo_to_blob':
gzip_zinfo.c:(.text+0xf22): undefined reference to `decode_int32'
/usr/bin/ld: gzip_zinfo.c:(.text+0xfca): undefined reference to `decode_int32'
/usr/bin/ld: /tmp/go-link-4207692161/000022.o: in function `blob_to_zinfo':
gzip_zinfo.c:(.text+0x1066): undefined reference to `decode_int32'
/usr/bin/ld: gzip_zinfo.c:(.text+0x10b5): undefined reference to `decode_int32'
/usr/bin/ld: gzip_zinfo.c:(.text+0x1105): undefined reference to `encode_int32'
/usr/bin/ld: gzip_zinfo.c:(.text+0x1136): undefined reference to `encode_offset'
/usr/bin/ld: gzip_zinfo.c:(.text+0x11fb): undefined reference to `decode_int32'
collect2: error: ld returned 1 exit status
```