### PR TITLE
Add artifact store interface

### DIFF
--- a/cmd/soci/commands/convert.go
+++ b/cmd/soci/commands/convert.go
@@ -144,7 +144,7 @@ var ConvertCommand = &cli.Command{
 			soci.WithSpanSize(spanSize),
 			soci.WithBuildToolIdentifier(buildToolIdentifier),
 			soci.WithOptimizations(optimizations),
-			soci.WithArtifactsDb(artifactsDb),
+			soci.WithArtifactStore(artifactsDb),
 			soci.WithForceRecreateZtocs(forceRecreateZtocs),
 		}
 

--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -129,7 +129,7 @@ var CreateCommand = &cli.Command{
 			soci.WithSpanSize(spanSize),
 			soci.WithBuildToolIdentifier(buildToolIdentifier),
 			soci.WithOptimizations(optimizations),
-			soci.WithArtifactsDb(artifactsDb),
+			soci.WithArtifactStore(artifactsDb),
 			soci.WithForceRecreateZtocs(forceRecreateZtocs),
 		}
 

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
 	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/awslabs/soci-snapshotter/soci/artifacts"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 
 	"github.com/opencontainers/go-digest"
@@ -51,11 +52,11 @@ var infoCommand = &cli.Command{
 			return err
 		}
 
-		artifactType, err := db.GetArtifactType(digest.String())
+		artifact, err := db.Get(ctx, digest.String())
 		if err != nil {
 			return err
 		}
