### PR TITLE
Honor registry mirrors when fetching SOCI artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS rapidgzip-builder
 
 ARG RAPIDGZIP_VERSION
 ARG TARGETARCH
+ENV SOCI_SNAPSHOTTER_SRC=/src/github.com/awslabs/soci-snapshotter
 
 RUN dnf update -y && dnf install -y \
     binutils \
@@ -90,7 +91,7 @@ RUN git clone https://github.com/mxmlnkn/rapidgzip.git && \
           -DCMAKE_C_FLAGS="-O2 -fPIC" \
           ${ISAL_FLAGS} \
           -DCMAKE_BUILD_TYPE=Release .. && \
-    make -j$(nproc) && \
+    cmake --build . --target rapidgzip --parallel "$(nproc)" && \
     cp src/tools/rapidgzip /opt/rapidgzip/usr/local/bin/ && \
     chmod +x /opt/rapidgzip/usr/local/bin/rapidgzip && \
     cd ../.. && \
@@ -104,9 +105,10 @@ ARG NERDCTL_VERSION
 ARG TARGETARCH
 ENV GOPROXY=direct
 ENV GOCOVERDIR=/test_coverage
+ENV SOCI_SNAPSHOTTER_SRC=/src/github.com/awslabs/soci-snapshotter
 
 COPY ./integ_entrypoint.sh /integ_entrypoint.sh
-COPY . $GOPATH/src/github.com/awslabs/soci-snapshotter
+COPY . ${SOCI_SNAPSHOTTER_SRC}
 RUN dnf update && dnf upgrade && dnf install -y \
     diffutils \
     findutils \
@@ -123,14 +125,14 @@ RUN dnf update && dnf upgrade && dnf install -y \
 COPY --from=igzip-builder /opt/igzip/usr /usr/local
 COPY --from=rapidgzip-builder /opt/rapidgzip/usr/local /usr/local
 
-RUN cp $GOPATH/src/github.com/awslabs/soci-snapshotter/out/soci /usr/local/bin/ \
-    && cp $GOPATH/src/github.com/awslabs/soci-snapshotter/out/soci-snapshotter-grpc /usr/local/bin/ \
+RUN cp ${SOCI_SNAPSHOTTER_SRC}/out/soci /usr/local/bin/ \
+    && cp ${SOCI_SNAPSHOTTER_SRC}/out/soci-snapshotter-grpc /usr/local/bin/ \
     && mkdir /etc/soci-snapshotter-grpc \
     && mkdir /etc/containerd/ \
-    && cp $GOPATH/src/github.com/awslabs/soci-snapshotter/integration/config/etc/soci-snapshotter-grpc/config.toml /etc/soci-snapshotter-grpc/ \
-    && cp $GOPATH/src/github.com/awslabs/soci-snapshotter/integration/config/etc/containerd/config.toml /etc/containerd/ \
-    && cp $GOPATH/src/github.com/awslabs/soci-snapshotter/soci-snapshotter.service /etc/systemd/system \
-    && cp $GOPATH/src/github.com/awslabs/soci-snapshotter/soci-snapshotter.socket /etc/systemd/system
+    && cp ${SOCI_SNAPSHOTTER_SRC}/integration/config/etc/soci-snapshotter-grpc/config.toml /etc/soci-snapshotter-grpc/ \
+    && cp ${SOCI_SNAPSHOTTER_SRC}/integration/config/etc/containerd/config.toml /etc/containerd/ \
+    && cp ${SOCI_SNAPSHOTTER_SRC}/soci-snapshotter.service /etc/systemd/system \
+    && cp ${SOCI_SNAPSHOTTER_SRC}/soci-snapshotter.socket /etc/systemd/system
 RUN curl -sSL --output /tmp/containerd.tgz https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-${TARGETARCH:-amd64}.tar.gz \
     && tar zxvf /tmp/containerd.tgz -C /usr/local/ \
     && rm -f /tmp/containerd.tgz

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,12 @@ $(COVDIR)/unit: $(COVDIR)
 integration: build
 	@echo "$@"
 	@echo "SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT)"
-	@GO111MODULE=$(GO111MODULE_VALUE) SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT) ENABLE_INTEGRATION_TEST=true gotestsum --rerun-fails --format standard-verbose --packages ./integration -- -timeout 0 $(GO_TEST_FLAGS)
+	@if command -v gotestsum >/dev/null 2>&1; then \
+		GO111MODULE=$(GO111MODULE_VALUE) SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT) ENABLE_INTEGRATION_TEST=true gotestsum --rerun-fails --format standard-verbose --packages ./integration -- -timeout 0 $(GO_TEST_FLAGS); \
+	else \
+		echo "gotestsum not found; falling back to go test ./integration"; \
+		GO111MODULE=$(GO111MODULE_VALUE) SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT) ENABLE_INTEGRATION_TEST=true go test ./integration -timeout 0 $(GO_TEST_FLAGS); \
+	fi
 
 show-integration-coverage: $(COVDIR)/unit
 	go tool covdata percent -i $(COVDIR)/integration

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ integration: build
 		GO111MODULE=$(GO111MODULE_VALUE) SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT) ENABLE_INTEGRATION_TEST=true gotestsum --rerun-fails --format standard-verbose --packages ./integration -- -timeout 0 $(GO_TEST_FLAGS); \
 	else \
 		echo "gotestsum not found; falling back to go test ./integration"; \
-		GO111MODULE=$(GO111MODULE_VALUE) SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT) ENABLE_INTEGRATION_TEST=true go test ./integration -timeout 0 $(GO_TEST_FLAGS); \
+		GO111MODULE=$(GO111MODULE_VALUE) SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT) ENABLE_INTEGRATION_TEST=true go test -v ./integration -timeout 0 $(GO_TEST_FLAGS); \
 	fi
 
 show-integration-coverage: $(COVDIR)/unit

