### PR TITLE
Run CI on ztoc module changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
       - 'Dockerfile'
       - 'integration/**'
       - 'scripts/**'
+      - 'ztoc/**' # Includes flatbuf + C files
       - '!benchmark/**'
 
 env:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Noticed in #1742 the changes should check the changes against our build CI but it did not. Added `ztoc/**` as a trigger for our Build workflow as it encompasses all of our flatbuffers + C files whihc don't get caught by our other wildcard matchers.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
