### PR TITLE
Support concatenated gzip (mgzip/pigz) layers in ztoc

### DIFF
--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -1120,8 +1120,33 @@ func FetchContentByDigest(sh *shell.Shell, contentStoreType store.ContentStoreTy
 	}
 }
 
+// readLayerTarFiles fetches a gzip-tar layer blob from containerd's content
+// store and returns the regular-file entries' contents keyed by tar path.
+func readLayerTarFiles(t *testing.T, sh *shell.Shell, layerDigest digest.Digest) map[string][]byte {
+	t.Helper()
+	layerBytes, err := FetchContentByDigest(sh, store.ContainerdContentStoreType, layerDigest)
+	if err != nil {
+		t.Fatalf("fetch layer %s: %v", layerDigest, err)
+	}
+	layerFile := filepath.Join(t.TempDir(), "layer.tar.gz")
+	if err := os.WriteFile(layerFile, layerBytes, 0644); err != nil {
+		t.Fatalf("write layer: %v", err)
+	}
+	files, _, err := testutil.GetFilesAndContentsWithinTarGz(layerFile)
+	if err != nil {
+		t.Fatalf("read layer tar: %v", err)
+	}
+	return files
+}
+
 func withContentStoreConfig(opts ...store.Option) snapshotterConfigOpt {
 	return func(c *config.Config) {
 		c.ServiceConfig.FSConfig.ContentStoreConfig = store.NewStoreConfig(opts...).ContentStoreConfig
 	}
+}
+
+func buildEstargzImage(sh *shell.Shell, src imageInfo, destRef string) {
+	sh.X("nerdctl", "image", "convert", "--estargz", "--oci",
+		"--platform", platforms.Format(src.platform),
+		src.ref, destRef)
 }

--- a/integration/ztoc_test.go
+++ b/integration/ztoc_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/util/testutil"
 	"github.com/awslabs/soci-snapshotter/ztoc"
 	"github.com/awslabs/soci-snapshotter/ztoc/compression"
+	"github.com/containerd/platforms"
 	"github.com/google/go-cmp/cmp"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -473,6 +474,74 @@ func dedupeZtocBlobs(ztocBlobs []*v1.Descriptor) []*v1.Descriptor {
 		}
 	}
 	return dedupedZtocBlobs
