### PR TITLE
Make sure draining the resp body for range-gets

### DIFF
--- a/fs/parallel_artifact_fetcher.go
+++ b/fs/parallel_artifact_fetcher.go
@@ -301,6 +301,7 @@ func writeToFileRange(file *os.File, rsc io.ReadCloser, lower, upper int64) erro
 	// Reading any more or less will result in an incorrect file being created,
 	// so use io.CopyN to guarantee we read exactly lower - upper + 1 bytes.
 	_, err := io.CopyN(w, rsc, readSize)
+	io.Copy(io.Discard, rsc) // Drain remaining data
 	if err != nil {
 		return fmt.Errorf("failed to write to temp file %s at offset %d: %w", file.Name(), lower, err)
 	}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
