### PR TITLE
Implement Standalone SOCI Image Convert mode for SOCI index creation without containerd

### DIFF
--- a/cmd/soci/commands/internal/standalone.go
+++ b/cmd/soci/commands/internal/standalone.go
@@ -1,0 +1,205 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import (
+	"cmp"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/awslabs/soci-snapshotter/soci"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/reference"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/urfave/cli/v3"
+	oraslib "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+type StandaloneImageInfo struct {
+	ContentStore content.Store
+	Image        images.Image
+	TempDir      string
+	OrasStore    *oci.Store
+}
+
+func (info *StandaloneImageInfo) Cleanup() {
+	if info.TempDir != "" {
+		cleanupTempDir(info.TempDir)
+	}
+}
+
+// DownloadImageFromRegistry downloads an image from a registry using ORAS
+// and returns a content store and image metadata that can be used by IndexBuilder.
+func DownloadImageFromRegistry(ctx context.Context, cmd *cli.Command, imageRef string) (*StandaloneImageInfo, error) {
+	refspec, err := reference.Parse(imageRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse image reference: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "soci-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %w", err)
+	}
+
+	orasStore, err := oci.New(tmpDir)
+	if err != nil {
+		cleanupTempDir(tmpDir)
+		return nil, fmt.Errorf("failed to create ORAS store: %w", err)
+	}
+
+	repo, err := newRemoteRepo(cmd, refspec)
+	if err != nil {
+		cleanupTempDir(tmpDir)
+		return nil, fmt.Errorf("failed to create remote repository: %w", err)
+	}
+
+	verbose := cmd.Bool("verbose")
+	if verbose {
+		fmt.Printf("Downloading image %s from registry...\n", imageRef)
+	}
+
+	manifestDesc, err := repo.Resolve(ctx, refspec.Object)
+	if err != nil {
+		cleanupTempDir(tmpDir)
+		return nil, fmt.Errorf("failed to resolve image %s: %w", imageRef, err)
+	}
+
+	copyOpts := oraslib.DefaultCopyGraphOptions
+	if verbose {
+		copyOpts.PreCopy = func(_ context.Context, desc ocispec.Descriptor) error {
+			mediaType := cmp.Or(desc.MediaType, soci.SociLayerMediaType)
+			fmt.Printf("  Downloading %s (%s, %d bytes)\n", desc.Digest.Encoded()[:12], mediaType, desc.Size)
+			return nil
+		}
+	}
+
+	if err := oraslib.CopyGraph(ctx, repo, orasStore, manifestDesc, copyOpts); err != nil {
+		cleanupTempDir(tmpDir)
+		return nil, fmt.Errorf("failed to download image %s: %w", imageRef, err)
+	}
+
+	if verbose {
+		fmt.Printf("Successfully downloaded image\n")
+	}
+
+	contentStore, err := local.NewStore(tmpDir)
+	if err != nil {
+		cleanupTempDir(tmpDir)
+		return nil, fmt.Errorf("failed to create content store: %w", err)
+	}
+
+	return &StandaloneImageInfo{
+		ContentStore: contentStore,
+		Image: images.Image{
+			Name:   imageRef,
+			Target: manifestDesc,
+		},
+		TempDir:   tmpDir,
+		OrasStore: orasStore,
+	}, nil
+}
+
+// PushConvertedImage pushes a converted OCI Index (containing image + SOCI indexes) to the registry.
+// This is similar to `nerdctl push` but works without containerd by using the ORAS OCI store directly.
+func PushConvertedImage(ctx context.Context, cmd *cli.Command, info *StandaloneImageInfo, convertedDesc ocispec.Descriptor, dstRef string) error {
+	verbose := cmd.Bool("verbose")
+
+	refspec, err := reference.Parse(dstRef)
+	if err != nil {
+		return fmt.Errorf("failed to parse reference %s: %w", dstRef, err)
+	}
+
+	repo, err := newRemoteRepo(cmd, refspec)
+	if err != nil {
+		return fmt.Errorf("failed to create remote repository: %w", err)
+	}
+
+	if verbose {
+		fmt.Printf("Pushing SOCI-enabled image to %s...\n", dstRef)
+	}
+
+	copyOpts := oraslib.DefaultCopyGraphOptions
+	if verbose {
+		copyOpts.PreCopy = func(_ context.Context, d ocispec.Descriptor) error {
+			mediaType := cmp.Or(d.MediaType, soci.SociLayerMediaType)
+			fmt.Printf("  Pushing %s (%s, %d bytes)\n", d.Digest.Encoded()[:12], mediaType, d.Size)
+			return nil
+		}
+	}
+
+	if err := oraslib.CopyGraph(ctx, info.OrasStore, repo, convertedDesc, copyOpts); err != nil {
+		return fmt.Errorf("failed to push to %s: %w", dstRef, err)
+	}
+
+	if err := repo.Tag(ctx, convertedDesc, refspec.Object); err != nil {
+		return fmt.Errorf("failed to tag %s: %w", dstRef, err)
+	}
+
+	if verbose {
+		fmt.Printf("Successfully pushed to %s (digest: %s)\n", dstRef, convertedDesc.Digest)
+	}
+
+	return nil
+}
+
+func newRemoteRepo(cmd *cli.Command, refspec reference.Spec) (*remote.Repository, error) {
+	repo, err := remote.NewRepository(refspec.Locator)
+	if err != nil {
+		return nil, err
+	}
+	username, password := ResolveCredentials(cmd, refspec.Hostname())
+	repo.Client = setupAuthClient(cmd, username, password)
+	repo.PlainHTTP = cmd.Bool("plain-http")
+	return repo, nil
+}
+
+func cleanupTempDir(tmpDir string) {
+	if err := os.RemoveAll(tmpDir); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to clean up temp directory %s: %v\n", tmpDir, err)
+	}
+}
+
+func setupAuthClient(cmd *cli.Command, username, password string) *auth.Client {
+	authClient := &auth.Client{
+		Credential: func(_ context.Context, host string) (auth.Credential, error) {
+			return auth.Credential{
+				Username: username,
+				Password: password,
+			}, nil
+		},
+	}
+
+	if cmd.Bool("skip-verify") {
+		authClient.Client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		}
+	}
+
+	return authClient
+}

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -54,6 +54,11 @@ This command creates a new SOCI-enabled image that packages the original image a
 > [!NOTE]
 > SOCI Index Manifest v2 is the recommended approach for production deployments as it provides immutable binding between the image and SOCI index, preventing runtime behavior changes.
 
