### PR TITLE
FUSE: report real filesystem stats in Statfs to fix df/kubelet 0-capa…

### DIFF
--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -461,7 +461,7 @@ func (l *layer) RootNode(baseInode uint32, idMapper idtools.IDMap) (fusefs.Inode
 	if l.isClosed() {
 		return nil, fmt.Errorf("layer is already closed")
 	}
-	return newNode(l.desc.Digest, l.r, l.blob, baseInode, l.resolver.overlayOpaqueType, l.resolver.config.LogFuseOperations, l.fuseOperationCounter, idMapper)
+	return newNode(l.desc.Digest, l.r, l.blob, baseInode, l.resolver.overlayOpaqueType, l.resolver.config.LogFuseOperations, l.fuseOperationCounter, idMapper, l.resolver.rootDir)
 }
 
 func (l *layer) ReadAt(p []byte, offset int64, opts ...remote.Option) (int, error) {

--- a/fs/layer/layer_test.go
+++ b/fs/layer/layer_test.go
@@ -50,6 +50,7 @@ import (
 func TestLayer(t *testing.T) {
 	testNodeRead(t, metadata.NewTempDbStore)
 	testExistence(t, metadata.NewTempDbStore)
+	testStatfs(t, metadata.NewTempDbStore)
 }
 
 func TestWaiter(t *testing.T) {


### PR DESCRIPTION
The FUSE layer previously returned zeroed Statfs, causing df to show 0 and kubelet to warn InvalidDiskCapacity on the image filesystem. 
```
0s (x255 over 45h)      Warning   InvalidDiskCapacity   Node/10.255.64.239                      invalid capacity 0 on image filesystem
0s (x256 over 45h)      Warning   InvalidDiskCapacity   Node/10.255.64.239                      invalid capacity 0 on image filesystem
0s (x257 over 45h)      Warning   InvalidDiskCapacity   Node/10.255.64.239                      invalid capacity 0 on image filesystem
```

we can get this log:
```
df -h /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs/
Filesystem      Size  Used Avail Use% Mounted on
soci               0     0     0    - /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs
```

This change plumbs a base path and fills Statfs from unix.Statfs, with a safe fallback to zeros. A minimal test ensures zero when base is empty and non-zero when provided.

After this change:
```
df -h /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs/
Filesystem      Size  Used Avail Use% Mounted on
soci             99G   60G   35G  64% /var/lib/soci-snapshotter-grpc/snapshotter/snapshots/1/fs
```

TODO:
The argument list for newNode is too long and could be refactored. I can tackle this in a follow-up PR.
