### PR TITLE
fix fscache not cleanup

### DIFF
--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -93,6 +93,7 @@ func (l *breakableLayer) SkipVerify()                          {}
 func (l *breakableLayer) ReadAt([]byte, int64, ...remote.Option) (int, error) {
 	return 0, fmt.Errorf("fail")
 }
+func (l *breakableLayer) GetCacheRefKey() string { return "" }
 func (l *breakableLayer) BackgroundFetch() error { return fmt.Errorf("fail") }
 func (l *breakableLayer) Check() error {
 	if !l.success {

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -104,6 +104,9 @@ type Layer interface {
 	// Done releases the reference to this layer. The resources related to this layer will be
 	// discarded sooner or later. Queries after calling this function won't be serviced.
 	Done()
+
+	// GetCacheRefKey returns the reference key for the cache used by the layer
+	GetCacheRefKey() string
 }
 
 // Info is the current status of a layer.
@@ -226,6 +229,12 @@ func newCache(root string, cacheType string, cfg config.FSConfig) (cache.BlobCac
 	)
 }
 
+func (r *Resolver) Evict(name string) {
+	r.layerCacheMu.Lock()
+	r.layerCache.Remove(name)
+	r.layerCacheMu.Unlock()
+}
+
 // Resolve resolves a layer based on the passed layer blob information.
 func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, refspec reference.Spec, desc, sociDesc ocispec.Descriptor, opCounter *FuseOperationCounter, disableVerification bool, metadataOpts ...metadata.Option) (_ Layer, retErr error) {
 	name := refspec.String() + "/" + desc.Digest.String()
@@ -339,7 +348,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, ref
 	}
 	disableXAttrs := getDisableXAttrAnnotation(sociDesc)
 	// Combine layer information together and cache it.
-	l := newLayer(r, desc, blobR, vr, bgLayerResolver, opCounter, disableXAttrs)
+	l := newLayer(r, desc, name, blobR, vr, bgLayerResolver, opCounter, disableXAttrs)
 	r.layerCacheMu.Lock()
 	cachedL, done2, added := r.layerCache.Add(name, l)
 	r.layerCacheMu.Unlock()
@@ -370,18 +379,8 @@ func (r *Resolver) resolveBlob(ctx context.Context, hosts []docker.RegistryHost,
 		r.blobCacheMu.Unlock()
 	}
 
-	httpCache, err := newCache(filepath.Join(r.rootDir, "httpcache"), r.config.HTTPCacheType, r.config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create http cache: %w", err)
-	}
-	defer func() {
-		if retErr != nil {
-			httpCache.Close()
-		}
-	}()
-
 	// Resolve the blob and cache the result.
-	b, err := r.resolver.Resolve(ctx, hosts, refspec, desc, httpCache)
+	b, err := r.resolver.Resolve(ctx, hosts, refspec, desc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve the source: %w", err)
 	}