+**Modes of Operation:**
+
+1. **Containerd mode** (default): Works with local containerd daemon and requires the image to be present in containerd
+2. **Standalone mode** (`--standalone`): Downloads image directly from registry, converts it, and pushes back without requiring containerd
+
 Usage: ```soci convert [flags] <source_image_ref> <dest_image_ref> ```
 
 Flags:
@@ -64,6 +69,8 @@ Flags:
    - `xattr` :  When true, adds DisableXAttrs annotation to SOCI index. This annotation often helps performance at pull time.
  - ```--all-platforms``` : Convert all platforms of a multi-platform image
  - ```--platform``` : Convert only the specified platform (e.g., linux/amd64)
+ - ```--standalone``` : Run in standalone mode without containerd daemon
+ - ```--user```, ```-u``` : Registry credentials in format `username:password` (when using standalone mode)
 
 **Example:**
 ```
@@ -73,6 +80,13 @@ soci convert public.ecr.aws/soci-workshop-examples/ffmpeg:latest public.ecr.aws/
 **Multi-platform example:**
 ```
 soci convert --all-platforms public.ecr.aws/soci-workshop-examples/ffmpeg:latest public.ecr.aws/soci-workshop-examples/ffmpeg:latest-soci
+```
+
+**Standalone mode example (no containerd required):**
+```
+soci convert --standalone --user myuser:mypass \
+  private.registry/myapp:v1.0 \
+  private.registry/myapp:v1.0-soci
 ```
 
 ### soci push

--- a/docs/registry-authentication.md
+++ b/docs/registry-authentication.md
@@ -153,7 +153,7 @@ kubeconfig_path="/path/to/kubeconfig"
 
 # SOCI CLI
 
-The SOCI CLI supports 2 mechanisms for getting registry credentials when pushing SOCI indexes:
+The SOCI CLI supports 2 mechanisms for getting registry credentials when pushing SOCI indexes (via `soci push`) or when using standalone convert mode (via `soci convert --standalone`):
 
 1. [Docker Config](#docker-config)
 2. [Explicit username/password via a parameter](#username--password-parameter)
@@ -166,11 +166,20 @@ Like the SOCI snapshotter, the SOCI CLI can load credentials from the Docker con
 
 ## Username + Password Parameter
 
-The SOCI CLI can also receive credentials via the `--user` parameter which accepts a `USERNAME:PASSWORD` string. E.g.:
+The SOCI CLI can also receive credentials via the `--user` parameter which accepts a `USERNAME:PASSWORD` string. This parameter works with both `soci push` and `soci convert --standalone` commands. E.g.:
 
+**With soci push:**
 ```
 # ECR_TOKEN = $(aws ecr get-login-password)
 # soci push --user AWS:$ECR_TOKEN $IMAGE
