### PR TITLE
add garbage collection labels to image mainfest

### DIFF
--- a/soci/soci_convert.go
+++ b/soci/soci_convert.go
@@ -307,6 +307,18 @@ func (b *IndexBuilder) annotateImages(ctx context.Context, ociIndex *ocispec.Ind
 			}
 			indexWithMetadata.Desc.Annotations[IndexAnnotationImageManifestDigest] = manifestDesc.Digest.String()
 		}
+
+		err = store.LabelGCRefContent(ctx, b.blobStore, *manifestDesc, "config", manifest.Config.Digest.String())
+		if err != nil {
+			return err
+		}
+
+		for i, layer := range manifest.Layers {
+			err = store.LabelGCRefContent(ctx, b.blobStore, *manifestDesc, fmt.Sprintf("l.%d", i), layer.Digest.String())
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**Issue #, if available:**
#1800 

**Description of changes:**
- adds missing labels to image manifest after `soci image convert`
- adds test to verify that all the labels exist on the converted image ~and the digest associated with the config labels points to the image. (Verified by doing a content get on this extracted digest)~

We now follow the following steps to ensure all the digests are referrenced in the labels
- make a map of digest(key) -> label(list)*
- iterate the layer digests and config digest from the manifest
- verify that there is atleast one label associated with the digests

*this ensures theres atleast one reference to each layer even if we end up adding multiple lables to layers in the future


**Testing performed:**
- soci convert now works in-place
- deleting image tags of original image does not corrupt converted images

```
sudo nerdctl pull jrottenberg/ffmpeg:latest
sudo soci convert jrottenberg/ffmpeg:latest jrottenberg/ffmpeg:latest
sudo ctr i inspect --content docker.io/jrottenberg/ffmpeg:latest
```
gives us a valid output 
```
docker.io/jrottenberg/ffmpeg:latest
│    Created: 2025-12-04 02:02:17.117510483 +0000 UTC
│    Updated: 2025-12-04 02:03:07.45875418 +0000 UTC
└── application/vnd.oci.image.index.v1+json @sha256:b2333f366fec96b22948ee73e77fa36dbdbdbed60da2f67ffe9d16fe5f7b8fac (803 bytes)
    ├── application/vnd.oci.image.manifest.v1+json @sha256:0b940c1d2b3a1069c42f179e09117dc2cd28fcbebe723a8c21d50d8399e584b0 (1187 bytes)
    │   │    Platform: linux/amd64
    │   ├── application/vnd.oci.image.config.v1+json @sha256:a8bf3d68fbdb7e4a79769f599d4172c46344a983e621a4eb340eaa32edd34ac7 (2977 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:20043066d3d5c78b45520c5707319835ac7d1f3d7f0dded0138ea0897d6a3188 (29724688 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:716e71fe910f5c1a05201f410f410e7e2c0276701158dde03d00568c05e0922a (1886898 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:3017d0488c3c00fee2ef3c8c23b653fcd36787eb1ed0866a8b0c8127852587e3 (16156 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:7cd4e390adb98b5b44c4c0ad7a43187784d7c55cd84972c5d2d0b0011f95f41f (21898 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:503ba9a45cd098fcbafd665e3fa1a61099502a896cae0cfa397265b0c396f517 (51234035 bytes)
    └── application/vnd.oci.image.manifest.v1+json @sha256:341bca01870c073893654c02bd7517c7c697e07898862ed16d2fbb6ad7ff920d (1114 bytes)
        │    Platform: linux/amd64
        ├── application/vnd.amazon.soci.index.v2+json @sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a (2 bytes)
        ├── application/octet-stream @sha256:463bedc6834a57f54f0f767a02177609f5721c2aca204fe0c615854e2a8f0fb1 (1216912 bytes)
        └── application/octet-stream @sha256:231dfcc2b681dd2df5d89b645fc09294edb524359fc632d874aa225ffe256682 (1124248 bytes)
```

previously it would error out  : `ctr: content digest sha256:a8bf3d68fbdb7e4a79769f599d4172c46344a983e621a4eb340eaa32edd34ac7: not found`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