@@ -397,6 +396,7 @@ func (r *Resolver) resolveBlob(ctx context.Context, hosts []docker.RegistryHost,
 func newLayer(
 	resolver *Resolver,
 	desc ocispec.Descriptor,
+	cacheRefKey string,
 	blob *blobRef,
 	r reader.Reader,
 	bgResolver backgroundfetcher.Resolver,
@@ -406,6 +406,7 @@ func newLayer(
 	return &layer{
 		resolver:             resolver,
 		desc:                 desc,
+		cacheRefKey:          cacheRefKey,
 		blob:                 blob,
 		r:                    r,
 		bgResolver:           bgResolver,
@@ -415,9 +416,10 @@ func newLayer(
 }
 
 type layer struct {
-	resolver *Resolver
-	desc     ocispec.Descriptor
-	blob     *blobRef
+	resolver    *Resolver
+	desc        ocispec.Descriptor
+	cacheRefKey string
+	blob        *blobRef
 
 	bgResolver backgroundfetcher.Resolver
 
@@ -428,6 +430,10 @@ type layer struct {
 
 	closed   bool
 	closedMu sync.Mutex
+}
+
+func (l *layer) GetCacheRefKey() string {
+	return l.cacheRefKey
 }
 
 func (l *layer) Info() Info {

--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -128,6 +128,9 @@ func (gr *reader) Close() (retErr error) {
 		return nil
 	}
 	gr.closed = true
+	if gr.spanManager != nil {
+		gr.spanManager.Close()
+	}
 	if err := gr.r.Close(); err != nil {
 		retErr = errors.Join(retErr, err)
 	}

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -97,7 +97,7 @@ func NewResolver(cfg config.BlobConfig, handlers map[string]Handler) *Resolver {
 	}
 }
 
-func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, refspec reference.Spec, desc ocispec.Descriptor, blobCache cache.BlobCache) (Blob, error) {
+func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, refspec reference.Spec, desc ocispec.Descriptor) (Blob, error) {
 
 	var (
 		validInterval = time.Duration(r.blobConfig.ValidInterval) * time.Second

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"sync"
 
 	"github.com/awslabs/soci-snapshotter/cache"
 	"github.com/awslabs/soci-snapshotter/util/ioutils"
@@ -49,6 +50,7 @@ type SpanManager struct {
 	spans                             []*span
 	ztoc                              *ztoc.Ztoc
 	maxSpanVerificationFailureRetries int
+	closeOnce                         sync.Once
 }
 
 type spanInfo struct {
@@ -430,6 +432,13 @@ func (m *SpanManager) verifySpanContents(compressedData []byte, spanID compressi
 
 // Close closes both the underlying zinfo data and blob cache.
 func (m *SpanManager) Close() {
-	m.zinfo.Close()
-	m.cache.Close()
+	m.closeOnce.Do(func() {
+		log.L.Debug("Spancache finalizer called. Cleaning up spancache")
+		if m.zinfo != nil {
+			m.zinfo.Close()
+		}
+		if m.cache != nil {
+			m.cache.Close()
+		}
+	})
 }


### PR DESCRIPTION
**Issue #, if available:**
1. When users run `nerdctl images rmi` to remove images, fscache is not cleaned up
2. When the snapshotter exits, fscache is not cleared
3. After restarting the snapshotter, a new batch of fscache directories is created with duplicate content
4. The snapshotter does not automatically restore fscache upon restart

**Description of changes:**
This patch implements explicit resource lifecycle management with immediate eviction support to fix resource leaks during unmount operations.

The core change enhances the LRU cache to support both deferred and immediate eviction modes. The `done` callback now accepts a boolean parameter: `false` for lazy cleanup and `true` for immediate removal. When immediate eviction is requested, cache entries are finalized and removed synchronously instead of waiting for LRU eviction.

A new `Close()` method is introduced alongside the existing `Done()` to distinguish between normal resource release and unmount scenarios. During filesystem unmount, layers call `Close()` to trigger immediate resource eviction, preventing the resource leaks observed in the original issue. Error paths are also updated to use immediate eviction for invalid or corrupted resources, ensuring they don't occupy cache space.

Additionally, the patch adds explicit cleanup of span manager resources in the reader's `Close()` method and improves snapshot restoration robustness by pre-creating required directories before mount operations. Overall, this provides deterministic cleanup timing with clear "release when convenient" vs. "release immediately" semantics, which is critical for proper resource management during unmounts and error handling. and error handling.

**Testing performed:**
1. Run an image
```bash
nerdctl run --snapshotter soci --rm -it env12.com/ocs9:soci echo "hello"
```

Observed:
```bash
Every 1.0s: du -h --max-depth=1 /var/lib/soci-snapshotter-grpc/soci/spancache                   VM-33-248-tlinux: Wed Nov  5 09:35:08 2025

25M     /var/lib/soci-snapshotter-grpc/soci/spancache/2068117739
25M     /var/lib/soci-snapshotter-grpc/soci/spancache
```

2. Remove the image
```bash
nerdctl images -q | xargs nerdctl rmi -f
Untagged: env12.com/ocs9:soci@sha256:979fe973858c87e1fb2152a9b17563f6fc59abc5c2f85293d15a7c827bbb6a02
Deleted: sha256:3a6ef9931f24a0ccd89e429366e0341d81b58d97bf7115612494f4249dd8d351
```

Observed:
```bash
Every 1.0s: du -h --max-depth=1 /var/lib/soci-snapshotter-grpc/soci/spancache                   VM-33-248-tlinux: Wed Nov  5 09:35:27 2025

4.0K    /var/lib/soci-snapshotter-grpc/soci/spancache
```

3. Re-run the image
```bash
nerdctl run --snapshotter soci --rm -it env12.com/ocs9:soci echo "hello"
env12.com/ocs9:soci:                                                              resolved       |++++++++++++++++++++++++++++++++++++++| 
index-sha256:979fe973858c87e1fb2152a9b17563f6fc59abc5c2f85293d15a7c827bbb6a02:    done           |++++++++++++++++++++++++++++++++++++++| 
manifest-sha256:fb1079429352f239c48ea35304477b270a42932d000b0707e4d96990f68afb2f: done           |++++++++++++++++++++++++++++++++++++++| 
config-sha256:ba7df7c2d4c09ddea132cac1bcc9d77c461db75fb49d681837695bbec4df6142:   done           |++++++++++++++++++++++++++++++++++++++| 
elapsed: 0.6 s                                                                    total:  3.2 Ki (5.3 KiB/s)                                       
hello
```

Observed:
```bash
Every 1.0s: du -h --max-depth=1 /var/lib/soci-snapshotter-grpc/soci/spancache                   VM-33-248-tlinux: Wed Nov  5 09:35:59 2025

71M     /var/lib/soci-snapshotter-grpc/soci/spancache/3428176031
71M     /var/lib/soci-snapshotter-grpc/soci/spancache
```

4. Kill the snapshotter process (Ctrl+C)

Observed:
```bash
Every 1.0s: du -h --max-depth=1 /var/lib/soci-snapshotter-grpc/soci/spancache                   VM-33-248-tlinux: Wed Nov  5 09:36:17 2025

4.0K    /var/lib/soci-snapshotter-grpc/soci/spancache
```

5. Restart the snapshotter process and run the container again

Observed:
```bash
Every 1.0s: du -h --max-depth=1 /var/lib/soci-snapshotter-grpc/soci/spancache                   VM-33-248-tlinux: Wed Nov  5 09:36:31 2025

25M     /var/lib/soci-snapshotter-grpc/soci/spancache/1469904631
25M     /var/lib/soci-snapshotter-grpc/soci/spancache
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