+```
+
+**With soci convert (standalone mode):**
+```
+# ECR_TOKEN = $(aws ecr get-login-password)
+# soci convert --standalone --user AWS:$ECR_TOKEN \
+#     source.registry/image:tag \
+#     dest.registry/image:tag-soci
 ```
 
 NOTE: This method will record the password in shell history if you do not use an environment variable like in the example.

--- a/docs/soci-index-manifest-v2.md
+++ b/docs/soci-index-manifest-v2.md
@@ -19,7 +19,9 @@ While SOCI-enabled images are additional images compared to SOCI Index Manifest 
 
 The SOCI snapshotter v0.10.0 will no longer consume SOCI Index Manifest v1 by default. Your existing images will not be lazily loaded after updating. To upgrade to SOCI Index Manifest v2, use the SOCI CLI to convert your images into SOCI-enabled images. You can push the SOCI-enabled images to your registry like any other image which will include the new SOCI indexes. You can pull the SOCI-enabled images with the SOCI snapshotter to get the benefits of lazy loading.
 
-A sample workflow:
+### Option 1: Using containerd (nerdctl)
+
+Sample workflow with containerd:
 
 ```
 sudo nerdctl pull --all-platforms 123456789012.dkr.us-west-2.ecr.amazonaws.com/example:latest
