### PR TITLE
Remove patch version requirement in go.mod

### DIFF
--- a/.github/workflows/benchmark-visualization.yml
+++ b/.github/workflows/benchmark-visualization.yml
@@ -19,7 +19,7 @@ permissions:
   deployments: write
 
 env:
-  GO_VERSION: '1.24.4'
+  GO_VERSION: '1.24.9'
 
 jobs:
   benchmark:

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,6 +1,6 @@
 module github.com/awslabs/soci-snapshotter/cmd
 
-go 1.24.9
+go 1.24.0
 
 require (
 	github.com/awslabs/soci-snapshotter v0.0.0-local

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/awslabs/soci-snapshotter
 
-go 1.24.9
+go 1.24.0
 
 require (
 	github.com/containerd/containerd v1.7.28


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Noticed our benchmarking script failed as we didn't have the right Go version. I think we probably don't need to mandate the absolute latest of Go so I just put the version to 1.24.0 and updated our Benchmarking script.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
