### PR TITLE
Add golang patent notice allowlist

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -11,6 +11,7 @@ allow-licenses:
   - 'BSD-2-Clause'
   - 'BSD-2-Clause-FreeBSD'
   - 'BSD-3-Clause'
+  - 'LicenseRef-scancode-google-patent-license-golang' # Golang packages are licensed under this
   - 'MIT'
   - 'ISC'
   - 'Python-2.0'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The dependencby bump script now includes `LicenseRef-scancode-google-patent-license-golang` in its scanning. Golang x packages are still under BSD-3 and this is more of a notice but this should work to allowlist those packages.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