@@ -28,6 +30,21 @@ sudo soci convert --all-platforms 123456789012.dkr.us-west-2.ecr.amazonaws.com/e
 sudo nerdctl push --all-platforms \
     123456789012.dkr.us-west-2.ecr.amazonaws.com/example:latest-soci
 ```
+
+### Option 2: Standalone mode (no containerd required)
+
+Sample workflow without containerd:
+
+```
+sudo soci convert --standalone --all-platforms \
+    --user $USER:$PASSWORD \
+    123456789012.dkr.us-west-2.ecr.amazonaws.com/example:latest \
+    123456789012.dkr.us-west-2.ecr.amazonaws.com/example:latest-soci
+```
+
+The standalone mode automatically downloads the image, converts it, and pushes it back to the registry in a single command. This is useful in CI/CD environments or when you don't have containerd available.
+
+### Using the converted image
 
 In your execution environment:
 

--- a/integration/standalone_convert_test.go
+++ b/integration/standalone_convert_test.go
@@ -1,0 +1,220 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/containerd/platforms"
+)
+
+func TestStandaloneConvertBasic(t *testing.T) {
+	t.Parallel()
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	imageRef := nginxImage
+	copyImage(sh, dockerhub(imageRef), regConfig.mirror(imageRef))
+
+	srcRef := regConfig.mirror(imageRef).ref
+	dstRef := srcRef + "-standalone-soci"
+
+	stopContainerd(t, sh)
+
+	sh.X("soci", "convert",
+		"--standalone",
+		"--all-platforms",
+		"--min-layer-size=0",
+		srcRef,
+		dstRef,
+	)
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	sh.X("nerdctl", "pull", "-q", dstRef)
+
+	srcDigest := getImageDigest(sh, srcRef)
+	dstDigest := getImageDigest(sh, dstRef)
+
+	validateConversion(t, sh, srcDigest, dstDigest)
+
+	sociV2Enabled := withPullModes(config.PullModes{
+		SOCIv1: config.V1{Enable: false},
+		SOCIv2: config.V2{Enable: true},
+	})
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, sociV2Enabled))
+	sh.X("nerdctl", "rmi", "-f", dstRef)
+	sh.X("nerdctl", "pull", "-q", "--snapshotter=soci", "--all-platforms", dstRef)
+
+	sh.X("nerdctl", "run", "--rm", "--net", "none", "--snapshotter=soci", dstRef, "echo", "success")
+}
+
+func TestStandaloneConvertSpecificPlatform(t *testing.T) {
+	t.Parallel()
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	imageRef := nginxImage
+	copyImage(sh, dockerhub(imageRef), regConfig.mirror(imageRef))
+
+	mirrorImg := regConfig.mirror(imageRef)
+	platformStr := platforms.Format(mirrorImg.platform)
+
+	srcRef := mirrorImg.ref
+	dstRef := srcRef + "-standalone-specific-platform"
+
+	stopContainerd(t, sh)
+
+	sh.X("soci", "convert",
+		"--standalone",
+		"--platform", platformStr,
+		"--min-layer-size=0",
+		srcRef,
+		dstRef,
+	)
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	sh.X("nerdctl", "pull", "-q", "--platform", platformStr, dstRef)
+
+	srcDigest := getImageDigest(sh, srcRef)
+	dstDigest := getImageDigest(sh, dstRef)
+
+	validateConversion(t, sh, srcDigest, dstDigest)
+}
+
+func TestStandaloneConvertWithUserAuth(t *testing.T) {
+	t.Parallel()
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	imageRef := nginxImage
+	copyImage(sh, dockerhub(imageRef), regConfig.mirror(imageRef))
+
+	srcRef := regConfig.mirror(imageRef).ref
+	dstRef := srcRef + "-standalone-user-auth"
+
+	stopContainerd(t, sh)
+
+	sh.X("soci", "convert",
+		"--standalone",
+		"--min-layer-size=0",
+		"--user", regConfig.creds(),
+		srcRef,
+		dstRef,
+	)
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	sh.X("nerdctl", "pull", "-q", dstRef)
+}
+
+func TestStandaloneInvalidConversion(t *testing.T) {
+	t.Parallel()
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	t.Run("nonexistent image", func(t *testing.T) {
+		output, err := sh.CombinedOLog("soci", "convert",
+			"--standalone",
+			regConfig.mirror("nonexistent:image").ref,
+			regConfig.mirror("nonexistent:image").ref+"-standalone-soci",
+		)
+		if err == nil {
+			t.Fatal("expected error for nonexistent image")
+		}
+
+		outputStr := string(output)
+		if !strings.Contains(outputStr, "failed to resolve image") {
+			t.Fatalf("expected error about failed download, got: %s", outputStr)
+		}
+	})
+
+	t.Run("missing destination ref", func(t *testing.T) {
+		output, err := sh.CombinedOLog("soci", "convert",
+			"--standalone",
+			regConfig.mirror(nginxImage).ref,
+		)
+		if err == nil {
+			t.Fatal("expected error for missing destination ref")
+		}
+
+		outputStr := string(output)
+		if !strings.Contains(outputStr, "destination image needs to be specified") {
+			t.Errorf("expected error about missing destination, got: %s", outputStr)
+		}
+	})
+}
+
+func TestStandaloneConvertIdempotent(t *testing.T) {
+	t.Parallel()
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	imageRef := nginxImage
+	copyImage(sh, dockerhub(imageRef), regConfig.mirror(imageRef))
+
+	srcRef := regConfig.mirror(imageRef).ref
+	dstRef1 := srcRef + "-standalone-soci1"
+	dstRef2 := srcRef + "-standalone-soci2"
+
+	stopContainerd(t, sh)
+
+	// First conversion
+	sh.X("soci", "convert",
+		"--standalone",
+		"--min-layer-size=0",
+		srcRef,
+		dstRef1,
+	)
+
+	// Second conversion of the already-converted image
+	sh.X("soci", "convert",
+		"--standalone",
+		"--min-layer-size=0",
+		dstRef1,
+		dstRef2,
+	)
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	// Pull both to containerd
+	sh.X("nerdctl", "pull", "-q", dstRef1)
+	sh.X("nerdctl", "pull", "-q", dstRef2)
+
+	digest1 := getImageDigest(sh, dstRef1)
+	digest2 := getImageDigest(sh, dstRef2)
+
+	if digest1 != digest2 {
+		t.Errorf("converting a SOCI-enabled image should be idempotent, but digests differ: %s vs %s", digest1, digest2)
+	}
+}

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -858,6 +858,12 @@ func getReferrers(sh *shell.Shell, regConfig registryConfig, imgName, digest str
 	return &index, nil
 }
 
+func stopContainerd(t *testing.T, sh *shell.Shell) {
+	if err := testutil.KillMatchingProcess(sh, "containerd"); err != nil {
+		t.Fatalf("failed to kill containerd: %v", err)
+	}
+}
+
 func rebootContainerd(t *testing.T, sh *shell.Shell, customContainerdConfig, customSnapshotterConfig string) *testutil.LogMonitor {
 	var (
 		containerdRoot    = "/var/lib/containerd"
@@ -867,11 +873,8 @@ func rebootContainerd(t *testing.T, sh *shell.Shell, customContainerdConfig, cus
 	)
 
 	// cleanup directories
-	err := testutil.KillMatchingProcess(sh, "containerd")
-	if err != nil {
-		sh.Fatal("failed to kill containerd: %v", err)
-	}
-	err = testutil.KillMatchingProcess(sh, "soci-snapshotter-grpc")
+	stopContainerd(t, sh)
+	err := testutil.KillMatchingProcess(sh, "soci-snapshotter-grpc")
 	if err != nil {
 		sh.Fatal("failed to kill soci: %v", err)
 	}


### PR DESCRIPTION
### NEW PR - https://github.com/awslabs/soci-snapshotter/pull/1881

**Issue #, if available:**
Closes https://github.com/awslabs/soci-snapshotter/issues/1057

**Description of changes:**

This PR adds standalone mode to the `soci convert` command, enabling SOCI index creation without requiring a running containerd daemon. This is particularly useful for CI/CD pipelines and environments where running containerd is impractical without privileged mode.

  ### Key Features

  - **Standalone Mode**: Download images directly from registries using ORAS, create SOCI indexes, and push converted images back to registries
  - **Authentication**: Full support for registry authentication via `--user` flag, Docker config, and environment variables
  - **TLS Options**: Support for `--skip-verify` and `--plain-http` flags
  - **Platform Selection**: Compatible with `--platform` and `--all-platforms` flags
  - **Verbose Output**: Optional `--verbose` flag for detailed progress information


 ### Usage Example

  ```
  soci convert --standalone \
    --user myuser:mypass \
    --verbose \
    source-registry.com/myimage:latest \
    dest-registry.com/myimage:latest-soci  