-		if artifactType == soci.ArtifactEntryTypeLayer {
+		if artifact.Type == artifacts.EntryTypeLayer {
 			return fmt.Errorf("the provided digest is of ztoc not SOCI index. Use \"soci ztoc info\" command to get detailed info of ztoc")
 		}
 

--- a/cmd/soci/commands/prefetch/list.go
+++ b/cmd/soci/commands/prefetch/list.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
 	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/awslabs/soci-snapshotter/soci/artifacts"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 
 	"github.com/opencontainers/go-digest"
@@ -61,7 +62,7 @@ var listCommand = &cli.Command{
 
 		var prefetches []prefetchInfo
 
-		addPrefetchInfo := func(entry *soci.ArtifactEntry, totalSpans int) {
+		addPrefetchInfo := func(entry *artifacts.Entry, totalSpans int) {
 			prefetches = append(prefetches, prefetchInfo{
 				Digest:      entry.Digest,
 				LayerDigest: entry.OriginalDigest,
@@ -70,8 +71,8 @@ var listCommand = &cli.Command{
 			})
 		}
 
-		err = db.Walk(func(entry *soci.ArtifactEntry) error {
-			if entry.Type != soci.ArtifactEntryTypePrefetch {
+		err = db.Walk(ctx, func(entry *artifacts.Entry) error {
+			if entry.Type != artifacts.EntryTypePrefetch {
 				return nil
 			}
 

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -108,8 +108,8 @@ func getZtoc(ctx context.Context, cmd *cli.Command, d digest.Digest) (*ztoc.Ztoc
 	return ztoc.Unmarshal(reader)
 }
 
-func getLayer(ctx context.Context, metadata *soci.ArtifactsDb, ztocDigest digest.Digest, cs content.Store) (content.ReaderAt, error) {
-	artifact, err := metadata.GetArtifactEntry(ztocDigest.String())
+func getLayer(ctx context.Context, artifactsDb *soci.ArtifactsDb, ztocDigest digest.Digest, cs content.Store) (content.ReaderAt, error) {
+	artifact, err := artifactsDb.Get(ctx, ztocDigest.String())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal"
 	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/awslabs/soci-snapshotter/soci/artifacts"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/awslabs/soci-snapshotter/ztoc"
 	"github.com/awslabs/soci-snapshotter/ztoc/compression"
@@ -64,11 +65,11 @@ var infoCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		entry, err := db.GetArtifactEntry(digest.String())
+		entry, err := db.Get(ctx, digest.String())
 		if err != nil {
 			return err
 		}
-		if entry.Type == soci.ArtifactEntryTypeIndex {
+		if entry.Type == artifacts.EntryTypeIndex {
 			return fmt.Errorf("the provided digest belongs to a SOCI index. Use `soci index info` to get the detailed information about it")
 		}
 		ctx, cancel := internal.AppContext(ctx, cmd)

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/awslabs/soci-snapshotter/soci/artifacts"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/awslabs/soci-snapshotter/util/dbutil"
 	"github.com/containerd/containerd/content"
@@ -41,55 +42,42 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-// Artifacts package stores SOCI artifacts info in the following schema.
+// ArtifactsDb is a remote (w.r.t containerd), bolt-db based store for
+// SOCI artifact metadata that implements the artifacts.RemoteStore interface.
+// It stores SOCI artifacts info in the following schema.
 //
 // - soci_artifacts
-//       - *soci_artifact_digest*       : bucket for each soci layer keyed by a unique string.
-//         - size : <varint>            : size of the artifact.
-//         - originalDigest : <string>  : the digest for the image manifest or layer
-//         - imageDigest: <string>      : the digest of the image index
-//         - platform: <string>         : the platform for the index
-//         - location: <string>         : the location of the artifact
-//         - type: <string>             : the type of the artifact (can be either "soci_index" or "soci_layer")
-
-// ArtifactsDB is a store for SOCI artifact metadata
+//   - soci_artifact_digest: <string>     : bucket for each soci layer keyed by a unique string.
+//   - size: <varint>                     : size of the artifact.
+//   - originalDigest: <string>           : the digest for the image manifest or layer
+//   - imageDigest: <string>              : the digest of the image index
+//   - platform: <string>                 : the platform for the index
+//   - location: <string>                 : the location of the artifact
+//   - type: <string>                     : the type of the artifact (can be either "soci_index" or "soci_layer")
 type ArtifactsDb struct {
 	db *bolt.DB
 }
-
-// ArtifactEntryType is the type of SOCI artifact represented by the ArtifactEntry
-type ArtifactEntryType string
 
 const (
 	artifactsDbName = "artifacts.db"
 )
 
 var (
-	bucketKeySociArtifacts  = []byte("soci_artifacts")
-	bucketKeySize           = []byte("size")
-	bucketKeyOriginalDigest = []byte("oci_digest")
-	bucketKeyImageDigest    = []byte("image_digest")
-	bucketKeyPlatform       = []byte("platform")
-	bucketKeyLocation       = []byte("location")
-	bucketKeyType           = []byte("type")
-	bucketKeyMediaType      = []byte("media_type")
-	bucketKeyArtifactType   = []byte("artifact_type")
-	bucketKeyCreatedAt      = []byte("created_at")
-	bucketKeySpanSize       = []byte("span_size")
-
-	// ArtifactEntryTypeIndex indicates that an ArtifactEntry is a SOCI index artifact
-	ArtifactEntryTypeIndex ArtifactEntryType = "soci_index"
-	// ArtifactEntryTypeLayer indicates that an ArtifactEntry is a SOCI layer artifact
-	ArtifactEntryTypeLayer ArtifactEntryType = "soci_layer"
-	// ArtifactEntryTypePrefetch indicates that an ArtifactEntry is a SOCI prefetch artifact
-	ArtifactEntryTypePrefetch ArtifactEntryType = "soci_prefetch"
-
-	db   *ArtifactsDb
-	once sync.Once
-)
-
-var (
 	ErrArtifactBucketNotFound = errors.New("soci_artifacts not found")
+	db                        *ArtifactsDb
+	once                      sync.Once
+	bucketKeySociArtifacts    = []byte("soci_artifacts")
+	bucketKeySize             = []byte("size")
+	bucketKeyOriginalDigest   = []byte("oci_digest")
+	bucketKeyImageDigest      = []byte("image_digest")
+	bucketKeyPlatform         = []byte("platform")
+	bucketKeyLocation         = []byte("location")
+	bucketKeyType             = []byte("type")
+	bucketKeyMediaType        = []byte("media_type")
+	bucketKeyArtifactType     = []byte("artifact_type")
+	bucketKeyCreatedAt        = []byte("created_at")
+	bucketKeySpanSize         = []byte("span_size")
+	errArtifactBucketNotFound = errors.New("soci_artifacts not found")
 )
 
 // Get the default artifacts db path
@@ -98,34 +86,6 @@ func ArtifactsDbPath(root string) string {
 		root = config.DefaultSociSnapshotterRootPath
 	}
 	return path.Join(root, artifactsDbName)
-}
-
-// ArtifactEntry is a metadata object for a SOCI artifact.
-type ArtifactEntry struct {
-	// Size is the SOCI artifact's size in bytes.
-	Size int64
-	// Digest is the SOCI artifact's digest.
-	Digest string
-	// OriginalDigest is the digest of the content for which the SOCI artifact was created.
-	OriginalDigest string
-	// ImageDigest is the digest of the container image that was used to generate the artifact
-	// ImageDigest refers to the image, OriginalDigest refers to the specific content within that
-	// image that was used to generate the Artifact.
-	ImageDigest string
-	// Platform is the platform for which the artifact was generated.
-	Platform string
-	// Location is the file path for the SOCI artifact.
-	Location string
-	// Type is the type of SOCI artifact.
-	Type ArtifactEntryType
-	// Media Type of the stored artifact.
-	MediaType string
-	// ArtifactType is the type of artifact stored (e.g. index manifest v1 vs index manifest v2)
-	ArtifactType string
-	// Creation time of SOCI artifact.
-	CreatedAt time.Time
-	// Span Size used to generate the SOCI artifact.
-	SpanSize int64
 }
 
 // NewDB returns an instance of an ArtifactsDB
@@ -152,42 +112,112 @@ func NewDB(path string) (*ArtifactsDb, error) {
 	return db, nil
 }
 
-func (db *ArtifactsDb) getIndexArtifactEntries(indexDigest string) ([]ArtifactEntry, error) {
-	artifactEntries := []ArtifactEntry{}
-	err := db.Walk(func(ae *ArtifactEntry) error {
-		if ae.Type == ArtifactEntryTypeIndex && ae.OriginalDigest == indexDigest {
-			artifactEntries = append(artifactEntries, *ae)
-		}
-		return nil
+func (db *ArtifactsDb) Get(ctx context.Context, digest string) (*artifacts.Entry, error) {
+	var entry *artifacts.Entry
+	err := db.db.View(func(tx *bolt.Tx) error {
+		var err error
+		entry, err = db.getArtifactEntry(tx, digest)
+		return err
 	})
 
-	return artifactEntries, err
-
+	return entry, err
 }
 
-// Walk applys a function to all ArtifactEntries in the ArtifactsDB
-func (db *ArtifactsDb) Walk(f func(*ArtifactEntry) error) error {
+func (db *ArtifactsDb) Write(ctx context.Context, entry *artifacts.Entry) error {
+	if entry == nil {
+		return fmt.Errorf("no entry to write")
+	}
+	return db.db.Update(func(tx *bolt.Tx) error {
+		return db.writeArtifactEntry(tx, entry)
+	})
+}
+
+func (db *ArtifactsDb) Walk(ctx context.Context, walkFn artifacts.WalkFn) error {
 	err := db.db.View(func(tx *bolt.Tx) error {
 		bucket, err := getArtifactsBucket(tx)
 		if err != nil {
 			return nil
 		}
-		bucket.ForEachBucket(func(k []byte) error {
+		return bucket.ForEachBucket(func(k []byte) error {
 			artifactBkt := bucket.Bucket(k)
 			ae, err := loadArtifact(artifactBkt, string(k))
 			if err != nil {
 				return err
 			}
-			return f(ae)
+			return walkFn(ae)
 		})
-		return nil
 	})
 	return err
 }
 
-// SyncWithLocalStore will sync the artifacts databse with SOCIs local content store, either adding new or removing old artifacts.
-func (db *ArtifactsDb) SyncWithLocalStore(ctx context.Context, blobStore store.Store, blobStorePath string, cs content.Store) error {
-	if err := db.RemoveOldArtifacts(ctx, blobStore); err != nil {
+func (db *ArtifactsDb) Remove(ctx context.Context, digest string) error {
+	return db.db.Update(func(tx *bolt.Tx) error {
+		bucket, err := getArtifactsBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		dgstBucket := bucket.Bucket([]byte(digest))
+		if dgstBucket == nil {
+			return fmt.Errorf("the index of the digest %s doesn't exist", digest)
+		}
+		return bucket.DeleteBucket([]byte(digest))
+	})
+}
+
+func (db *ArtifactsDb) Filter(ctx context.Context, filterFn artifacts.FilterFn) ([]*artifacts.Entry, error) {
+	var filtered []*artifacts.Entry
+	err := db.db.View(func(tx *bolt.Tx) error {
+		bucket, err := getArtifactsBucket(tx)
+		if err != nil {
+			return nil
+		}
+		return bucket.ForEachBucket(func(k []byte) error {
+			artifactBkt := bucket.Bucket(k)
+			ae, err := loadArtifact(artifactBkt, string(k))
+			if err != nil {
+				return err
+			}
+			if filterFn(ae) {
+				filtered = append(filtered, ae)
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return filtered, nil
+}
+
+func (db *ArtifactsDb) Find(ctx context.Context, filterFn artifacts.FilterFn) (*artifacts.Entry, error) {
+	var found *artifacts.Entry
+	err := db.db.View(func(tx *bolt.Tx) error {
+		bucket, err := getArtifactsBucket(tx)
+		if err != nil {
+			return nil
+		}
+		return bucket.ForEachBucket(func(k []byte) error {
+			artifactBkt := bucket.Bucket(k)
+			ae, err := loadArtifact(artifactBkt, string(k))
+			if err != nil {
+				return err
+			}
+			if filterFn(ae) {
+				found = ae
+				return errors.New("found") // return error to stop iteration
+			}
+			return nil
+		})
+	})
+	if err != nil && err.Error() != "found" {
+		return nil, err
+	}
+	return found, nil
+}
+
+func (db *ArtifactsDb) Sync(ctx context.Context, blobStore store.Store, blobStorePath string, cs content.Store) error {
+	if err := db.removeOldArtifacts(ctx, blobStore); err != nil {
 		return fmt.Errorf("failed to remove old artifacts from db: %w", err)
 	}
 	if err := db.addNewArtifacts(ctx, blobStorePath, cs); err != nil {
@@ -196,12 +226,11 @@ func (db *ArtifactsDb) SyncWithLocalStore(ctx context.Context, blobStore store.S
 	return nil
 }
 
-// RemoveOldArtifacts will remove any artifacts from the artifacts database that
-// no longer exist in SOCIs local content store. NOTE: Removing buckets while iterating
-// (bucket.ForEach) causes unexpected behavior (see: https://github.com/boltdb/bolt/issues/426).
+// NOTE: Removing buckets while iterating (bucket.ForEach) causes unexpected
+// behavior (see: https://github.com/boltdb/bolt/issues/426).
 // This implementation works around this issue by appending buckets to a slice when
 // iterating and removing them after.
-func (db *ArtifactsDb) RemoveOldArtifacts(ctx context.Context, blobStore store.Store) error {
+func (db *ArtifactsDb) removeOldArtifacts(ctx context.Context, blobStore store.Store) error {
 	err := db.db.Update(func(tx *bolt.Tx) error {
 		bucket, err := getArtifactsBucket(tx)
 		if err != nil {
@@ -287,8 +316,8 @@ func (db *ArtifactsDb) addNewArtifacts(ctx context.Context, blobStorePath string
 		}
 		// entry is an index
 		indexDigest := addHashPrefix(d.Name())
-		ae, err := db.GetArtifactEntry(indexDigest)
-		if err != nil && !errors.Is(err, ErrArtifactBucketNotFound) && !errors.Is(err, errdefs.ErrNotFound) {
+		ae, err := db.Get(ctx, indexDigest)
+		if err != nil && !errors.Is(err, errArtifactBucketNotFound) && !errors.Is(err, errdefs.ErrNotFound) {
 			return err
 		}
 		if ae == nil {
@@ -300,19 +329,19 @@ func (db *ArtifactsDb) addNewArtifacts(ctx context.Context, blobStorePath string
 				return err
 			}
 
-			indexEntry := &ArtifactEntry{
+			indexEntry := &artifacts.Entry{
 				Size:           info.Size(),
 				Digest:         indexDigest,
 				OriginalDigest: manifestDigest,
 				ImageDigest:    manifestDigest,
 				Platform:       platforms.Format(platform[0]),
-				Type:           ArtifactEntryTypeIndex,
+				Type:           artifacts.EntryTypeIndex,
 				Location:       manifestDigest,
 				MediaType:      sociIndex.MediaType,
 				ArtifactType:   sociIndex.Config.MediaType,
 				CreatedAt:      time.Now(),
 			}
-			if err = db.WriteArtifactEntry(indexEntry); err != nil {
+			if err = db.Write(ctx, indexEntry); err != nil {
 				return err
 			}
 			for _, zt := range sociIndex.Blobs {
@@ -324,17 +353,17 @@ func (db *ArtifactsDb) addNewArtifacts(ctx context.Context, blobStorePath string
 						return fmt.Errorf("failed to parse span size from annotations for layer  %s: %w", zt.Digest.String(), err)
 					}
 				}
-				ztocEntry := &ArtifactEntry{
+				ztocEntry := &artifacts.Entry{
 					Size:           zt.Size,
 					Digest:         zt.Digest.String(),
 					OriginalDigest: zt.Annotations[IndexAnnotationImageLayerDigest],
-					Type:           ArtifactEntryTypeLayer,
+					Type:           artifacts.EntryTypeLayer,
 					Location:       zt.Annotations[IndexAnnotationImageLayerDigest],
 					MediaType:      SociLayerMediaType,
 					CreatedAt:      time.Now(),
 					SpanSize:       spanSize,
 				}
-				if err := db.WriteArtifactEntry(ztocEntry); err != nil {
+				if err := db.Write(ctx, ztocEntry); err != nil {
 					return err
 				}
 			}
@@ -343,19 +372,7 @@ func (db *ArtifactsDb) addNewArtifacts(ctx context.Context, blobStorePath string
 	})
 }
 
-// GetArtifactEntry loads a single ArtifactEntry from the ArtifactsDB by digest
-func (db *ArtifactsDb) GetArtifactEntry(digest string) (*ArtifactEntry, error) {
-	var entry *ArtifactEntry
-	err := db.db.View(func(tx *bolt.Tx) error {
-		var err error
-		entry, err = db.getArtifactEntry(tx, digest)
-		return err
-	})
-
-	return entry, err
-}
-
-func (db *ArtifactsDb) getArtifactEntry(tx *bolt.Tx, digest string) (*ArtifactEntry, error) {
+func (db *ArtifactsDb) getArtifactEntry(tx *bolt.Tx, digest string) (*artifacts.Entry, error) {
 	bucket, err := getArtifactsBucket(tx)
 	if err != nil {
 		return nil, err
@@ -363,80 +380,7 @@ func (db *ArtifactsDb) getArtifactEntry(tx *bolt.Tx, digest string) (*ArtifactEn
 	return getArtifactEntryByDigest(bucket, digest)
 }
 
-// GetArtifactType gets Type of an ArtifactEntry from the ArtifactsDB by digest
-func (db *ArtifactsDb) GetArtifactType(digest string) (ArtifactEntryType, error) {
-	ae, err := db.GetArtifactEntry(digest)
-	if err != nil {
-		return "", err
-	}
-	return ae.Type, nil
-}
-
-// RemoveArtifactEntryByIndexDigest removes an index's artifact entry using its digest
-func (db *ArtifactsDb) RemoveArtifactEntryByIndexDigest(digest []byte) error {
-	return db.db.Update(func(tx *bolt.Tx) error {
-		bucket, err := getArtifactsBucket(tx)
-		if err != nil {
-			return err
-		}
-
-		dgstBucket := bucket.Bucket(digest)
-		if dgstBucket == nil {
-			return fmt.Errorf("the index of the digest %s doesn't exist", digest)
-		}
-
-		if indexBucket(dgstBucket) {
-			return bucket.DeleteBucket(digest)
-		}
-		return fmt.Errorf("the digest %s does not correspond to an index", digest)
-	})
-}
-
-// GetArtifactEntriesByImageDigest returns all index digests greated from a given image digest
-func (db *ArtifactsDb) GetArtifactEntriesByImageDigest(digest string) ([][]byte, error) {
-	entries := make([][]byte, 0)
-	return entries, db.db.View(func(tx *bolt.Tx) error {
-		bucket, err := getArtifactsBucket(tx)
-		if err != nil {
-			return err
-		}
-
-		c := bucket.Cursor()
-		for k, _ := c.First(); k != nil; k, _ = c.Next() {
-			artifactBucket := bucket.Bucket(k)
-			if indexBucket(artifactBucket) && hasImageDigest(artifactBucket, digest) {
-				entries = append(entries, k)
-			}
-		}
-		return nil
-	})
-}
-
-// Determines whether a bucket represents an index, as opposed to a zTOC
-func indexBucket(b *bolt.Bucket) bool {
-	mt := string(b.Get(bucketKeyMediaType))
-	return mt == ocispec.MediaTypeImageManifest
-}
-
-// Determines whether a bucket's image digest is the same as digest
-func hasImageDigest(b *bolt.Bucket, digest string) bool {
-	imgDigest := string(b.Get(bucketKeyImageDigest))
-	return digest == imgDigest
-}
-
-// WriteArtifactEntry stores a single ArtifactEntry into the ArtifactsDB.
-// If there is already an artifact in the ArtifactsDB with the same Digest,
-// the old data is overwritten.
-func (db *ArtifactsDb) WriteArtifactEntry(entry *ArtifactEntry) error {
-	if entry == nil {
-		return fmt.Errorf("no entry to write")
-	}
-	return db.db.Update(func(tx *bolt.Tx) error {
-		return db.writeArtifactEntry(tx, entry)
-	})
-}
-
-func (db *ArtifactsDb) writeArtifactEntry(tx *bolt.Tx, entry *ArtifactEntry) error {
+func (db *ArtifactsDb) writeArtifactEntry(tx *bolt.Tx, entry *artifacts.Entry) error {
 	bucket, err := tx.CreateBucketIfNotExists(bucketKeySociArtifacts)
 	if err != nil {
 		return err
@@ -444,31 +388,16 @@ func (db *ArtifactsDb) writeArtifactEntry(tx *bolt.Tx, entry *ArtifactEntry) err
 	return putArtifactEntry(bucket, entry)
 }
 
-// updateSociV2ArtifactReference updates the image and manifest digests associated with the SOCI index digest in the artifacts db.
-// the indexDigest is the SOCI index to updated, the manifestDigest is the specific image manifest that the SOCI index is bound to,
-// and the imageDigest is the target of the image (this is the same as the manifestDigest for single platform images, but different for mult-platform)
-func (db *ArtifactsDb) updateSociV2ArtifactReference(indexDigest string, manifestDigest string, imageDigest string) error {
-	return db.db.Update(func(tx *bolt.Tx) error {
-		ae, err := db.getArtifactEntry(tx, indexDigest)
-		if err != nil {
-			return err
-		}
-		ae.ImageDigest = imageDigest
-		ae.OriginalDigest = manifestDigest
-		return db.writeArtifactEntry(tx, ae)
-	})
-}
-
 func getArtifactsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
 	artifacts := tx.Bucket(bucketKeySociArtifacts)
 	if artifacts == nil {
-		return nil, ErrArtifactBucketNotFound
+		return nil, errArtifactBucketNotFound
 	}
 
 	return artifacts, nil
 }
 
-func getArtifactEntryByDigest(artifacts *bolt.Bucket, digest string) (*ArtifactEntry, error) {
+func getArtifactEntryByDigest(artifacts *bolt.Bucket, digest string) (*artifacts.Entry, error) {
 	artifactBkt := artifacts.Bucket([]byte(digest))
 	if artifactBkt == nil {
 		return nil, fmt.Errorf("couldn't retrieve artifact for %s, %w", digest, errdefs.ErrNotFound)
@@ -476,8 +405,8 @@ func getArtifactEntryByDigest(artifacts *bolt.Bucket, digest string) (*ArtifactE
 	return loadArtifact(artifactBkt, digest)
 }
 
-func loadArtifact(artifactBkt *bolt.Bucket, digest string) (*ArtifactEntry, error) {
-	ae := ArtifactEntry{Digest: digest}
+func loadArtifact(artifactBkt *bolt.Bucket, digest string) (*artifacts.Entry, error) {
+	ae := artifacts.Entry{Digest: digest}
 	encodedSize := artifactBkt.Get(bucketKeySize)
 	size, err := dbutil.DecodeInt(encodedSize)
 	if err != nil {
@@ -503,7 +432,7 @@ func loadArtifact(artifactBkt *bolt.Bucket, digest string) (*ArtifactEntry, erro
 	}
 	ae.Size = size
 	ae.Location = string(artifactBkt.Get(bucketKeyLocation))
-	ae.Type = ArtifactEntryType(artifactBkt.Get(bucketKeyType))
+	ae.Type = artifacts.EntryType(artifactBkt.Get(bucketKeyType))
 	ae.OriginalDigest = string(artifactBkt.Get(bucketKeyOriginalDigest))
 	ae.ImageDigest = string(artifactBkt.Get(bucketKeyImageDigest))
 	ae.Platform = string(artifactBkt.Get(bucketKeyPlatform))
@@ -514,7 +443,7 @@ func loadArtifact(artifactBkt *bolt.Bucket, digest string) (*ArtifactEntry, erro
 	return &ae, nil
 }
 
-func putArtifactEntry(artifacts *bolt.Bucket, ae *ArtifactEntry) error {
+func putArtifactEntry(artifacts *bolt.Bucket, ae *artifacts.Entry) error {
 	if artifacts == nil {
 		return fmt.Errorf("can't write ArtifactEntry: the bucket does not exist")
 	}

--- a/soci/artifacts/entry.go
+++ b/soci/artifacts/entry.go
@@ -1,0 +1,58 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package artifacts
+
+import "time"
+
+// Entry is a metadata object for a SOCI artifact.
+type Entry struct {
+	// Size is the SOCI artifact's size in bytes.
+	Size int64
+	// Digest is the SOCI artifact's (ztoc or SOCI index) digest.
+	Digest string
+	// OriginalDigest is the digest of the content (layer for ztoc, manifest for SOCI index) for which the SOCI artifact was created.
+	OriginalDigest string
+	// ImageDigest is the digest of the container image that was used to generate the artifact.
+	// This is the image manifest's digest for single platform images or the image index's digest for multi-platform images.
+	ImageDigest string
+	// Platform is the platform for which the artifact was generated.
+	Platform string
+	// Location is the file path for the SOCI artifact.
+	Location string
+	// Type is the type of SOCI artifact.
+	Type EntryType
+	// Media Type of the stored artifact.
+	MediaType string
+	// ArtifactType is the type of artifact stored (e.g. index manifest v1 vs index manifest v2)
+	ArtifactType string
+	// Creation time of SOCI artifact.
+	CreatedAt time.Time
+	// Span Size used to generate the SOCI artifact.
+	SpanSize int64
+}
+
+// ArtifactEntryType is the type of SOCI artifact represented by the ArtifactEntry
+type EntryType string
+
+const (
+	// EntryTypeIndex indicates that an ArtifactEntry is a SOCI index artifact
+	EntryTypeIndex EntryType = "soci_index"
+	// EntryTypeLayer indicates that an ArtifactEntry is a SOCI layer artifact
+	EntryTypeLayer EntryType = "soci_layer"
+	// EntryTypePrefetch indicates that an ArtifactEntry is a SOCI prefetch artifact
+	EntryTypePrefetch EntryType = "soci_prefetch"
+)

--- a/soci/artifacts/filter.go
+++ b/soci/artifacts/filter.go
@@ -1,0 +1,90 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package artifacts
+
+type FilterFn func(*Entry) bool
+
+// WithAnyFilters combines the given filters with OR logic
+func WithAnyFilters(filters ...FilterFn) FilterFn {
+	if len(filters) == 0 {
+		return func(*Entry) bool {
+			return true
+		}
+	}
+	return func(e *Entry) bool {
+		for _, f := range filters {
+			if f(e) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// WithAllFilters combines the given filters with AND logic
+func WithAllFilters(filters ...FilterFn) FilterFn {
+	return func(e *Entry) bool {
+		for _, f := range filters {
+			if !f(e) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// WithDigest returns a filter that matches entries with the specified digest
+func WithDigest(digest string) FilterFn {
+	return func(e *Entry) bool {
+		return e.Digest == digest
+	}
+}
+
+// WithImageDigest returns a filter that matches entries with the specified image digest
+func WithImageDigest(digest string) FilterFn {
+	return func(e *Entry) bool {
+		return e.ImageDigest == digest
+	}
+}
+
+// WithOriginalDigest returns a filter that matches entries with the specified original digest
+func WithOriginalDigest(digest string) FilterFn {
+	return func(e *Entry) bool {
+		return e.OriginalDigest == digest
+	}
+}
+
+// WithEntryType returns a filter that matches entries with the specified entry type
+func WithEntryType(t EntryType) FilterFn {
+	return func(e *Entry) bool {
+		return e.Type == t
+	}
+}
+
+// WithMediaType returns a filter that matches entries with the specified media type
+func WithMediaType(mediaType string) FilterFn {
+	return func(e *Entry) bool {
+		return e.MediaType == mediaType
+	}
+}
+
+// With Platform returns a filter that matches entries with the specified platform
+func WithPlatform(p string) FilterFn {
+	return func(e *Entry) bool {
+		return e.Platform == p
+	}
+}

--- a/soci/artifacts/store.go
+++ b/soci/artifacts/store.go
@@ -1,0 +1,52 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package artifacts
+
+import (
+	"context"
+
+	"github.com/awslabs/soci-snapshotter/soci/store"
+	"github.com/containerd/containerd/content"
+)
+
+type WalkFn func(*Entry) error
+
+// Store is a store for SOCI artifact metadata
+// TODO: add comments
+type Store interface {
+	// Get gets an entry from the store by its digest
+	Get(ctx context.Context, digest string) (*Entry, error)
+	// Write writes an entry into the store
+	Write(ctx context.Context, entry *Entry) error
+	// Walk walks all entries in the store, calling walkFn for each entry
+	// Returning an error from the walkFn, stops the walk.
+	Walk(ctx context.Context, walkFn WalkFn) error
+	// Remove removes an entry from the store by its digest
+	Remove(ctx context.Context, digest string) error
+	// Filter filters entries in the store, returning only those that match the filter function
+	Filter(ctx context.Context, filterFn FilterFn) ([]*Entry, error)
+	// Find finds the first (in storage order) entry in the store that matches the given filter function
+	Find(ctx context.Context, filterFn FilterFn) (*Entry, error)
+}
+
+// RemoteStore is a remote (w.r.t containerd) store for SOCI artifact metadata
+type RemoteStore interface {
+	Store
+	// Sync will sync the artifacts databse with SOCIs local content store, either adding new or removing old artifacts.
+	// TODO: do we really need all these params?
+	Sync(ctx context.Context, blobStore store.Store, blobStorePath string, cs content.Store) error
+}

--- a/soci/artifacts_test.go
+++ b/soci/artifacts_test.go
@@ -21,8 +21,369 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/awslabs/soci-snapshotter/soci/artifacts"
 	bolt "go.etcd.io/bbolt"
 )
+
+func TestArtifactDBWalk(t *testing.T) {
+	db, err := newTestableDb()
+	if err != nil {
+		t.Fatalf("can't create a test db")
+	}
+	const (
+		dgst1 = "sha256:10d6aec48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		dgst2 = "sha256:20d6a9c48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		dgst3 = "sha256:80d6aec48caaaaaaaa5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+	)
+	entries := []artifacts.Entry{
+		{Digest: dgst1, Size: 10, Type: artifacts.EntryTypeIndex},
+		{Digest: dgst2, Size: 20, Type: artifacts.EntryTypeIndex},
+		{Digest: dgst3, Size: 30, Type: artifacts.EntryTypeLayer},
+	}
+	for _, entry := range entries {
+		if err := db.Write(t.Context(), &entry); err != nil {
+			t.Fatalf("can't write entry")
+		}
+	}
+	var walked []*artifacts.Entry
+	err = db.Walk(t.Context(), func(e *artifacts.Entry) error {
+		walked = append(walked, e)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk failed")
+	}
+	if len(walked) != len(entries) {
+		t.Fatalf("expected %d entries, got %d", len(entries), len(walked))
+	}
+}
+
+func TestArtifactDBFind(t *testing.T) {
+	db, err := newTestableDb()
+	if err != nil {
+		t.Fatalf("can't create a test db")
+	}
+	const (
+		dgst1         = "sha256:10d6aec48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		originalDgst1 = "sha256:1236aec48c0a74635a5f3dc666628c1673afaa21ed6e1270a9a44de66e811111"
+		dgst2         = "sha256:20d6a9c48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		dgst3         = "sha256:80d6aec48caaaaaaaa5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		originalDgst3 = "sha256:bbbbbbb48c0a74635a5f3dc666628c1673afaa21ed6e1270a9a44de66e811111"
+		dgst4         = "sha256:99d6aec48caaaaaaaa5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		dgst5         = "sha256:a7f3c9d2e8b4f1a6c5d8e9f2b3a4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
+		dgst6         = "sha256:3e8f7a2b9c4d1e6f5a8b7c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9"
+		imageDigest   = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+		platformAmd64 = "linux/amd64"
+		platformArm64 = "linux/arm64"
+	)
+	entries := []artifacts.Entry{
+		{
+			Size:           10,
+			Digest:         dgst1,
+			OriginalDigest: originalDgst1,
+			Location:       "/var/soci-snapshotter/test1",
+			Type:           artifacts.EntryTypeIndex,
+			ImageDigest:    imageDigest,
+			Platform:       platformAmd64,
+		},
+		{
+			Size:           20,
+			Digest:         dgst2,
+			OriginalDigest: originalDgst1,
+			Location:       "/var/soci-snapshotter/test2",
+			Type:           artifacts.EntryTypeIndex,
+			ImageDigest:    imageDigest,
+			Platform:       platformAmd64,
+		},
+		{
+			Size:           15,
+			Digest:         dgst3,
+			OriginalDigest: originalDgst1,
+			Location:       "/var/soci-snapshotter/test3",
+			Type:           artifacts.EntryTypeIndex,
+			ImageDigest:    imageDigest,
+			Platform:       platformAmd64,
+		},
+		{
+			Size:           10,
+			Digest:         dgst4,
+			OriginalDigest: originalDgst1,
+			Location:       "/var/soci-snapshotter/test1",
+			Type:           artifacts.EntryTypeLayer,
+			ImageDigest:    imageDigest,
+			Platform:       platformAmd64,
+		},
+		{
+			Size:           25,
+			Digest:         dgst5,
+			OriginalDigest: originalDgst3,
+			Location:       "/var/soci-snapshotter/test1",
+			Type:           artifacts.EntryTypeLayer,
+			ImageDigest:    imageDigest,
+			Platform:       platformArm64,
+			MediaType:      "test1",
+		},
+		{
+			Size:           30,
+			Digest:         dgst6,
+			OriginalDigest: originalDgst3,
+			Location:       "/var/soci-snapshotter/test1",
+			Type:           artifacts.EntryTypeLayer,
+			ImageDigest:    imageDigest,
+			Platform:       platformArm64,
+			MediaType:      "test2",
+		},
+	}
+	for _, entry := range entries {
+		err = db.Write(t.Context(), &entry)
+		if err != nil {
+			t.Fatalf("can't put ArtifactEntry to a bucket")
+		}
+	}
+
+	tests := []struct {
+		name             string
+		filter           artifacts.FilterFn
+		expectedArtifact *artifacts.Entry
+	}{
+		{
+			name:             "test find with digest",
+			filter:           artifacts.WithDigest(dgst1),
+			expectedArtifact: &entries[0],
+		},
+		{
+			name:             "test find with entry type index",
+			filter:           artifacts.WithEntryType(artifacts.EntryTypeIndex),
+			expectedArtifact: &entries[0],
+		},
+		{
+			name:             "test find with original digest",
+			filter:           artifacts.WithOriginalDigest(originalDgst1),
+			expectedArtifact: &entries[0],
+		},
+		{
+			name:             "test find with image digest",
+			filter:           artifacts.WithImageDigest(imageDigest),
+			expectedArtifact: &entries[0],
+		},
+		{
+			name:             "test find with platform",
+			filter:           artifacts.WithPlatform(platformAmd64),
+			expectedArtifact: &entries[0],
+		},
+		{
+			name:             "test find with media type",
+			filter:           artifacts.WithMediaType("test1"),
+			expectedArtifact: &entries[4],
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			artifact, err := db.Find(t.Context(), test.filter)
+			if err != nil {
+				t.Fatalf("cannot find artifact entry")
+			}
+			if *artifact != *test.expectedArtifact {
+				t.Fatalf("retrieved artifact entry doesn't match")
+			}
+		})
+	}
+}
+
+func TestArtifactDBFilter(t *testing.T) {
+	db, err := newTestableDb()
+	if err != nil {
+		t.Fatalf("can't create a test db")
+	}
+	const (
+		dgst1         = "sha256:10d6aec48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		originalDgst1 = "sha256:1236aec48c0a74635a5f3dc666628c1673afaa21ed6e1270a9a44de66e811111"
+		dgst2         = "sha256:20d6a9c48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		dgst3         = "sha256:80d6aec48caaaaaaaa5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		originalDgst3 = "sha256:bbbbbbb48c0a74635a5f3dc666628c1673afaa21ed6e1270a9a44de66e811111"
+		dgst4         = "sha256:99d6aec48caaaaaaaa5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		dgst5         = "sha256:a7f3c9d2e8b4f1a6c5d8e9f2b3a4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
+		dgst6         = "sha256:3e8f7a2b9c4d1e6f5a8b7c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9"
+		imageDigest   = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+		platformAmd64 = "linux/amd64"
+		platformArm64 = "linux/arm64"
+	)
+	entries := []artifacts.Entry{
+		{
+			Size:           10,
+			Digest:         dgst1,
+			OriginalDigest: originalDgst1,
+			Location:       "/var/soci-snapshotter/test1",
+			Type:           artifacts.EntryTypeIndex,
+			ImageDigest:    imageDigest,
+			Platform:       platformAmd64,
+		},
+		{
+			Size:           20,
+			Digest:         dgst2,
+			OriginalDigest: originalDgst1,
+			Location:       "/var/soci-snapshotter/test2",
+			Type:           artifacts.EntryTypeIndex,
+			ImageDigest:    imageDigest,
+			Platform:       platformAmd64,
+		},
+		{
+			Size:           15,
+			Digest:         dgst3,
+			OriginalDigest: originalDgst1,
+			Location:       "/var/soci-snapshotter/test3",
+			Type:           artifacts.EntryTypeIndex,
+			ImageDigest:    imageDigest,
+			Platform:       platformAmd64,
+		},
+		{
+			Size:           10,
+			Digest:         dgst4,
+			OriginalDigest: originalDgst1,
+			Location:       "/var/soci-snapshotter/test1",
+			Type:           artifacts.EntryTypeLayer,
+			ImageDigest:    imageDigest,
+			Platform:       platformAmd64,
+		},
+		{
+			Size:           25,
+			Digest:         dgst5,
+			OriginalDigest: originalDgst3,
+			Location:       "/var/soci-snapshotter/test1",
+			Type:           artifacts.EntryTypeLayer,
+			ImageDigest:    imageDigest,
+			Platform:       platformArm64,
+			MediaType:      "test1",
+		},
+		{
+			Size:           30,
+			Digest:         dgst6,
+			OriginalDigest: originalDgst3,
+			Location:       "/var/soci-snapshotter/test1",
+			Type:           artifacts.EntryTypeLayer,
+			ImageDigest:    imageDigest,
+			Platform:       platformArm64,
+			MediaType:      "test2",
+		},
+	}
+	for _, entry := range entries {
+		err = db.Write(t.Context(), &entry)
+		if err != nil {
+			t.Fatalf("can't put ArtifactEntry to a bucket")
+		}
+	}
+
+	tests := []struct {
+		name            string
+		filter          artifacts.FilterFn
+		expectedLength  int
+		expectedEntries []*artifacts.Entry
+	}{
+		{
+			name:            "test filter with digest",
+			filter:          artifacts.WithDigest(dgst1),
+			expectedEntries: []*artifacts.Entry{&entries[0]},
+		},
+		{
+			name:            "test filter with entry type index",
+			filter:          artifacts.WithEntryType(artifacts.EntryTypeIndex),
+			expectedEntries: []*artifacts.Entry{&entries[0], &entries[1], &entries[2]},
+		},
+		{
+			name:            "test filter with entry type layer",
+			filter:          artifacts.WithEntryType(artifacts.EntryTypeLayer),
+			expectedEntries: []*artifacts.Entry{&entries[3], &entries[4], &entries[5]},
+		},
+		{
+			name:            "test filter with original digest",
+			filter:          artifacts.WithOriginalDigest(originalDgst1),
+			expectedEntries: []*artifacts.Entry{&entries[0], &entries[1], &entries[2], &entries[3]},
+		},
+		{
+			name:            "test filter with image digest",
+			filter:          artifacts.WithImageDigest(imageDigest),
+			expectedEntries: []*artifacts.Entry{&entries[0], &entries[1], &entries[2], &entries[3], &entries[4], &entries[5]},
+		},
+		{
+			name:            "test filter with platform",
+			filter:          artifacts.WithPlatform(platformAmd64),
+			expectedEntries: []*artifacts.Entry{&entries[0], &entries[1], &entries[2], &entries[3]},
+		},
+		{
+			name:            "test filter with media type",
+			filter:          artifacts.WithMediaType("test1"),
+			expectedEntries: []*artifacts.Entry{&entries[4]},
+		},
+		{
+			name:            "test filter with all filters",
+			filter:          artifacts.WithAllFilters(artifacts.WithEntryType(artifacts.EntryTypeIndex), artifacts.WithOriginalDigest(originalDgst1)),
+			expectedEntries: []*artifacts.Entry{&entries[0], &entries[1], &entries[2]},
+		},
+		{
+			name:            "test filter with any filters",
+			filter:          artifacts.WithAnyFilters(artifacts.WithPlatform(platformAmd64), artifacts.WithPlatform(platformArm64)),
+			expectedEntries: []*artifacts.Entry{&entries[0], &entries[1], &entries[2], &entries[3], &entries[4], &entries[5]},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entries, err := db.Filter(t.Context(), test.filter)
+			if err != nil {
+				t.Fatalf("cannot filter artifact entries")
+			}
+			if len(entries) != len(test.expectedEntries) {
+				t.Fatalf("the length of filtered entries should be %d, but equals to %d", test.expectedLength, len(entries))
+			}
+			for _, expected := range test.expectedEntries {
+				found := false
+				for _, actual := range entries {
+					if *expected == *actual {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected entry not found: %+v", expected)
+				}
+			}
+		})
+	}
+}
+
+func TestArtifactDBRemove(t *testing.T) {
+	db, err := newTestableDb()
+	if err != nil {
+		t.Fatalf("can't create a test db")
+	}
+	const (
+		dgst         = "sha256:10d6aec48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55"
+		originalDgst = "sha256:1236aec48c0a74635a5f3dc666628c1673afaa21ed6e1270a9a44de66e811111"
+		imageDigest  = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+		platform     = "linux/amd64"
+	)
+	entry := &artifacts.Entry{
+		Size:           10,
+		Digest:         dgst,
+		OriginalDigest: originalDgst,
+		Location:       "/var/soci-snapshotter/test",
+		Type:           artifacts.EntryTypeIndex,
+		ImageDigest:    imageDigest,
+		Platform:       platform,
+	}
+	err = db.Write(t.Context(), entry)
+	if err != nil {
+		t.Fatalf("can't write entry")
+	}
+	err = db.Remove(t.Context(), dgst)
+	if err != nil {
+		t.Fatalf("can't remove entry")
+	}
+	_, err = db.Get(t.Context(), dgst)
+	if err == nil {
+		t.Fatalf("entry should not exist after removal")
+	}
+}
 
 func TestGetIndexArtifactEntries(t *testing.T) {
 	db, err := newTestableDb()
@@ -39,13 +400,13 @@ func TestGetIndexArtifactEntries(t *testing.T) {
 		imageDigest   = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 		platform      = "linux/amd64"
 	)
-	entries := []ArtifactEntry{
+	entries := []artifacts.Entry{
 		{
 			Size:           10,
 			Digest:         dgst1,
 			OriginalDigest: originalDgst1,
 			Location:       "/var/soci-snapshotter/test1",
-			Type:           ArtifactEntryTypeIndex,
+			Type:           artifacts.EntryTypeIndex,
 			ImageDigest:    imageDigest,
 			Platform:       platform,
 		},
@@ -54,7 +415,7 @@ func TestGetIndexArtifactEntries(t *testing.T) {
 			Digest:         dgst2,
 			OriginalDigest: originalDgst1,
 			Location:       "/var/soci-snapshotter/test2",
-			Type:           ArtifactEntryTypeIndex,
+			Type:           artifacts.EntryTypeIndex,
 			ImageDigest:    imageDigest,
 			Platform:       platform,
 		},
@@ -63,7 +424,7 @@ func TestGetIndexArtifactEntries(t *testing.T) {
 			Digest:         dgst3,
 			OriginalDigest: originalDgst3,
 			Location:       "/var/soci-snapshotter/test3",
-			Type:           ArtifactEntryTypeIndex,
+			Type:           artifacts.EntryTypeIndex,
 			ImageDigest:    imageDigest,
 			Platform:       platform,
 		},
@@ -72,19 +433,22 @@ func TestGetIndexArtifactEntries(t *testing.T) {
 			Digest:         dgst4,
 			OriginalDigest: originalDgst1,
 			Location:       "/var/soci-snapshotter/test1",
-			Type:           ArtifactEntryTypeLayer,
+			Type:           artifacts.EntryTypeLayer,
 			ImageDigest:    imageDigest,
 			Platform:       platform,
 		},
 	}
 	for _, entry := range entries {
-		err = db.WriteArtifactEntry(&entry)
+		err = db.Write(t.Context(), &entry)
 		if err != nil {
 			t.Fatalf("can't put ArtifactEntry to a bucket")
 		}
 	}
 
-	retrievedEntries, err := db.getIndexArtifactEntries(originalDgst1)
+	retrievedEntries, err := db.Filter(t.Context(), artifacts.WithAllFilters(
+		artifacts.WithEntryType(artifacts.EntryTypeIndex),
+		artifacts.WithOriginalDigest(originalDgst1),
+	))
 	if err != nil {
 		t.Fatalf("could not retrieve artifact entries for original digest %s", originalDgst1)
 	}
@@ -93,7 +457,7 @@ func TestGetIndexArtifactEntries(t *testing.T) {
 		t.Fatalf("the length of retrieved entries should be equal to 2, but equals to %d", len(retrievedEntries))
 	}
 
-	if retrievedEntries[0] != entries[0] || retrievedEntries[1] != entries[1] {
+	if *retrievedEntries[0] != entries[0] || *retrievedEntries[1] != entries[1] {
 		t.Fatalf("the retrieved content should match to the original content")
 	}
 }
@@ -149,21 +513,21 @@ func TestArtifactEntry_ReadWrite_Using_ArtifactsDb(t *testing.T) {
 		imageDigest  = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 		platform     = "linux/amd64"
 	)
-	ae := &ArtifactEntry{
+	ae := &artifacts.Entry{
 		Size:           10,
 		Digest:         dgst,
 		OriginalDigest: originalDgst,
 		Location:       "/var/soci-snapshotter/test",
-		Type:           ArtifactEntryTypeIndex,
+		Type:           artifacts.EntryTypeIndex,
 		ImageDigest:    imageDigest,
 		Platform:       platform,
 		SpanSize:       10,
 	}
-	err = db.WriteArtifactEntry(ae)
+	err = db.Write(t.Context(), ae)
 	if err != nil {
 		t.Fatalf("can't put ArtifactEntry to a bucket")
 	}
-	readArtifactEntry, err := db.GetArtifactEntry(dgst)
+	readArtifactEntry, err := db.Get(t.Context(), dgst)
 	if err != nil {
 		t.Fatalf("cannot get artifact entry with the digest=%s", dgst)
 	}
@@ -183,7 +547,7 @@ func TestArtifactEntry_ReadWrite_AtomicDbOperations(t *testing.T) {
 		imageDigest  = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 		platform     = "linux/amd64"
 	)
-	ae := ArtifactEntry{
+	ae := artifacts.Entry{
 		Size:           10,
 		Digest:         dgst,
 		OriginalDigest: originalDgst,

--- a/soci/soci_convert.go
+++ b/soci/soci_convert.go
@@ -146,7 +146,7 @@ func (b *IndexBuilder) Convert(ctx context.Context, img images.Image, opts ...Co
 	}
 
 	// Update artifacts DB references to the new image/index digests
-	err = b.updateSociV2ArtifactReferences(&ociIndex, ociIndexDesc.Digest.String())
+	err = b.updateSociV2ArtifactReferences(ctx, &ociIndex, ociIndexDesc.Digest.String())
 	if err != nil {
 		return nil, err
 	}
@@ -376,13 +376,16 @@ func (b *IndexBuilder) pushOCIObject(ctx context.Context, obj any) (ocispec.Desc
 // When we create the SOCI index manifest v2, we add it to the artifacts DB with the original image manifest digest
 // and image digest. When we add the annotations, we change the manifest digest and create a new image with a new
 // digest. This function goes back and fixes the artifacts DB so that the index is associated with the new manifest and image digests.
-func (b *IndexBuilder) updateSociV2ArtifactReferences(index *ocispec.Index, indexDigest string) error {
+func (b *IndexBuilder) updateSociV2ArtifactReferences(ctx context.Context, index *ocispec.Index, indexDigest string) error {
 	for _, manifestDesc := range index.Manifests {
 		if manifestDesc.ArtifactType == SociIndexArtifactTypeV2 {
-			err := b.config.artifactsDb.updateSociV2ArtifactReference(manifestDesc.Digest.String(), manifestDesc.Annotations[IndexAnnotationImageManifestDigest], indexDigest)
+			ae, err := b.config.artifactStore.Get(ctx, manifestDesc.Digest.String())
 			if err != nil {
 				return err
 			}
+			ae.ImageDigest = indexDigest
+			ae.OriginalDigest = manifestDesc.Annotations[IndexAnnotationImageManifestDigest]
+			return b.config.artifactStore.Write(ctx, ae)
 		}
 	}
 	return nil


### PR DESCRIPTION
**Issue #, if available:** 

**Description of changes:**
Adds an artifact metadata store interface and refactors artifacts db to implement that interface. This should allow us to add different implementations of artifacts metadata store (for example, using containerd labels as mentioned in https://github.com/awslabs/soci-snapshotter/issues/1803) without soci index builder having a hard dependency on artifacts db. 

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
