### PR TITLE
Make LogMonitor threadsafe

### DIFF
--- a/integration/log_test.go
+++ b/integration/log_test.go
@@ -22,8 +22,6 @@ import (
 	"time"
 )
 
-const sensitiveInfoMonitorKey = "sensitive-info-monitor"
-
 // TestSnapshotterDoesNotLogSensitiveInformation verifies that the snapshotter
 // doesn't log sensitive information during various operations.
 func TestSnapshotterDoesNotLogSensitiveInformation(t *testing.T) {
@@ -59,10 +57,9 @@ func TestSnapshotterDoesNotLogSensitiveInformation(t *testing.T) {
 				done()
 			})
 
-			logMonitor := rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, tc.opts...))
-			logMonitor.Add(sensitiveInfoMonitorKey, sensitiveInfoMonitor(t, sensitivePatterns...))
+			logMonitor := rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, tc.opts...), sensitiveInfoMonitor(t, sensitivePatterns...))
 			t.Cleanup(func() {
-				logMonitor.Remove(sensitiveInfoMonitorKey)
+				logMonitor.Cleanup(t)
 			})
 
 			copyImage(sh, dockerhub(image), regConfig.mirror(image))


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Our LogMonitor is not threadsafe, which occasionally leads to test failures such at [this](https://github.com/awslabs/soci-snapshotter/actions/runs/19478810665/job/55745386314?pr=1775#step:5:447) one. Small change to help avoid this issue.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