```



**Testing performed:**

  -  Added new Integration test and all integration tests pass (TestStandaloneConvert*)
    - Basic conversion with validation
    - Specific platform selection (--platform)
    - Authentication with --user flag
    - Error handling (nonexistent images, missing arguments)
    - Idempotency verification
  - Tested on ARM64 architecture (linux/arm64/v8) (lima on macOs)
     - `lima sudo GO_TEST_FLAGS="-run TestStandaloneConvert" make integration`
     - `lima sudo make test`
  - Manual verification of image download, conversion, and push workflow
  
```
sudo ./out/soci convert xxx.xxx.com/xxx:full xxx.xxx.com/xxx:standalone-test-99 --all-platforms --standalone --user $REPOSITORY:$TOKEN  --verbose

Standalone mode: downloading image xxx.xxx.com/xxx:full
Downloading image xxx.xxx.com/xxx:full from registry...
  Downloading fd398e9fa269 (application/vnd.oci.image.layer.v1.tar+gzip, 5616874 bytes)
  Downloading 12bb71ceae34 (application/vnd.oci.image.layer.v1.tar+gzip, 221568 bytes)
  Downloading d28cb90eb7da (application/vnd.oci.image.config.v1+json, 17958 bytes)
  Downloading ef6465a1674b (application/vnd.oci.image.layer.v1.tar+gzip, 78 bytes)
  Downloading 3e9c02b40ec1 (application/vnd.oci.image.layer.v1.tar+gzip, 14489277 bytes)
  Downloading 7511aa994dfe (application/vnd.oci.image.layer.v1.tar+gzip, 3222 bytes)
  Downloading 5b91cf883cde (application/vnd.oci.image.layer.v1.tar+gzip, 10392231 bytes)
  Downloading f6a26d16afc7 (application/vnd.oci.image.layer.v1.tar+gzip, 10395600 bytes)
  Downloading 4f4fb700ef54 (application/vnd.oci.image.layer.v1.tar+gzip, 32 bytes)
  Downloading d8c6b361b623 (application/vnd.oci.image.layer.v1.tar+gzip, 271302478 bytes)
  Downloading faf5416d559a (application/vnd.oci.image.manifest.v1+json, 2383 bytes)
