### PR TITLE
fix: skip processing ztocs/indexes that are found in the artifacts store but not in the content store

### DIFF
--- a/integration/index_test.go
+++ b/integration/index_test.go
@@ -79,7 +79,7 @@ func prepareCustomSociIndices(t *testing.T, sh *shell.Shell, images []testImageI
 			}
 		}
 		img.imgInfo = dockerhub(imgName, withPlatform(platform))
-		img.sociIndexDigest = buildIndex(sh, img.imgInfo, withIndexBuildConfig(indexBuildConfig), withMinLayerSize(0), withRunRebuildDbBeforeCreate())
+		img.sociIndexDigest = buildIndex(sh, img.imgInfo, withIndexBuildConfig(indexBuildConfig), withMinLayerSize(0))
 		ztocDigests, err := getZtocDigestsForImage(sh, img.imgInfo)
 		if err != nil {
 			t.Fatalf("could not get ztoc digests: %v", err)
@@ -345,7 +345,7 @@ func TestSociIndexRemoveAndRebuildWithSharedLayers(t *testing.T) {
 		// the following 2 images share layers
 		img1 := dockerhub(nginxAlpineImage)
 		img2 := dockerhub(nginxAlpineImage2)
-		imgDigest := buildIndex(sh, img1, withMinLayerSize(0), withRunRebuildDbBeforeCreate())
+		imgDigest := buildIndex(sh, img1, withMinLayerSize(0))
 		if imgDigest == "" {
 			t.Fatal("failed to get soci index for nginx alpine test image")
 		}

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -128,8 +128,6 @@ func TestRunMultipleContainers(t *testing.T) {
 				buildIndexOpts := []indexBuildOption{withMinLayerSize(0)}
 				if tt.forceRecreateZtocs {
 					buildIndexOpts = append(buildIndexOpts, withForceRecreateZtocs(true))
-				} else {
-					buildIndexOpts = append(buildIndexOpts, withRunRebuildDbBeforeCreate())
 				}
 				indexDigest := buildIndex(sh, regConfig.mirror(container.containerImage), buildIndexOpts...)
 				sh.X("soci", "push", "--user", regConfig.mirror(container.containerImage).creds, regConfig.mirror(container.containerImage).ref)

--- a/integration/util_soci_test.go
+++ b/integration/util_soci_test.go
@@ -92,19 +92,6 @@ func withForceRecreateZtocs(forceRecreateZtocs bool) indexBuildOption {
 	}
 }
 
-// withRebuildDbBeforeCreate syncs the artifact store with the content store before calling "soci create"
-// We do this because the artifact store could be out of sync with the content store when 'soci create' is called.
-// This is problematic in cases where we create soci indexes for some images, delete those indexes and immediately recreate
-// them (like in TestSociIndexRemove) - as there could be ztoc entries in the artifact store which are not present in the
-// content store, causing 'soci create/convert' without --force flag to throw an error.
-//
-// We can run this by default and probably remove this option in the future when the race condition with rebuild-db is solved.
-func withRunRebuildDbBeforeCreate() indexBuildOption {
-	return func(ibc *indexBuildConfig) {
-		ibc.runRebuildDbBeforeCreate = true
-	}
-}
-
 // withSpanSize overrides the default span size to use when creating an index with `buildIndex`
 func withSpanSize(spanSize int64) indexBuildOption {
 	return func(ibc *indexBuildConfig) {


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/soci-snapshotter/issues/1789

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