+}
+
+// eStargz layers are concatenated gzip members.
+func TestSociZtocWithEstargzLayers(t *testing.T) {
+	t.Parallel()
+
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	src := dockerhub(alpineImage)
+	sh.X(append([]string{"nerdctl", "pull", "-q", "--platform", platforms.Format(src.platform)}, encodeImageInfoNerdctl(src)[0]...)...)
+
+	mirrorRef := regConfig.mirror("alpine-estargz:latest")
+	buildEstargzImage(sh, src, mirrorRef.ref)
+	sh.X(append([]string{"nerdctl", "push", "-q"}, encodeImageInfoNerdctl(mirrorRef)[0]...)...)
+
+	indexDigest := buildIndex(sh, mirrorRef, withMinLayerSize(0))
+	if indexDigest == "" {
+		t.Fatal("failed to create SOCI index for eStargz-compressed image")
+	}
+
+	sociIndex, err := sociIndexFromDigest(sh, indexDigest)
+	if err != nil {
+		t.Fatalf("failed to read SOCI index: %v", err)
+	}
+	var ztocFound bool
+	for _, blob := range sociIndex.Blobs {
+		if blob.MediaType != soci.SociLayerMediaType {
+			continue
+		}
+		ztocFound = true
+
+		layerDigest, err := digest.Parse(blob.Annotations[soci.IndexAnnotationImageLayerDigest])
+		if err != nil {
+			t.Fatalf("parse layer digest: %v", err)
+		}
+		files := readLayerTarFiles(t, sh, layerDigest)
+		names := make([]string, 0, len(files))
+		for n := range files {
+			names = append(names, n)
+		}
+		slices.Sort(names)
+		for _, name := range names {
+			expected := files[name]
+			if len(expected) == 0 || len(expected) > 16<<10 {
+				continue
+			}
+			extracted, err := sh.OLog("soci", "ztoc", "get-file", blob.Digest.String(), name)
+			if err != nil {
+				t.Fatalf("get-file %s: %v", name, err)
+			}
+			actual := bytes.TrimSuffix(extracted, []byte{'\n'})
+			if !bytes.Equal(actual, expected) {
+				t.Fatalf("%s content mismatch: expected %d bytes, got %d bytes", name, len(expected), len(actual))
+			}
+		}
+	}
+	if !ztocFound {
+		t.Fatal("no ztoc was generated for the eStargz layer")
+	}
+
+	sh.X("soci", "push", "--user", regConfig.creds(), mirrorRef.ref)
+	sh.X("ctr", "i", "rm", mirrorRef.ref)
+	sh.X(append(imagePullCmd, "--soci-index-digest", indexDigest, mirrorRef.ref)...)
+	checkFuseMounts(t, sh, 1)
 }
 
 func verifyInfoOutput(zinfo Info, ztoc *ztoc.Ztoc) error {


### PR DESCRIPTION
**Issue #, if available:**
Fixes #1834. The C-level zinfo code only processed the first gzip member, causing all ztoc entries to map to span 0 for mgzip-compressed layers. This adds handling for multiple concatenated gzip members in all three functions: index generation, file-based extraction, and buffer-based extraction.

**Description of changes:**

- Handle concatenated gzip members in `generate_zinfo_from_fp` by detecting additional data after Z_STREAM_END and resetting inflate state for the next member
  - Ref - https://github.com/madler/zlib/blob/master/examples/zran.c#L221-L228
- Handle concatenated gzip members in both extraction functions (`extract_data_from_fp`, `extract_data_from_buffer`) by manually skipping the 8-byte gzip trailer on the first member boundary (raw inflate mode), then switching to gzip mode (windowBits=47) which auto-consumes subsequent trailers
  -  Ref - https://github.com/madler/zlib/blob/master/examples/zran.c#L418-L436

**Testing performed:**
- Added unit test - 
```
lima sudo go test -v -count=1 -run TestDecompressWithPigz ./ztoc/...
=== RUN   TestDecompressWithPigz
=== RUN   TestDecompressWithPigz/span_size_64KB
=== RUN   TestDecompressWithPigz/span_size_256KB
=== RUN   TestDecompressWithPigz/span_size_1MB
--- PASS: TestDecompressWithPigz (0.53s)
    --- PASS: TestDecompressWithPigz/span_size_64KB (0.17s)
    --- PASS: TestDecompressWithPigz/span_size_256KB (0.17s)
    --- PASS: TestDecompressWithPigz/span_size_1MB (0.18s)
PASS
ok      github.com/awslabs/soci-snapshotter/ztoc        0.540s
PASS
ok      github.com/awslabs/soci-snapshotter/ztoc/compression    0.002s [no tests to run]
?       github.com/awslabs/soci-snapshotter/ztoc/compression/fbs/zinfo  [no test files]
?       github.com/awslabs/soci-snapshotter/ztoc/fbs/ztoc       [no test files]
```

```
lima sudo GO_TEST_FLAGS="-run TestSociZtocWithEstargzLayers -count=1 -timeout 10m" make integration


 SOCI_SNAPSHOTTER_PROJECT_ROOT=/Volumes/git/prafulg/soci-snapshotter
 === RUN   TestSociZtocWithEstargzLayers
 === PAUSE TestSociZtocWithEstargzLayers
 === CONT  TestSociZtocWithEstargzLayers
 --- PASS: TestSociZtocWithEstargzLayers (10.75s)
 PASS
 ok         github.com/awslabs/soci-snapshotter/integration 102.684s

 DONE 1 tests in 96.664s
```

- Tried converting/indexing the same image layer as https://github.com/awslabs/soci-snapshotter/issues/1834 that threw 0 start and end span, 

```
{
  "version": "0.9",
  "build_tool": "AWS SOCI CLI v0.2",
  "size": 7262136,
  "span_size": 4194304,
  "num_spans": 118,
  "num_files": 15553,
  "num_multi_span_files": 80,
  "files": [
    {
      "filename": "app/var/data/conda-env/x86_64-conda-linux-gnu",
      "offset": 512,
      "size": 0,
      "type": "dir",
      "start_span": 0,
      "end_span": 0
    },
    {
      "filename": "app/var/data/conda-env/x86_64-conda-linux-gnu/bin",
      "offset": 1024,
      "size": 0,
      "type": "dir",
      "start_span": 0,
      "end_span": 0
    },
....
  {
    "filename": "app/var/data/conda-env/lib/libopenblasp-r0.3.30.so",
    "offset": 97394176,
    "size": 41424320,
    "type": "reg",
    "start_span": 23,
    "end_span": 32
  }
....
    {
      "filename": "app/var/data/conda-env/man/man1/bzegrep.1",
      "offset": 498103296,
      "size": 18,
      "type": "reg",
      "start_span": 117,
      "end_span": 117
    },
    {
      "filename": "app/var/data/conda-env/man/man1/bzcmp.1",
      "offset": 498104320,
      "size": 18,
      "type": "reg",
      "start_span": 117,
      "end_span": 117
    },
    {
      "filename": "app/var/data/conda-env/man/man1/bzmore.1",
      "offset": 498105344,
      "size": 4310,
      "type": "reg",
      "start_span": 117,
      "end_span": 117
    }
  ]
}
```

- Manual test - 

```
sudo soci convert --all-platforms xx/functions/user-function:0.2.0 xx/functions/user-function:0.2.0-soci

sudo nerdctl push --all-platforms xx/functions/user-function:0.2.0

-- clean all containerd and soci cache

lima sudo bash -c 'systemctl stop soci-snapshotter-grpc && cp /Volumes/git/prafulg/soci-snapshotter/out/soci-snapshotter-grpc /usr/local/bin/soci-snapshotter-grpc && cp /Volumes/git/prafulg/soci-snapshotter/out/soci /usr/local/bin/soci && systemctl start
  soci-snapshotter-grpc && sleep 2 && systemctl is-active soci-snapshotter-grpc


lima sudo nerdctl run --net host --rm --platform linux/amd64 --snapshotter soci --entrypoint sh xxxx/functions/user-function:0.2.0-soci -c "/app/var/data/conda-env/bin/python3.12 -c \"import sys; print(sys.version)\""
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