Successfully downloaded image
Converting image to SOCI-enabled format with 1 platform(s)
ztoc skipped - layer sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 (application/vnd.oci.image.layer.v1.tar+gzip) size 32 is less than min-layer-size 10485760
ztoc skipped - layer sha256:5b91cf883cde9e49909af81cdce1cc89948745e38796395b0a90d859d7db97d2 (application/vnd.oci.image.layer.v1.tar+gzip) size 10392231 is less than min-layer-size 10485760
ztoc skipped - layer sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 (application/vnd.oci.image.layer.v1.tar+gzip) size 32 is less than min-layer-size 10485760
ztoc skipped - layer sha256:ef6465a1674b258144bd7eac86347823926436a5d53f100cadfe098c82e4c4d4 (application/vnd.oci.image.layer.v1.tar+gzip) size 78 is less than min-layer-size 10485760
ztoc skipped - layer sha256:f6a26d16afc76b03f36290b56770ae0db2ab11aab759d2c7bd49bdfc865b3b87 (application/vnd.oci.image.layer.v1.tar+gzip) size 10395600 is less than min-layer-size 10485760
ztoc skipped - layer sha256:fd398e9fa269e6877ec10f14d61837fc23f05d757530fed2946073018dc07705 (application/vnd.oci.image.layer.v1.tar+gzip) size 5616874 is less than min-layer-size 10485760
ztoc skipped - layer sha256:12bb71ceae3401038ce93aa7ce3a115f4a5cb3e9a85277ef4a97718c0fc9298e (application/vnd.oci.image.layer.v1.tar+gzip) size 221568 is less than min-layer-size 10485760
ztoc skipped - layer sha256:ef6465a1674b258144bd7eac86347823926436a5d53f100cadfe098c82e4c4d4 (application/vnd.oci.image.layer.v1.tar+gzip) size 78 is less than min-layer-size 10485760
ztoc skipped - layer sha256:7511aa994dfed5f54c697fcec6db7176449e7d87317b3f6ad093185182ce01c7 (application/vnd.oci.image.layer.v1.tar+gzip) size 3222 is less than min-layer-size 10485760
layer sha256:3e9c02b40ec11c1a3cc84f775102e2a3b100700fc7753098adc6d62e3fc6563b -> ztoc sha256:0aa198e2f2f6ff02675b7f7dc27e008a1b81bc15a87a5e4d5f868259a3cdc5f0
layer sha256:d8c6b361b623cabb0a89fad4a7d491d7d543f0834ca0c581e0176e1b76a68a15 -> ztoc sha256:ea8f91d2a57139b053186c8a1ae1901684bc06fda5b7d00aef0bd3d6d4e9e4c1
Successfully created SOCI-enabled image: sha256:f265a1fddffc035eb949ac3ff03a597ce4c823b8bde2ae6cb63a0c85f69d0de9
Pushing SOCI-enabled image to xxx.xxx.com/xxx:standalone-test-99...
Successfully pushed SOCI-enabled image to xxx.xxx.com/xxx:standalone-test-99 (digest: sha256:f265a1fddffc035eb949ac3ff03a597ce4c823b8bde2ae6cb63a0c85f69d0de9)
```

Integration tests -

```
sudo GO_TEST_FLAGS="-run TestStandalone -count=1" make integration
cd cmd/ ; GO111MODULE=auto go build -o /Volumes/git/prafulg/soci-snapshotter/out/soci-snapshotter-grpc  -ldflags '-X github.com/awslabs/soci-snapshotter/version.Version=be11c954.m -X github.com/awslabs/soci-snapshotter/version.Revision=be11c954b73ee597b504985deea72eebdefce2f2.m  -s -w '  ./soci-snapshotter-grpc
cd cmd/ ; GO111MODULE=auto go build -o /Volumes/git/prafulg/soci-snapshotter/out/soci  -ldflags '-X github.com/awslabs/soci-snapshotter/version.Version=be11c954.m -X github.com/awslabs/soci-snapshotter/version.Revision=be11c954b73ee597b504985deea72eebdefce2f2.m  -s -w '  ./soci
integration
SOCI_SNAPSHOTTER_PROJECT_ROOT=/Volumes/git/prafulg/soci-snapshotter
=== RUN   TestStandaloneConvertBasic
=== PAUSE TestStandaloneConvertBasic
=== RUN   TestStandaloneConvertSpecificPlatform
=== PAUSE TestStandaloneConvertSpecificPlatform
=== RUN   TestStandaloneConvertWithUserAuth
=== PAUSE TestStandaloneConvertWithUserAuth
=== RUN   TestStandaloneInvalidConversion
=== PAUSE TestStandaloneInvalidConversion
=== RUN   TestStandaloneConvertIdempotent
=== PAUSE TestStandaloneConvertIdempotent
=== CONT  TestStandaloneConvertBasic
=== CONT  TestStandaloneInvalidConversion
=== CONT  TestStandaloneConvertSpecificPlatform
=== CONT  TestStandaloneConvertWithUserAuth
=== CONT  TestStandaloneConvertIdempotent
=== RUN   TestStandaloneInvalidConversion/nonexistent_image
=== RUN   TestStandaloneInvalidConversion/missing_destination_ref
--- PASS: TestStandaloneInvalidConversion (1.38s)
    --- PASS: TestStandaloneInvalidConversion/nonexistent_image (0.11s)
    --- PASS: TestStandaloneInvalidConversion/missing_destination_ref (0.03s)
--- PASS: TestStandaloneConvertSpecificPlatform (21.16s)
--- PASS: TestStandaloneConvertWithUserAuth (21.28s)
--- PASS: TestStandaloneConvertIdempotent (22.26s)
--- PASS: TestStandaloneConvertBasic (22.51s)
PASS
ok      github.com/awslabs/soci-snapshotter/integration 132.773s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