--- a/docs/build.md
+++ b/docs/build.md
@@ -29,6 +29,7 @@ to install them on your machine:
 
 - **[go](https://go.dev/doc/install) >= 1.25** - required to build the project;
 to confirm please check with `go version`.
+- **[gotestsum](https://github.com/gotestyourself/gotestsum)** - used by `make integration` when available for richer test output; otherwise the Makefile falls back to `go test ./integration`.
 - **[containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) >= 1.4** -
 required to run the SOCI snapshotter; to confirm please check with `sudo containerd --version`.
 - **fuse** - used for mounting without root access (`sudo yum install fuse`).

--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -25,7 +25,9 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
+	"strings"
 
 	sociremote "github.com/awslabs/soci-snapshotter/fs/remote"
 	socihttp "github.com/awslabs/soci-snapshotter/internal/http"
@@ -226,6 +228,16 @@ type clientWrapper struct {
 
 func (c *clientWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return c.Client.Do(req)
+}
+
+func withLocatorHost(refspec reference.Spec, host string) (reference.Spec, error) {
+	repoPath := strings.TrimPrefix(refspec.Locator, refspec.Hostname())
+	repoPath = strings.TrimPrefix(repoPath, "/")
+	if repoPath == "" {
+		return reference.Spec{}, fmt.Errorf("invalid image locator %q", refspec.Locator)
+	}
+	refspec.Locator = path.Join(host, repoPath)
+	return refspec, nil
 }
 
 func newRemoteStore(refspec reference.Spec, client *http.Client) (*remote.Repository, error) {

--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -77,8 +77,8 @@ type orasBlobStore struct {
 	*remote.Repository
 }
 
-func newRemoteBlobStore(refspec reference.Spec, client *http.Client) (*orasBlobStore, error) {
-	repo, err := newRemoteStore(refspec, client)
+func newRemoteBlobStoreFromHost(refspec reference.Spec, host docker.RegistryHost) (*orasBlobStore, error) {
+	repo, err := newRemoteStoreFromHost(refspec, host)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create remote store: %w", err)
 	}
@@ -230,14 +230,36 @@ func (c *clientWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return c.Client.Do(req)
 }
 
-func withLocatorHost(refspec reference.Spec, host string) (reference.Spec, error) {
+func withLocatorHost(refspec reference.Spec, host docker.RegistryHost) (reference.Spec, error) {
+	if host.Host == "" || strings.Contains(host.Host, "/") {
+		return reference.Spec{}, fmt.Errorf("invalid registry host %q", host.Host)
+	}
+
 	repoPath := strings.TrimPrefix(refspec.Locator, refspec.Hostname())
 	repoPath = strings.TrimPrefix(repoPath, "/")
 	if repoPath == "" {
 		return reference.Spec{}, fmt.Errorf("invalid image locator %q", refspec.Locator)
 	}
-	refspec.Locator = path.Join(host, repoPath)
+
+	repoPrefix, err := repositoryPrefixFromHostPath(host.Path)
+	if err != nil {
+		return reference.Spec{}, err
+	}
+
+	refspec.Locator = path.Join(host.Host, repoPrefix, repoPath)
 	return refspec, nil
+}
+
+func repositoryPrefixFromHostPath(hostPath string) (string, error) {
+	clean := path.Clean(hostPath)
+	switch {
+	case clean == ".", clean == "/", clean == "/v2":
+		return "", nil
+	case strings.HasPrefix(clean, "/v2/"):
+		return strings.TrimPrefix(clean, "/v2/"), nil
+	default:
+		return "", fmt.Errorf("unsupported registry host path %q; expected /v2 or /v2/<prefix>", hostPath)
+	}
 }
 
 func newRemoteStore(refspec reference.Spec, client *http.Client) (*remote.Repository, error) {
@@ -249,6 +271,26 @@ func newRemoteStore(refspec reference.Spec, client *http.Client) (*remote.Reposi
 	repo.PlainHTTP, err = docker.MatchLocalhost(refspec.Hostname())
 	if err != nil {
 		return nil, fmt.Errorf("cannot create repository %s: %w", refspec.Locator, err)
+	}
+
+	return repo, nil
+}
+
+func newRemoteStoreFromHost(refspec reference.Spec, host docker.RegistryHost) (*remote.Repository, error) {
+	repo, err := newRemoteStore(refspec, host.Client)
+	if err != nil {
+		return nil, err
+	}
+
+	switch strings.ToLower(host.Scheme) {
+	case "http":
+		repo.PlainHTTP = true
+	case "", "https":
+		// Keep the default behavior from newRemoteStore:
+		// - localhost uses plain HTTP
+		// - all other hosts use HTTPS
+	default:
+		return nil, fmt.Errorf("unsupported registry scheme %q for host %q", host.Scheme, host.Host)
 	}
 
 	return repo, nil

--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -98,7 +98,7 @@ func (r *orasBlobStore) Resolve(ctx context.Context, reference string) (ocispec.
 	}
 
 	tr := &clientWrapper{r.Client}
-	url := sociremote.CraftBlobURL(reference, ref)
+	url := sociremote.CraftBlobURL(r.PlainHTTP, ref)
 	resp, err := sociremote.GetHeader(ctx, url, tr)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -166,7 +166,7 @@ func (r *orasBlobStore) FetchRange(ctx context.Context, reference string, lower,
 	}
 
 	tr := &clientWrapper{r.Client}
-	realURL := sociremote.CraftBlobURL(reference, ref)
+	realURL := sociremote.CraftBlobURL(r.PlainHTTP, ref)
 	resp, err := GetContentWithRange(ctx, realURL, tr, lower, upper)
 	if err != nil {
 		return nil, cleanFetchErrors(err)
@@ -205,7 +205,7 @@ func (r *orasBlobStore) doInitialFetch(ctx context.Context, reference string) (b
 	}
 
 	tr := &clientWrapper{r.Client}
-	url := sociremote.CraftBlobURL(reference, ref)
+	url := sociremote.CraftBlobURL(r.PlainHTTP, ref)
 	resp, err := sociremote.GetHeaderWithGet(ctx, url, tr)
 	if err != nil {
 		return false, fmt.Errorf("error getting header info: %v", err)
@@ -320,7 +320,6 @@ func constructRef(refspec reference.Spec, desc ocispec.Descriptor) string {
 // It first checks the local store for the artifact.
 // If not found, if constructs the ref and fetches it from remote.
 func (f *artifactFetcher) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser, bool, error) {
-
 	// Check local store first
 	rc, err := f.localStore.Fetch(ctx, desc)
 	if err == nil {

--- a/fs/artifact_fetcher_test.go
+++ b/fs/artifact_fetcher_test.go
@@ -305,6 +305,20 @@ func TestNewRemoteStore(t *testing.T) {
 	}
 }
 
+func TestWithLocatorHost(t *testing.T) {
+	refspec, err := reference.Parse("docker.io/library/nginx:latest")
+	if err != nil {
+		t.Fatalf("unexpected failure parsing reference: %v", err)
+	}
+	rewritten, err := withLocatorHost(refspec, "example-mirror.local")
+	if err != nil {
+		t.Fatalf("unexpected failure rewriting reference: %v", err)
+	}
+	if rewritten.Locator != "example-mirror.local/library/nginx" {
+		t.Fatalf("unexpected locator, expected %q, got %q", "example-mirror.local/library/nginx", rewritten.Locator)
+	}
+}
+
 func TestFetchSociArtifacts(t *testing.T) {
 	fakeZtoc := []byte("test data")
 	fakeZtocDesc := ocispec.Descriptor{

--- a/fs/artifact_fetcher_test.go
+++ b/fs/artifact_fetcher_test.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	"github.com/containerd/containerd/reference"
+	"github.com/containerd/containerd/remotes/docker"
 	"github.com/google/go-cmp/cmp"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -306,16 +308,129 @@ func TestNewRemoteStore(t *testing.T) {
 }
 
 func TestWithLocatorHost(t *testing.T) {
+	testCases := []struct {
+		name            string
+		host            docker.RegistryHost
+		expectedLocator string
+		expectedError   string
+	}{
+		{
+			name: "rewrites locator with mirror host",
+			host: docker.RegistryHost{
+				Host: "example-mirror.local",
+				Path: "/v2",
+			},
+			expectedLocator: "example-mirror.local/library/nginx",
+		},
+		{
+			name: "rewrites locator with mirror path prefix",
+			host: docker.RegistryHost{
+				Host: "example-mirror.local",
+				Path: "/v2/team-a",
+			},
+			expectedLocator: "example-mirror.local/team-a/library/nginx",
+		},
+		{
+			name: "invalid mirror path",
+			host: docker.RegistryHost{
+				Host: "example-mirror.local",
+				Path: "/custom/path",
+			},
+			expectedError: "unsupported registry host path",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			refspec, err := reference.Parse("docker.io/library/nginx:latest")
+			if err != nil {
+				t.Fatalf("unexpected failure parsing reference: %v", err)
+			}
+			rewritten, err := withLocatorHost(refspec, tc.host)
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.expectedError)
+				}
+				if got := err.Error(); !strings.Contains(got, tc.expectedError) {
+					t.Fatalf("unexpected error, expected substring %q, got %q", tc.expectedError, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected failure rewriting reference: %v", err)
+			}
+			if rewritten.Locator != tc.expectedLocator {
+				t.Fatalf("unexpected locator, expected %q, got %q", tc.expectedLocator, rewritten.Locator)
+			}
+		})
+	}
+}
+
+func TestNewRemoteStoreFromHost(t *testing.T) {
+	client := &http.Client{}
 	refspec, err := reference.Parse("docker.io/library/nginx:latest")
 	if err != nil {
 		t.Fatalf("unexpected failure parsing reference: %v", err)
 	}
-	rewritten, err := withLocatorHost(refspec, "example-mirror.local")
-	if err != nil {
-		t.Fatalf("unexpected failure rewriting reference: %v", err)
+
+	testCases := []struct {
+		name              string
+		host              docker.RegistryHost
+		shouldBePlainHTTP bool
+		expectedError     string
+	}{
+		{
+			name: "http mirror uses plain http",
+			host: docker.RegistryHost{
+				Host:   "example-mirror.local",
+				Scheme: "http",
+				Client: client,
+			},
+			shouldBePlainHTTP: true,
+		},
+		{
+			name: "https mirror does not use plain http",
+			host: docker.RegistryHost{
+				Host:   "example-mirror.local",
+				Scheme: "https",
+				Client: client,
+			},
+			shouldBePlainHTTP: false,
+		},
+		{
+			name: "invalid scheme fails",
+			host: docker.RegistryHost{
+				Host:   "example-mirror.local",
+				Scheme: "ftp",
+				Client: client,
+			},
+			expectedError: "unsupported registry scheme",
+		},
 	}
-	if rewritten.Locator != "example-mirror.local/library/nginx" {
-		t.Fatalf("unexpected locator, expected %q, got %q", "example-mirror.local/library/nginx", rewritten.Locator)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rewritten, err := withLocatorHost(refspec, docker.RegistryHost{Host: tc.host.Host, Path: "/v2"})
+			if err != nil {
+				t.Fatalf("unexpected failure rewriting reference: %v", err)
+			}
+			store, err := newRemoteStoreFromHost(rewritten, tc.host)
+			if tc.expectedError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.expectedError)
+				}
+				if got := err.Error(); !strings.Contains(got, tc.expectedError) {
+					t.Fatalf("unexpected error, expected substring %q, got %q", tc.expectedError, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error, got %v", err)
+			}
+			if store.PlainHTTP != tc.shouldBePlainHTTP {
+				t.Fatalf("unexpected plain http setting, expected %v, got %v", tc.shouldBePlainHTTP, store.PlainHTTP)
+			}
+		})
 	}
 }
 

--- a/fs/artifact_fetcher_test.go
+++ b/fs/artifact_fetcher_test.go
@@ -23,7 +23,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/awslabs/soci-snapshotter/soci"
@@ -507,6 +510,133 @@ func TestFetchSociArtifacts(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOrasBlobStoreHonorsPlainHTTPMirror(t *testing.T) {
+	blob := []byte("plain http blob")
+	registry, blobDigest, headRequests, getRequests := newPlainHTTPBlobRegistry(t, blob)
+	defer registry.Close()
+
+	store, rewritten := newPlainHTTPBlobStore(t, registry)
+	ref := constructRef(rewritten, ocispec.Descriptor{Digest: blobDigest})
+
+	t.Run("Resolve", func(t *testing.T) {
+		desc, err := store.Resolve(context.Background(), ref)
+		if err != nil {
+			t.Fatalf("unexpected resolve failure: %v", err)
+		}
+		if got, want := desc.Digest, blobDigest; got != want {
+			t.Fatalf("unexpected digest, got %s, want %s", got, want)
+		}
+		if got, want := desc.Size, int64(len(blob)); got != want {
+			t.Fatalf("unexpected size, got %d, want %d", got, want)
+		}
+		if got := atomic.LoadInt32(headRequests); got == 0 {
+			t.Fatal("expected mirror host to receive a HEAD request")
+		}
+	})
+
+	t.Run("FetchRange", func(t *testing.T) {
+		rc, err := store.FetchRange(context.Background(), ref, 1, 5)
+		if err != nil {
+			t.Fatalf("unexpected range fetch failure: %v", err)
+		}
+		defer rc.Close()
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("unexpected read failure: %v", err)
+		}
+		if got, want := string(data), string(blob[1:6]); got != want {
+			t.Fatalf("unexpected ranged bytes, got %q, want %q", got, want)
+		}
+		if got := atomic.LoadInt32(getRequests); got == 0 {
+			t.Fatal("expected mirror host to receive a GET request")
+		}
+	})
+
+	t.Run("InitialFetch", func(t *testing.T) {
+		ok, err := store.doInitialFetch(context.Background(), ref)
+		if err != nil {
+			t.Fatalf("unexpected initial fetch failure: %v", err)
+		}
+		if !ok {
+			t.Fatal("expected initial fetch to observe ranged GET support")
+		}
+	})
+}
+
+func newPlainHTTPBlobStore(t *testing.T, registry *httptest.Server) (*orasBlobStore, reference.Spec) {
+	t.Helper()
+
+	host := registryHostFromServer(registry)
+	refspec, err := reference.Parse("docker.io/library/nginx:latest")
+	if err != nil {
+		t.Fatalf("unexpected failure parsing reference: %v", err)
+	}
+	rewritten, err := withLocatorHost(refspec, host)
+	if err != nil {
+		t.Fatalf("unexpected failure rewriting reference: %v", err)
+	}
+	store, err := newRemoteBlobStoreFromHost(rewritten, host)
+	if err != nil {
+		t.Fatalf("unexpected failure creating remote blob store: %v", err)
+	}
+	return store, rewritten
+}
+
+func newPlainHTTPBlobRegistry(t *testing.T, blob []byte) (*httptest.Server, digest.Digest, *int32, *int32) {
+	t.Helper()
+
+	blobDigest := digest.FromBytes(blob)
+	blobPath := "/v2/library/nginx/blobs/" + blobDigest.String()
+	var headRequests int32
+	var getRequests int32
+
+	registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != blobPath {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Accept-Ranges", "bytes")
+		switch r.Method {
+		case http.MethodHead:
+			atomic.AddInt32(&headRequests, 1)
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Length", strconv.Itoa(len(blob)))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			atomic.AddInt32(&getRequests, 1)
+			w.Header().Set("Content-Type", "application/octet-stream")
+			if r.Header.Get("Range") == "" {
+				w.Header().Set("Content-Length", strconv.Itoa(len(blob)))
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(blob)
+				return
+			}
+			chunk := rangedBlobChunk(t, blob, r.Header.Get("Range"))
+			w.Header().Set("Content-Length", strconv.Itoa(len(chunk)))
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %s/%d", strings.TrimPrefix(r.Header.Get("Range"), "bytes="), len(blob)))
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = w.Write(chunk)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+
+	return registry, blobDigest, &headRequests, &getRequests
+}
+
+func rangedBlobChunk(t *testing.T, blob []byte, rangeHeader string) []byte {
+	t.Helper()
+
+	var lower, upper int
+	if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &lower, &upper); err != nil {
+		t.Fatalf("unexpected range header %q: %v", rangeHeader, err)
+	}
+	if lower < 0 || upper >= len(blob) || lower > upper {
+		t.Fatalf("unexpected byte range [%d,%d] for blob size %d", lower, upper, len(blob))
+	}
+	return blob[lower : upper+1]
 }
 
 func newFakeArtifactFetcher(ref string, contents []byte) (*artifactFetcher, error) {

--- a/fs/fetch_soci_index_test.go
+++ b/fs/fetch_soci_index_test.go
@@ -1,0 +1,166 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/snapshot"
+	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/awslabs/soci-snapshotter/soci/store"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+type inMemoryTestStore struct {
+	*memory.Store
+}
+
+func newInMemoryTestStore() *inMemoryTestStore {
+	return &inMemoryTestStore{
+		Store: memory.New(),
+	}
+}
+
+func (s *inMemoryTestStore) Label(context.Context, ocispec.Descriptor, string, string) error {
+	return nil
+}
+
+func (s *inMemoryTestStore) Delete(context.Context, digest.Digest) error {
+	return nil
+}
+
+func (s *inMemoryTestStore) BatchOpen(ctx context.Context) (context.Context, store.CleanupFunc, error) {
+	return ctx, store.NopCleanup, nil
+}
+
+func registryHostFromServer(ts *httptest.Server) docker.RegistryHost {
+	u, _ := url.Parse(ts.URL)
+	return docker.RegistryHost{
+		Host:   u.Host,
+		Scheme: u.Scheme,
+		Path:   "/v2",
+		Client: ts.Client(),
+	}
+}
+
+func TestFetchSociIndexFallsBackToNextHost(t *testing.T) {
+	indexBytes, err := soci.MarshalIndex(soci.NewIndex(soci.V2, nil, nil, nil))
+	if err != nil {
+		t.Fatalf("failed to marshal index: %v", err)
+	}
+	indexDigest := digest.FromBytes(indexBytes)
+	manifestDigest := digest.FromString("manifest")
+	indexBlobPath := "/v2/library/nginx/blobs/" + indexDigest.String()
+	indexManifestPath := "/v2/library/nginx/manifests/" + indexDigest.String()
+
+	var firstHostRequests int32
+	firstHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&firstHostRequests, 1)
+		http.Error(w, "temporary upstream failure", http.StatusBadGateway)
+	}))
+	defer firstHost.Close()
+
+	var secondHostRequests int32
+	secondHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&secondHostRequests, 1)
+		if r.URL.Path != indexBlobPath && r.URL.Path != indexManifestPath {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", strconv.Itoa(len(indexBytes)))
+		switch r.Method {
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(indexBytes)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer secondHost.Close()
+
+	fs := &filesystem{
+		contentStore: newInMemoryTestStore(),
+	}
+	index, err := fs.fetchSociIndex(
+		context.Background(),
+		"docker.io/library/nginx:latest",
+		indexDigest.String(),
+		manifestDigest.String(),
+		[]docker.RegistryHost{
+			registryHostFromServer(firstHost),
+			registryHostFromServer(secondHost),
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if index == nil {
+		t.Fatal("expected non-nil index")
+	}
+	if got := atomic.LoadInt32(&firstHostRequests); got == 0 {
+		t.Fatal("expected first registry host to be attempted")
+	}
+	if got := atomic.LoadInt32(&secondHostRequests); got == 0 {
+		t.Fatal("expected second registry host to be attempted")
+	}
+}
+
+func TestFetchSociIndexReturnsNoIndexWhenAllHostsFail(t *testing.T) {
+	indexBytes, err := soci.MarshalIndex(soci.NewIndex(soci.V2, nil, nil, nil))
+	if err != nil {
+		t.Fatalf("failed to marshal index: %v", err)
+	}
+	indexDigest := digest.FromBytes(indexBytes)
+	manifestDigest := digest.FromString("manifest")
+
+	failingHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "temporary upstream failure", http.StatusBadGateway)
+	}))
+	defer failingHost.Close()
+
+	fs := &filesystem{
+		contentStore: newInMemoryTestStore(),
+	}
+	_, err = fs.fetchSociIndex(
+		context.Background(),
+		"docker.io/library/nginx:latest",
+		indexDigest.String(),
+		manifestDigest.String(),
+		[]docker.RegistryHost{
+			registryHostFromServer(failingHost),
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if !errors.Is(err, snapshot.ErrNoIndex) {
+		t.Fatalf("expected error to match snapshot.ErrNoIndex, got: %v", err)
+	}
+}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -447,42 +447,37 @@ func (fs *filesystem) MountParallel(ctx context.Context, mountpoint string, labe
 	}
 	// download the target layer
 	s := src[0]
-	if len(s.Hosts) == 0 {
-		return fmt.Errorf("no registry hosts available for %q", imageRef)
-	}
-	host := s.Hosts[0]
-	if host.Client == nil {
-		return fmt.Errorf("registry host %q has no http client", host.Host)
-	}
-	refspec, err := reference.Parse(imageRef)
-	if err != nil {
-		return fmt.Errorf("cannot parse image ref (%s): %w", imageRef, err)
-	}
-	refspec, err = withLocatorHost(refspec, host)
-	if err != nil {
-		return err
-	}
 	desc := s.Target
 	imageDigest, ok := labels[ctdsnapshotters.TargetManifestDigestLabel]
 	if !ok {
 		return errors.New("layer has no image manifest attached")
 	}
 	// If lazy-loading is disabled and the image has no jobs associated with it, start premounting all jobs
-	if !fs.inProgressImageUnpacks.ImageExists(imageDigest) {
-		err := fs.preloadAllLayers(ctx, desc, imageDigest, refspec, host)
-		if err != nil {
-			return fmt.Errorf("failed to preload layers for image manifest digest %s: %w", imageDigest, err)
+	hostRefs, hostErr := buildRegistryHostRefs(imageRef, s.Hosts)
+	for _, hostRef := range hostRefs {
+		if !fs.inProgressImageUnpacks.ImageExists(imageDigest) {
+			err := fs.preloadAllLayers(ctx, desc, imageDigest, hostRef.refspec, hostRef.host, fs.contentStore)
+			if err != nil {
+				hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q: %w", hostRef.host.Host, err))
+				continue
+			}
 		}
-	}
 
-	err = fs.rebase(ctx, desc.Digest, imageDigest, mountpoint)
-	if err != nil {
-		return fmt.Errorf("failed to rebase layer %s: %w", desc.Digest, err)
+		err := fs.rebase(ctx, desc.Digest, imageDigest, mountpoint)
+		if err != nil {
+			hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q: failed to rebase layer %s: %w", hostRef.host.Host, desc.Digest, err))
+			continue
+		}
+
+		return nil
 	}
-	return nil
+	if hostErr != nil {
+		return fmt.Errorf("failed to preload layers for image manifest digest %s: %w", imageDigest, hostErr)
+	}
+	return fmt.Errorf("failed to preload layers for image manifest digest %s", imageDigest)
 }
 
-func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descriptor, imageDigest string, refspec reference.Spec, cachedHost docker.RegistryHost) error {
+func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descriptor, imageDigest string, refspec reference.Spec, cachedHost docker.RegistryHost, localStore store.BasicStore) error {
 	manifest, err := fs.getImageManifest(ctx, imageDigest)
 	if err != nil {
 		return fmt.Errorf("cannot get image manifest: %w", err)
@@ -548,7 +543,7 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 					if err != nil {
 						return fmt.Errorf("error adding layer job: %w", err)
 					}
-					go fs.premount(premountCtx, l, refspec, remoteStore, diffIDMap, layerJob)
+					go fs.premount(premountCtx, l, refspec, localStore, remoteStore, diffIDMap, layerJob)
 				}
 			}
 		}
@@ -561,7 +556,7 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 	return err
 }
 
-func (fs *filesystem) premount(ctx context.Context, desc ocispec.Descriptor, refspec reference.Spec, remoteStore resolverStorage, diffIDMap map[string]digest.Digest, layerJob *layerUnpackJob) error {
+func (fs *filesystem) premount(ctx context.Context, desc ocispec.Descriptor, refspec reference.Spec, localStore store.BasicStore, remoteStore resolverStorage, diffIDMap map[string]digest.Digest, layerJob *layerUnpackJob) error {
 	var err error
 	defer func() {
 		// If there is a context error (usually context cancelled),
@@ -595,7 +590,7 @@ func (fs *filesystem) premount(ctx context.Context, desc ocispec.Descriptor, ref
 
 	archive := NewLayerArchive(compressedVerifier, newAsyncVerifier(uncompressedDigest.Verifier()), decompressStream, layerJob.bufferPool)
 	chunkSize := fs.pullModes.Parallel.ConcurrentDownloadChunkSize
-	fetcher, err := newParallelArtifactFetcher(refspec, fs.contentStore, remoteStore, layerJob, chunkSize, compressedVerifier)
+	fetcher, err := newParallelArtifactFetcher(refspec, localStore, remoteStore, layerJob, chunkSize, compressedVerifier)
 	if err != nil {
 		log.G(ctx).WithError(err).Error("cannot create fetcher")
 		return err
@@ -764,46 +759,7 @@ func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels 
 	}
 	// download the target layer
 	s := src[0]
-	if len(s.Hosts) == 0 {
-		return fmt.Errorf("no registry hosts available for %q", imageRef)
-	}
-	host := s.Hosts[0]
-	if host.Client == nil {
-		return fmt.Errorf("registry host %q has no http client", host.Host)
-	}
-	refspec, err := reference.Parse(imageRef)
-	if err != nil {
-		return fmt.Errorf("cannot parse image ref (%s): %w", imageRef, err)
-	}
-	refspec, err = withLocatorHost(refspec, host)
-	if err != nil {
-		return err
-	}
-	remoteStore, err := newRemoteBlobStoreFromHost(refspec, host)
-	if err != nil {
-		return fmt.Errorf("cannot create remote store: %w", err)
-	}
-	fetcher, err := newArtifactFetcher(refspec, fs.contentStore, remoteStore)
-	if err != nil {
-		return fmt.Errorf("cannot create fetcher: %w", err)
-	}
-
 	desc := s.Target
-
-	// If the descriptor size is zero, the artifact fetcher will resolve it.
-	// However, it never returns this resolved descriptor.
-	// Since the unpacker is also in charge of storing the content and the
-	// ORAS store requires an expected size, we need to resolve here.
-	if desc.Size == 0 {
-		// In remoteStore.Reference, Registry and Target should be correct.
-		// However, we need Reference to point to the current layer.
-		blobRef := remoteStore.Reference
-		blobRef.Reference = s.Target.Digest.String()
-		desc, err = remoteStore.Resolve(ctx, blobRef.String())
-		if err != nil {
-			return fmt.Errorf("cannot resolve size of layer (%s): %w", blobRef.String(), err)
-		}
-	}
 
 	imageDigest, ok := labels[ctdsnapshotters.TargetManifestDigestLabel]
 	if !ok {
@@ -822,15 +778,150 @@ func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels 
 		return fmt.Errorf("digest %s not found in image manifest", desc.Digest.String())
 	}
 
-	archive := NewLayerArchive(nil, newAsyncVerifier(uncompressedDigest.Verifier()), nil, nil)
-	unpacker := NewLayerUnpacker(fetcher, archive)
+	hostRefs, hostErr := buildRegistryHostRefs(imageRef, s.Hosts)
+	if len(hostRefs) == 0 {
+		return hostErr
+	}
+	if err := fs.unpackLocalLayerFromRegistryHosts(ctx, mountpoint, mounts, desc, uncompressedDigest, hostRefs); err != nil {
+		if hostErr != nil {
+			return errors.Join(hostErr, err)
+		}
+		return err
+	}
+	return nil
+}
 
-	err = unpacker.Unpack(ctx, desc, mountpoint, mounts)
-	if err != nil {
-		return fmt.Errorf("cannot unpack the layer: %w", err)
+type registryHostRef struct {
+	refspec reference.Spec
+	host    docker.RegistryHost
+}
+
+func buildRegistryHostRefs(imageRef string, hosts []docker.RegistryHost) ([]registryHostRef, error) {
+	if len(hosts) == 0 {
+		return nil, fmt.Errorf("no registry hosts available for %q", imageRef)
 	}
 
+	baseRefspec, err := reference.Parse(imageRef)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse image ref (%s): %w", imageRef, err)
+	}
+
+	var (
+		hostRefs []registryHostRef
+		hostErr  error
+	)
+	for _, host := range hosts {
+		if host.Client == nil {
+			hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q has no http client", host.Host))
+			continue
+		}
+
+		refspec, err := withLocatorHost(baseRefspec, host)
+		if err != nil {
+			hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q: %w", host.Host, err))
+			continue
+		}
+
+		hostRefs = append(hostRefs, registryHostRef{
+			refspec: refspec,
+			host:    host,
+		})
+	}
+
+	if len(hostRefs) == 0 {
+		return nil, hostErr
+	}
+	return hostRefs, hostErr
+}
+
+func (fs *filesystem) unpackLocalLayerFromRegistryHosts(ctx context.Context, mountpoint string, mounts []mount.Mount, desc ocispec.Descriptor, uncompressedDigest digest.Digest, hostRefs []registryHostRef) error {
+	var hostErr error
+	for _, hostRef := range hostRefs {
+		if err := resetMountpoint(mountpoint); err != nil {
+			hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q: %w", hostRef.host.Host, err))
+			continue
+		}
+
+		remoteStore, err := newRemoteBlobStoreFromHost(hostRef.refspec, hostRef.host)
+		if err != nil {
+			hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q: cannot create remote store: %w", hostRef.host.Host, err))
+			continue
+		}
+		fetcher, err := newArtifactFetcher(hostRef.refspec, fs.contentStore, remoteStore)
+		if err != nil {
+			hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q: cannot create fetcher: %w", hostRef.host.Host, err))
+			continue
+		}
+
+		attemptDesc := desc
+		// If the descriptor size is zero, the artifact fetcher will resolve it.
+		// However, it never returns this resolved descriptor.
+		// Since the unpacker is also in charge of storing the content and the
+		// ORAS store requires an expected size, we need to resolve here.
+		if attemptDesc.Size == 0 {
+			// In remoteStore.Reference, Registry and Target should be correct.
+			// However, we need Reference to point to the current layer.
+			blobRef := remoteStore.Reference
+			blobRef.Reference = desc.Digest.String()
+			attemptDesc, err = remoteStore.Resolve(ctx, blobRef.String())
+			if err != nil {
+				hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q: cannot resolve size of layer (%s): %w", hostRef.host.Host, blobRef.String(), err))
+				continue
+			}
+		}
+
+		archive := NewLayerArchive(nil, newAsyncVerifier(uncompressedDigest.Verifier()), nil, nil)
+		unpacker := NewLayerUnpacker(fetcher, archive)
+		if err := unpacker.Unpack(ctx, attemptDesc, mountpoint, mounts); err != nil {
+			hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q: cannot unpack the layer: %w", hostRef.host.Host, err))
+			continue
+		}
+		return nil
+	}
+
+	if err := resetMountpoint(mountpoint); err != nil {
+		return errors.Join(hostErr, fmt.Errorf("failed to clean mountpoint %s after local mount failure: %w", mountpoint, err))
+	}
+	if hostErr != nil {
+		return hostErr
+	}
+	return fmt.Errorf("cannot unpack layer %s: no registry hosts were attempted", desc.Digest)
+}
+
+func resetMountpoint(mountpoint string) error {
+	info, err := os.Stat(mountpoint)
+	if err != nil {
+		return fmt.Errorf("cannot stat mountpoint %s: %w", mountpoint, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("mountpoint %s is not a directory", mountpoint)
+	}
+
+	entries, err := os.ReadDir(mountpoint)
+	if err != nil {
+		return fmt.Errorf("cannot read mountpoint %s: %w", mountpoint, err)
+	}
+	for _, entry := range entries {
+		if err := removeAllWithWritableDirs(filepath.Join(mountpoint, entry.Name())); err != nil {
+			return fmt.Errorf("cannot clean mountpoint %s: %w", mountpoint, err)
+		}
+	}
 	return nil
+}
+
+func removeAllWithWritableDirs(path string) error {
+	if err := filepath.WalkDir(path, func(curr string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		return os.Chmod(curr, 0700)
+	}); err != nil {
+		return err
+	}
+	return os.RemoveAll(path)
 }
 
 func (fs *filesystem) getSociContext(ctx context.Context, imageRef, indexDigest, imageManifestDigest string, hosts []docker.RegistryHost) (*sociContext, error) {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -450,12 +450,15 @@ func (fs *filesystem) MountParallel(ctx context.Context, mountpoint string, labe
 	if len(s.Hosts) == 0 {
 		return fmt.Errorf("no registry hosts available for %q", imageRef)
 	}
-	client := s.Hosts[0].Client
+	host := s.Hosts[0]
+	if host.Client == nil {
+		return fmt.Errorf("registry host %q has no http client", host.Host)
+	}
 	refspec, err := reference.Parse(imageRef)
 	if err != nil {
 		return fmt.Errorf("cannot parse image ref (%s): %w", imageRef, err)
 	}
-	refspec, err = withLocatorHost(refspec, s.Hosts[0].Host)
+	refspec, err = withLocatorHost(refspec, host)
 	if err != nil {
 		return err
 	}
@@ -466,7 +469,7 @@ func (fs *filesystem) MountParallel(ctx context.Context, mountpoint string, labe
 	}
 	// If lazy-loading is disabled and the image has no jobs associated with it, start premounting all jobs
 	if !fs.inProgressImageUnpacks.ImageExists(imageDigest) {
-		err := fs.preloadAllLayers(ctx, desc, imageDigest, refspec, client)
+		err := fs.preloadAllLayers(ctx, desc, imageDigest, refspec, host)
 		if err != nil {
 			return fmt.Errorf("failed to preload layers for image manifest digest %s: %w", imageDigest, err)
 		}
@@ -479,7 +482,7 @@ func (fs *filesystem) MountParallel(ctx context.Context, mountpoint string, labe
 	return nil
 }
 
-func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descriptor, imageDigest string, refspec reference.Spec, cachedClient *http.Client) error {
+func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descriptor, imageDigest string, refspec reference.Spec, cachedHost docker.RegistryHost) error {
 	manifest, err := fs.getImageManifest(ctx, imageDigest)
 	if err != nil {
 		return fmt.Errorf("cannot get image manifest: %w", err)
@@ -495,8 +498,8 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 	}
 	// Clone client if it's our internal [socihttp.AuthClient]
 	// so that this image pull request has an isolated client reference.
-	client := cachedClient
-	if authClient, ok := cachedClient.Transport.(*socihttp.AuthClient); ok {
+	client := cachedHost.Client
+	if authClient, ok := cachedHost.Client.Transport.(*socihttp.AuthClient); ok {
 		retryClient := resolver.CloneRetryableClient(authClient.Client())
 		// The clone will have a cleaned cache
 		newAuthClient := authClient.CloneWithNewClient(retryClient)
@@ -510,7 +513,9 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 			Transport: newAuthClient,
 		}
 	}
-	remoteStore, err := newRemoteBlobStore(refspec, client)
+	host := cachedHost
+	host.Client = client
+	remoteStore, err := newRemoteBlobStoreFromHost(refspec, host)
 	if err != nil {
 		return fmt.Errorf("cannot create remote store: %w", err)
 	}
@@ -762,16 +767,19 @@ func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels 
 	if len(s.Hosts) == 0 {
 		return fmt.Errorf("no registry hosts available for %q", imageRef)
 	}
-	client := s.Hosts[0].Client
+	host := s.Hosts[0]
+	if host.Client == nil {
+		return fmt.Errorf("registry host %q has no http client", host.Host)
+	}
 	refspec, err := reference.Parse(imageRef)
 	if err != nil {
 		return fmt.Errorf("cannot parse image ref (%s): %w", imageRef, err)
 	}
-	refspec, err = withLocatorHost(refspec, s.Hosts[0].Host)
+	refspec, err = withLocatorHost(refspec, host)
 	if err != nil {
 		return err
 	}
-	remoteStore, err := newRemoteBlobStore(refspec, client)
+	remoteStore, err := newRemoteBlobStoreFromHost(refspec, host)
 	if err != nil {
 		return fmt.Errorf("cannot create remote store: %w", err)
 	}
@@ -836,7 +844,7 @@ func (fs *filesystem) getSociContext(ctx context.Context, imageRef, indexDigest,
 }
 
 func (fs *filesystem) fetchSociIndex(ctx context.Context, imageRef, indexDigest, imageManifestDigest string, hosts []docker.RegistryHost) (*soci.Index, error) {
-	refspec, err := reference.Parse(imageRef)
+	baseRefspec, err := reference.Parse(imageRef)
 	if err != nil {
 		return nil, err
 	}
@@ -844,28 +852,53 @@ func (fs *filesystem) fetchSociIndex(ctx context.Context, imageRef, indexDigest,
 	if len(hosts) == 0 {
 		return nil, fmt.Errorf("no registry hosts available for %q", imageRef)
 	}
-	refspec, err = withLocatorHost(refspec, hosts[0].Host)
-	if err != nil {
-		return nil, err
+
+	var (
+		hostErr    error
+		noIndexErr error
+	)
+	for _, host := range hosts {
+		refspec, err := withLocatorHost(baseRefspec, host)
+		if err != nil {
+			hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q: %w", host.Host, err))
+			continue
+		}
+		if host.Client == nil {
+			hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q has no http client", host.Host))
+			continue
+		}
+
+		remoteStore, err := newRemoteStoreFromHost(refspec, host)
+		if err != nil {
+			hostErr = errors.Join(hostErr, fmt.Errorf("registry host %q: %w", host.Host, err))
+			continue
+		}
+
+		indexDesc, err := fs.findSociIndexDesc(ctx, imageManifestDigest, indexDigest, remoteStore)
+		if err != nil {
+			noIndexErr = errors.Join(noIndexErr, fmt.Errorf("registry host %q: %w", host.Host, err))
+			continue
+		}
+
+		log.G(ctx).WithFields(logrus.Fields{
+			"digest": indexDesc.Digest.String(),
+			"host":   host.Host,
+		}).Infof("fetching SOCI artifacts using index descriptor")
+
+		index, err := FetchSociArtifacts(ctx, refspec, indexDesc, fs.contentStore, remoteStore)
+		if err == nil {
+			return index, nil
+		}
+		noIndexErr = errors.Join(noIndexErr, fmt.Errorf("registry host %q: %w", host.Host, err))
 	}
 
-	remoteStore, err := newRemoteStore(refspec, hosts[0].Client)
-	if err != nil {
-		return nil, err
+	if noIndexErr != nil {
+		return nil, fmt.Errorf("%w: unable to fetch SOCI artifacts from all configured registry hosts: %w", snapshot.ErrNoIndex, errors.Join(noIndexErr, hostErr))
 	}
-
-	indexDesc, err := fs.findSociIndexDesc(ctx, imageManifestDigest, indexDigest, remoteStore)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", snapshot.ErrNoIndex, err)
+	if hostErr != nil {
+		return nil, hostErr
 	}
-
-	log.G(ctx).WithField("digest", indexDesc.Digest.String()).Infof("fetching SOCI artifacts using index descriptor")
-
-	index, err := FetchSociArtifacts(ctx, refspec, indexDesc, fs.contentStore, remoteStore)
-	if err != nil {
-		return nil, fmt.Errorf("%w: error trying to fetch SOCI artifacts: %w", snapshot.ErrNoIndex, err)
-	}
-	return index, nil
+	return nil, fmt.Errorf("unable to fetch SOCI artifacts for image %q", imageRef)
 }
 
 func (fs *filesystem) findSociIndexDesc(ctx context.Context, imageManifestDigest string, sociIndexDigest string, remoteStore *orasremote.Repository) (ocispec.Descriptor, error) {

--- a/fs/local_registry_fallback_test.go
+++ b/fs/local_registry_fallback_test.go
@@ -1,0 +1,202 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/containerd/containerd/remotes/docker"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type countingTestStore struct {
+	*inMemoryTestStore
+	deleteCalls int32
+}
+
+func newCountingTestStore() *countingTestStore {
+	return &countingTestStore{
+		inMemoryTestStore: newInMemoryTestStore(),
+	}
+}
+
+func (s *countingTestStore) Delete(context.Context, digest.Digest) error {
+	atomic.AddInt32(&s.deleteCalls, 1)
+	return nil
+}
+
+func TestUnpackLocalLayerFromRegistryHostsFallsBackWithoutRefetchingRemote(t *testing.T) {
+	layerBytes := makeTestTarLayer(t, "hello.txt", "mirror fallback")
+	layerDigest := digest.FromBytes(layerBytes)
+	blobPath := "/v2/library/nginx/blobs/" + layerDigest.String()
+
+	var firstHostRequests int32
+	firstHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&firstHostRequests, 1)
+		http.Error(w, "temporary upstream failure", http.StatusBadGateway)
+	}))
+	defer firstHost.Close()
+
+	var secondHostGetRequests int32
+	secondHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != blobPath {
+			http.NotFound(w, r)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			atomic.AddInt32(&secondHostGetRequests, 1)
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Length", strconv.Itoa(len(layerBytes)))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(layerBytes)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer secondHost.Close()
+
+	hostRefs, err := buildRegistryHostRefs("docker.io/library/nginx:latest", []docker.RegistryHost{
+		registryHostFromServer(firstHost),
+		registryHostFromServer(secondHost),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error building registry hosts: %v", err)
+	}
+
+	mountpoint := filepath.Join(t.TempDir(), "fs")
+	if err := os.MkdirAll(mountpoint, 0755); err != nil {
+		t.Fatalf("failed to create mountpoint: %v", err)
+	}
+
+	fs := &filesystem{
+		contentStore: newInMemoryTestStore(),
+	}
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    layerDigest,
+		Size:      int64(len(layerBytes)),
+	}
+	if err := fs.unpackLocalLayerFromRegistryHosts(context.Background(), mountpoint, nil, desc, layerDigest, hostRefs); err != nil {
+		t.Fatalf("unexpected error unpacking layer: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(mountpoint, "hello.txt"))
+	if err != nil {
+		t.Fatalf("failed to read unpacked file: %v", err)
+	}
+	if got, want := string(content), "mirror fallback"; got != want {
+		t.Fatalf("unexpected unpacked content, got %q, want %q", got, want)
+	}
+	if got := atomic.LoadInt32(&firstHostRequests); got == 0 {
+		t.Fatal("expected first registry host to be attempted")
+	}
+	if got, want := atomic.LoadInt32(&secondHostGetRequests), int32(1); got != want {
+		t.Fatalf("unexpected number of GET requests to fallback host, got %d, want %d", got, want)
+	}
+}
+
+func TestUnpackLocalLayerFromRegistryHostsDoesNotDeleteCachedBlobOnApplyFailure(t *testing.T) {
+	layerBytes := []byte("not a tar archive")
+	layerDigest := digest.FromBytes(layerBytes)
+	blobPath := "/v2/library/nginx/blobs/" + layerDigest.String()
+
+	registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != blobPath {
+			http.NotFound(w, r)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Length", strconv.Itoa(len(layerBytes)))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(layerBytes)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer registry.Close()
+
+	hostRefs, err := buildRegistryHostRefs("docker.io/library/nginx:latest", []docker.RegistryHost{
+		registryHostFromServer(registry),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error building registry hosts: %v", err)
+	}
+
+	mountpoint := filepath.Join(t.TempDir(), "fs")
+	if err := os.MkdirAll(mountpoint, 0755); err != nil {
+		t.Fatalf("failed to create mountpoint: %v", err)
+	}
+
+	contentStore := newCountingTestStore()
+	fs := &filesystem{
+		contentStore: contentStore,
+	}
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    layerDigest,
+		Size:      int64(len(layerBytes)),
+	}
+	err = fs.unpackLocalLayerFromRegistryHosts(context.Background(), mountpoint, nil, desc, layerDigest, hostRefs)
+	if err == nil {
+		t.Fatal("expected unpack failure for invalid tar content")
+	}
+	if got := atomic.LoadInt32(&contentStore.deleteCalls); got != 0 {
+		t.Fatalf("unexpected content store deletes, got %d, want 0", got)
+	}
+	exists, err := contentStore.Exists(context.Background(), desc)
+	if err != nil {
+		t.Fatalf("failed checking cached blob existence: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected cached blob to remain available after apply failure")
+	}
+}
+
+func makeTestTarLayer(t *testing.T, name, contents string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	payload := []byte(contents)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0644,
+		Size: int64(len(payload)),
+	}); err != nil {
+		t.Fatalf("failed to write tar header: %v", err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatalf("failed to write tar payload: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/fs/registry_hosts_test.go
+++ b/fs/registry_hosts_test.go
@@ -1,0 +1,225 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/remotes/docker"
+)
+
+func TestBuildRegistryHostRefsRewritesLocatorsInOrder(t *testing.T) {
+	hosts := []docker.RegistryHost{
+		{
+			Host:   "first.example",
+			Path:   "/v2",
+			Client: &http.Client{},
+		},
+		{
+			Host:   "second.example",
+			Path:   "/v2/team-a",
+			Client: &http.Client{},
+		},
+	}
+
+	hostRefs, err := buildRegistryHostRefs("docker.io/library/nginx:latest", hosts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotLocators := []string{
+		hostRefs[0].refspec.Locator,
+		hostRefs[1].refspec.Locator,
+	}
+	wantLocators := []string{
+		"first.example/library/nginx",
+		"second.example/team-a/library/nginx",
+	}
+	if !slices.Equal(gotLocators, wantLocators) {
+		t.Fatalf("unexpected locators, got %v, want %v", gotLocators, wantLocators)
+	}
+}
+
+func TestBuildRegistryHostRefsReturnsUsableHostsAndSkippedHostErrors(t *testing.T) {
+	hosts := []docker.RegistryHost{
+		{
+			Host: "missing-client.example",
+			Path: "/v2",
+		},
+		{
+			Host:   "bad-path.example",
+			Path:   "/custom/path",
+			Client: &http.Client{},
+		},
+		{
+			Host:   "failing.example",
+			Path:   "/v2",
+			Client: &http.Client{},
+		},
+	}
+
+	hostRefs, err := buildRegistryHostRefs("docker.io/library/nginx:latest", hosts)
+	if err == nil {
+		t.Fatal("expected skipped-host error but got nil")
+	}
+	if len(hostRefs) != 1 {
+		t.Fatalf("expected one usable host, got %d", len(hostRefs))
+	}
+	if got, want := hostRefs[0].host.Host, "failing.example"; got != want {
+		t.Fatalf("unexpected host, got %q, want %q", got, want)
+	}
+
+	for _, want := range []string{
+		`registry host "missing-client.example" has no http client`,
+		`registry host "bad-path.example": unsupported registry host path`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
+	}
+}
+
+func TestBuildRegistryHostRefsReturnsErrorWhenNoHostsAreUsable(t *testing.T) {
+	hosts := []docker.RegistryHost{
+		{
+			Host: "missing-client.example",
+			Path: "/v2",
+		},
+		{
+			Host:   "bad-path.example",
+			Path:   "/custom/path",
+			Client: &http.Client{},
+		},
+	}
+
+	hostRefs, err := buildRegistryHostRefs("docker.io/library/nginx:latest", hosts)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if len(hostRefs) != 0 {
+		t.Fatalf("expected no usable hosts, got %d", len(hostRefs))
+	}
+	for _, want := range []string{
+		`registry host "missing-client.example" has no http client`,
+		`registry host "bad-path.example": unsupported registry host path`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %v", want, err)
+		}
+	}
+}
+
+func TestResetMountpointRecreatesEmptyDirectory(t *testing.T) {
+	mountpoint := filepath.Join(t.TempDir(), "snapshots", "target")
+	if err := os.MkdirAll(mountpoint, 0700); err != nil {
+		t.Fatalf("failed to create mountpoint: %v", err)
+	}
+	if err := os.Chmod(mountpoint, 0751); err != nil {
+		t.Fatalf("failed to chmod mountpoint: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(mountpoint, "stale-dir"), 0700); err != nil {
+		t.Fatalf("failed to create stale directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mountpoint, "stale-dir", "nested"), []byte("data"), 0600); err != nil {
+		t.Fatalf("failed to seed nested mountpoint content: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mountpoint, "stale"), []byte("data"), 0600); err != nil {
+		t.Fatalf("failed to seed mountpoint: %v", err)
+	}
+
+	if err := resetMountpoint(mountpoint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	info, err := os.Stat(mountpoint)
+	if err != nil {
+		t.Fatalf("expected mountpoint to exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected mountpoint to be a directory")
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0751); got != want {
+		t.Fatalf("expected mountpoint mode %v, got %v", want, got)
+	}
+	entries, err := os.ReadDir(mountpoint)
+	if err != nil {
+		t.Fatalf("failed to read mountpoint: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty mountpoint, found %d entries", len(entries))
+	}
+}
+
+func TestResetMountpointPreservesDirectory(t *testing.T) {
+	mountpoint := filepath.Join(t.TempDir(), "snapshots", "target")
+	if err := os.MkdirAll(mountpoint, 0755); err != nil {
+		t.Fatalf("failed to create mountpoint: %v", err)
+	}
+
+	before, err := os.Stat(mountpoint)
+	if err != nil {
+		t.Fatalf("failed to stat mountpoint: %v", err)
+	}
+
+	if err := resetMountpoint(mountpoint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	after, err := os.Stat(mountpoint)
+	if err != nil {
+		t.Fatalf("expected mountpoint to exist: %v", err)
+	}
+
+	if !os.SameFile(before, after) {
+		t.Fatal("expected mountpoint directory itself to be preserved")
+	}
+}
+
+func TestResetMountpointRemovesReadOnlyDirectories(t *testing.T) {
+	mountpoint := filepath.Join(t.TempDir(), "snapshots", "target")
+	if err := os.MkdirAll(mountpoint, 0755); err != nil {
+		t.Fatalf("failed to create mountpoint: %v", err)
+	}
+
+	readonlyDir := filepath.Join(mountpoint, "readonly")
+	if err := os.Mkdir(readonlyDir, 0755); err != nil {
+		t.Fatalf("failed to create readonly dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(readonlyDir, "nested"), []byte("data"), 0600); err != nil {
+		t.Fatalf("failed to seed readonly dir: %v", err)
+	}
+	if err := os.Chmod(readonlyDir, 0555); err != nil {
+		t.Fatalf("failed to chmod readonly dir: %v", err)
+	}
+
+	if err := resetMountpoint(mountpoint); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	entries, err := os.ReadDir(mountpoint)
+	if err != nil {
+		t.Fatalf("failed to read mountpoint: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty mountpoint, found %d entries", len(entries))
+	}
+}

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -454,8 +454,12 @@ func redirect(ctx context.Context, blobURL string, tr http.RoundTripper) (string
 	return "", fmt.Errorf("%w on redirect %v", ErrUnexpectedStatusCode, res.StatusCode)
 }
 
-func CraftBlobURL(reference string, ref registry.Reference) string {
-	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s", resolver.DefaultScheme(reference), ref.Host(), ref.Repository, ref.Reference)
+func CraftBlobURL(plainHTTP bool, ref registry.Reference) string {
+	scheme := "https"
+	if plainHTTP {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s", scheme, ref.Host(), ref.Repository, ref.Reference)
 }
 
 func GetHeader(ctx context.Context, realURL string, rt http.RoundTripper) (*http.Response, error) {

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -686,7 +686,10 @@ func TestMirror(t *testing.T) {
 [[plugins."io.containerd.snapshotter.v1.soci".resolver.host."%s".mirrors]]
 host = "%s"
 insecure = true
-`, regConfig.host, regAltConfig.hostWithPort())
+[[plugins."io.containerd.snapshotter.v1.soci".resolver.host."%s".mirrors]]
+host = "%s"
+insecure = true
+`, regConfig.host, "127.0.0.1:1", regConfig.host, regAltConfig.hostWithPort())
 
 	var withCustomMirrorConfig = func(cfg *config.Config) {
 		cfg.ServiceConfig.FSConfig.BlobConfig.CheckAlways = true
@@ -696,6 +699,10 @@ insecure = true
 		}
 		cfg.ServiceConfig.ResolverConfig.Host[regConfig.host] = config.HostConfig{
 			Mirrors: []config.MirrorConfig{
+				{
+					Host:     "127.0.0.1:1",
+					Insecure: true,
+				},
 				{
 					Host:     regAltConfig.hostWithPort(),
 					Insecure: true,
@@ -736,7 +743,7 @@ insecure = true
 		sh.Pipe(nil, shell.C("nerdctl", "run", "--name", "test", "--pull", "never", "--net", "none", "--rm", regConfig.mirror(imageName).ref, "tar", "-zc", "/usr"), tarExportArgs)
 	}
 
-	// test if mirroring is working (switching to registryAltHost)
+	// test if mirror fallback is working (dead mirror -> registryAltHost)
 	testSameTarContents(t, sh, sample,
 		func(t *testing.T, tarExportArgs ...string) {
 			sh.


### PR DESCRIPTION
**Issue #, if available:**
Fixes #1013

**Description of changes:**
SOCI artifact discovery/fetch (index + zTOCs) was constructing an ORAS repository from the original image locator (e.g. docker.io/...), causing the snapshotter to ignore configured registry mirrors and talk to the origin registry for SOCI artifacts.

This changes the SOCI index fetch path to use the resolved docker.RegistryHost (mirror host + client) when constructing the ORAS repository locator. This makes SOCI artifact requests follow the same mirror configuration used for layer pulls.

**Testing performed:**
✅ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
