### PR TITLE
Lower Error to Warn in remote mount id-mapping

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -944,7 +944,7 @@ func (fs *filesystem) IDMapMount(ctx context.Context, mountpoint, activeLayerID 
 	l := fs.layer[mountpoint]
 	if l == nil {
 		fs.layerMu.Unlock()
-		logger.Error("failed to create remote id-mapped mount")
+		logger.Warnf("failed to create remote id-mapped mount: %s", errdefs.ErrNotFound)
 		return "", errdefs.ErrNotFound
 	}
 	fs.layer[newMountpoint] = l


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This should have been a warn instead of an error to begin with as it's nota fatal operation

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
