### PR TITLE
Port GzipZinfo to Go

### DIFF
--- a/ztoc/compression/flate/dict_decoder.go
+++ b/ztoc/compression/flate/dict_decoder.go
@@ -1,0 +1,149 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Forked from Go stdlib compress/flate/dict_decoder.go.
+// Added Window() method to export sliding window state for zinfo checkpoints.
+
+package flate
+
+const WindowSize = 32768
+
+// dictDecoder implements the LZ77 sliding dictionary as used in decompression.
+type dictDecoder struct {
+	hist []byte // Sliding window history
+
+	// Invariant: 0 <= rdPos <= wrPos <= len(hist)
+	wrPos int  // Current output position in buffer
+	rdPos int  // Have emitted hist[:rdPos] already
+	full  bool // Has a full window length been written yet?
+
+	totalWritten int64 // Total uncompressed bytes written (across all wraps)
+}
+
+func (dd *dictDecoder) init(size int, dict []byte) {
+	*dd = dictDecoder{hist: dd.hist}
+
+	if cap(dd.hist) < size {
+		dd.hist = make([]byte, size)
+	}
+	dd.hist = dd.hist[:size]
+
+	if len(dict) > len(dd.hist) {
+		dict = dict[len(dict)-len(dd.hist):]
+	}
+	dd.wrPos = copy(dd.hist, dict)
+	if dd.wrPos == len(dd.hist) {
+		dd.wrPos = 0
+		dd.full = true
+	}
+	dd.rdPos = dd.wrPos
+}
+
+func (dd *dictDecoder) histSize() int {
+	if dd.full {
+		return len(dd.hist)
+	}
+	return dd.wrPos
+}
+
+func (dd *dictDecoder) availRead() int {
+	return dd.wrPos - dd.rdPos
+}
+
+func (dd *dictDecoder) availWrite() int {
+	return len(dd.hist) - dd.wrPos
+}
+
+func (dd *dictDecoder) writeSlice() []byte {
+	return dd.hist[dd.wrPos:]
+}
+
+func (dd *dictDecoder) writeMark(cnt int) {
+	dd.wrPos += cnt
+	dd.totalWritten += int64(cnt)
+}
+
+func (dd *dictDecoder) writeByte(c byte) {
+	dd.hist[dd.wrPos] = c
+	dd.wrPos++
+	dd.totalWritten++
+}
+
+func (dd *dictDecoder) writeCopy(dist, length int) int {
+	dstBase := dd.wrPos
+	dstPos := dstBase
+	srcPos := dstPos - dist
+	endPos := dstPos + length
+	if endPos > len(dd.hist) {
+		endPos = len(dd.hist)
+	}
+
+	if srcPos < 0 {
+		srcPos += len(dd.hist)
+		dstPos += copy(dd.hist[dstPos:endPos], dd.hist[srcPos:])
+		srcPos = 0
+	}
+
+	for dstPos < endPos {
+		dstPos += copy(dd.hist[dstPos:endPos], dd.hist[srcPos:dstPos])
+	}
+
+	dd.wrPos = dstPos
+	written := dstPos - dstBase
+	dd.totalWritten += int64(written)
+	return written
+}
+
+func (dd *dictDecoder) tryWriteCopy(dist, length int) int {
+	dstPos := dd.wrPos
+	endPos := dstPos + length
+	if dstPos < dist || endPos > len(dd.hist) {
+		return 0
+	}
+	dstBase := dstPos
+	srcPos := dstPos - dist
+
+	for dstPos < endPos {
+		dstPos += copy(dd.hist[dstPos:endPos], dd.hist[srcPos:dstPos])
+	}
+
+	dd.wrPos = dstPos
+	written := dstPos - dstBase
+	dd.totalWritten += int64(written)
+	return written
+}
+
+func (dd *dictDecoder) readFlush() []byte {
+	toRead := dd.hist[dd.rdPos:dd.wrPos]
+	dd.rdPos = dd.wrPos
+	if dd.wrPos == len(dd.hist) {
+		dd.wrPos, dd.rdPos = 0, 0
+		dd.full = true
+	}
+	return toRead
+}
+
+// Window returns the current 32KB sliding window in decompression order,
+// matching the layout produced by zlib's inflate (used for zinfo checkpoints).
+// The C code captures the window as: window[WINSIZE-left:] + window[:WINSIZE-left]
+// where left = strm.avail_out (remaining space in the output window buffer).
+// Go's dictDecoder uses a circular buffer: hist with wrPos as the write cursor.
+// When full, the oldest data starts at wrPos and wraps around.
+func (dd *dictDecoder) Window() [WindowSize]byte {
+	var win [WindowSize]byte
+	if !dd.full {
+		// Buffer hasn't wrapped yet. Data is hist[0:wrPos], preceded by zeros.
+		// This matches C behavior: when less than WINSIZE has been output,
+		// the window is zero-padded at the beginning.
+		if dd.wrPos > 0 {
+			copy(win[WindowSize-dd.wrPos:], dd.hist[:dd.wrPos])
+		}
+	} else {
+		// Buffer has wrapped. wrPos is where next write goes = oldest data position.
+		// Data in decompression order: hist[wrPos:] then hist[:wrPos]
+		n := copy(win[:], dd.hist[dd.wrPos:])
+		copy(win[n:], dd.hist[:dd.wrPos])
+	}
+	return win
+}

--- a/ztoc/compression/flate/inflate.go
+++ b/ztoc/compression/flate/inflate.go
@@ -1,0 +1,728 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Forked from Go stdlib compress/flate/inflate.go.
+// Changes: exported Decompressor, added OnBlockEnd callback, added public
+// accessors (ByteOffset, BitsState, Window, InjectBits, TotalOut).
+
+package flate
+
+import (
+	"bufio"
+	"io"
+	"math/bits"
+	"strconv"
+	"sync"
+)
+
+const (
+	maxCodeLen     = 16
+	maxNumLit      = 286
+	maxNumDist     = 30
+	numCodes       = 19
+	endBlockMarker = 256
+	maxMatchOffset = 1 << 15
+)
+
+var fixedOnce sync.Once
+var fixedHuffmanDecoder huffmanDecoder
+
+type CorruptInputError int64
+
+func (e CorruptInputError) Error() string {
+	return "flate: corrupt input before offset " + strconv.FormatInt(int64(e), 10)
+}
+
+type InternalError string
+
+func (e InternalError) Error() string { return "flate: internal error: " + string(e) }
+
+// Reader is the actual read interface needed by NewReader.
+type Reader interface {
+	io.Reader
+	io.ByteReader
+}
+
+const (
+	huffmanChunkBits  = 9
+	huffmanNumChunks  = 1 << huffmanChunkBits
+	huffmanCountMask  = 15
+	huffmanValueShift = 4
+)
+
+type huffmanDecoder struct {
+	min      int
+	chunks   [huffmanNumChunks]uint32
+	links    [][]uint32
+	linkMask uint32
+}
+
+func (h *huffmanDecoder) init(lengths []int) bool {
+	const sanity = false
+
+	if h.min != 0 {
+		*h = huffmanDecoder{}
+	}
+
+	var count [maxCodeLen]int
+	var min, max int
+	for _, n := range lengths {
+		if n == 0 {
+			continue
+		}
+		if min == 0 || n < min {
+			min = n
+		}
+		if n > max {
+			max = n
+		}
+		count[n]++
+	}
+
+	if max == 0 {
+		return true
+	}
+
+	code := 0
+	var nextcode [maxCodeLen]int
+	for i := min; i <= max; i++ {
+		code <<= 1
+		nextcode[i] = code
+		code += count[i]
+	}
+
+	if code != 1<<uint(max) && !(code == 1 && max == 1) {
+		return false
+	}
+
+	h.min = min
+	if max > huffmanChunkBits {
+		numLinks := 1 << (uint(max) - huffmanChunkBits)
+		h.linkMask = uint32(numLinks - 1)
+
+		link := nextcode[huffmanChunkBits+1] >> 1
+		h.links = make([][]uint32, huffmanNumChunks-link)
+		for j := uint(link); j < huffmanNumChunks; j++ {
+			reverse := int(bits.Reverse16(uint16(j)))
+			reverse >>= uint(16 - huffmanChunkBits)
+			off := j - uint(link)
+			if sanity && h.chunks[reverse] != 0 {
+				panic("impossible: overwriting existing chunk")
+			}
+			h.chunks[reverse] = uint32(off<<huffmanValueShift | (huffmanChunkBits + 1))
+			h.links[off] = make([]uint32, numLinks)
+		}
+	}
+
+	for i, n := range lengths {
+		if n == 0 {
+			continue
+		}
+		code := nextcode[n]
+		nextcode[n]++
+		chunk := uint32(i<<huffmanValueShift | n)
+		reverse := int(bits.Reverse16(uint16(code)))
+		reverse >>= uint(16 - n)
+		if n <= huffmanChunkBits {
+			for off := reverse; off < len(h.chunks); off += 1 << uint(n) {
+				if sanity && h.chunks[off] != 0 {
+					panic("impossible: overwriting existing chunk")
+				}
+				h.chunks[off] = chunk
+			}
+		} else {
+			j := reverse & (huffmanNumChunks - 1)
+			if sanity && h.chunks[j]&huffmanCountMask != huffmanChunkBits+1 {
+				panic("impossible: not an indirect chunk")
+			}
+			value := h.chunks[j] >> huffmanValueShift
+			linktab := h.links[value]
+			reverse >>= huffmanChunkBits
+			for off := reverse; off < len(linktab); off += 1 << uint(n-huffmanChunkBits) {
+				if sanity && linktab[off] != 0 {
+					panic("impossible: overwriting existing chunk")
+				}
+				linktab[off] = chunk
+			}
+		}
+	}
+
+	return true
+}
+
+// Decompressor is the DEFLATE decompression state machine.
+// Exported (unlike stdlib's unexported decompressor) so that callers can
+// access block-boundary metadata needed for building gzip seek indices.
+type Decompressor struct {
+	// Input source.
+	r       Reader
+	rBuf    *bufio.Reader
+	roffset int64
+
+	// Input bits, in top of b.
+	b  uint32
+	nb uint
+
+	// Huffman decoders for literal/length, distance.
+	h1, h2 huffmanDecoder
+
+	// Length arrays used to define Huffman codes.
+	bits     *[maxNumLit + maxNumDist]int
+	codebits *[numCodes]int
+
+	// Output history, buffer.
+	dict dictDecoder
+
+	// Temporary buffer (avoids repeated allocation).
+	buf [4]byte
+
+	// Next step in the decompression, and decompression state.
+	step      func(*Decompressor)
+	stepState int
+	final     bool
+	err       error
+	toRead    []byte
+	hl, hd    *huffmanDecoder
+	copyLen   int
+	copyDist  int
+
+	// Total uncompressed bytes emitted.
+	totalOut int64
+
+	// OnBlockEnd is called at every deflate block boundary (when finishBlock
+	// fires). The argument is true if this was the final block.
+	// Set this before reading to capture checkpoints.
+	OnBlockEnd func(final bool)
+}
+
+var codeOrder = [...]int{16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15}
+
+func (f *Decompressor) nextBlock() {
+	for f.nb < 1+2 {
+		if f.err = f.moreBits(); f.err != nil {
+			return
+		}
+	}
+	f.final = f.b&1 == 1
+	f.b >>= 1
+	typ := f.b & 3
+	f.b >>= 2
+	f.nb -= 1 + 2
+	switch typ {
+	case 0:
+		f.dataBlock()
+	case 1:
+		f.hl = &fixedHuffmanDecoder
+		f.hd = nil
+		f.huffmanBlock()
+	case 2:
+		if f.err = f.readHuffman(); f.err != nil {
+			break
+		}
+		f.hl = &f.h1
+		f.hd = &f.h2
+		f.huffmanBlock()
+	default:
+		f.err = CorruptInputError(f.roffset)
+	}
+}
+
+func (f *Decompressor) Read(b []byte) (int, error) {
+	for {
+		if len(f.toRead) > 0 {
+			n := copy(b, f.toRead)
+			f.toRead = f.toRead[n:]
+			f.totalOut += int64(n)
+			if len(f.toRead) == 0 {
+				return n, f.err
+			}
+			return n, nil
+		}
+		if f.err != nil {
+			return 0, f.err
+		}
+		f.step(f)
+		if f.err != nil && len(f.toRead) == 0 {
+			f.toRead = f.dict.readFlush()
+		}
+	}
+}
+
+func (f *Decompressor) Close() error {
+	if f.err == io.EOF {
+		return nil
+	}
+	return f.err
+}
+
+func (f *Decompressor) readHuffman() error {
+	for f.nb < 5+5+4 {
+		if err := f.moreBits(); err != nil {
+			return err
+		}
+	}
+	nlit := int(f.b&0x1F) + 257
+	if nlit > maxNumLit {
+		return CorruptInputError(f.roffset)
+	}
+	f.b >>= 5
+	ndist := int(f.b&0x1F) + 1
+	if ndist > maxNumDist {
+		return CorruptInputError(f.roffset)
+	}
+	f.b >>= 5
+	nclen := int(f.b&0xF) + 4
+	f.b >>= 4
+	f.nb -= 5 + 5 + 4
+
+	for i := 0; i < nclen; i++ {
+		for f.nb < 3 {
+			if err := f.moreBits(); err != nil {
+				return err
+			}
+		}
+		f.codebits[codeOrder[i]] = int(f.b & 0x7)
+		f.b >>= 3
+		f.nb -= 3
+	}
+	for i := nclen; i < len(codeOrder); i++ {
+		f.codebits[codeOrder[i]] = 0
+	}
+	if !f.h1.init(f.codebits[0:]) {
+		return CorruptInputError(f.roffset)
+	}
+
+	for i, n := 0, nlit+ndist; i < n; {
+		x, err := f.huffSym(&f.h1)
+		if err != nil {
+			return err
+		}
+		if x < 16 {
+			f.bits[i] = x
+			i++
+			continue
+		}
+		var rep int
+		var nb uint
+		var b int
+		switch x {
+		default:
+			return InternalError("unexpected length code")
+		case 16:
+			rep = 3
+			nb = 2
+			if i == 0 {
+				return CorruptInputError(f.roffset)
+			}
+			b = f.bits[i-1]
+		case 17:
+			rep = 3
+			nb = 3
+			b = 0
+		case 18:
+			rep = 11
+			nb = 7
+			b = 0
+		}
+		for f.nb < nb {
+			if err := f.moreBits(); err != nil {
+				return err
+			}
+		}
+		rep += int(f.b & uint32(1<<nb-1))
+		f.b >>= nb
+		f.nb -= nb
+		if i+rep > n {
+			return CorruptInputError(f.roffset)
+		}
+		for j := 0; j < rep; j++ {
+			f.bits[i] = b
+			i++
+		}
+	}
+
+	if !f.h1.init(f.bits[0:nlit]) || !f.h2.init(f.bits[nlit:nlit+ndist]) {
+		return CorruptInputError(f.roffset)
+	}
+
+	if f.h1.min < f.bits[endBlockMarker] {
+		f.h1.min = f.bits[endBlockMarker]
+	}
+
+	return nil
+}
+
+func (f *Decompressor) huffmanBlock() {
+	const (
+		stateInit = iota
+		stateDict
+	)
+
+	switch f.stepState {
+	case stateInit:
+		goto readLiteral
+	case stateDict:
+		goto copyHistory
+	}
+
+readLiteral:
+	{
+		v, err := f.huffSym(f.hl)
+		if err != nil {
+			f.err = err
+			return
+		}
+		var n uint
+		var length int
+		switch {
+		case v < 256:
+			f.dict.writeByte(byte(v))
+			if f.dict.availWrite() == 0 {
+				f.toRead = f.dict.readFlush()
+				f.step = (*Decompressor).huffmanBlock
+				f.stepState = stateInit
+				return
+			}
+			goto readLiteral
+		case v == 256:
+			f.finishBlock()
+			return
+		case v < 265:
+			length = v - (257 - 3)
+			n = 0
+		case v < 269:
+			length = v*2 - (265*2 - 11)
+			n = 1
+		case v < 273:
+			length = v*4 - (269*4 - 19)
+			n = 2
+		case v < 277:
+			length = v*8 - (273*8 - 35)
+			n = 3
+		case v < 281:
+			length = v*16 - (277*16 - 67)
+			n = 4
+		case v < 285:
+			length = v*32 - (281*32 - 131)
+			n = 5
+		case v < maxNumLit:
+			length = 258
+			n = 0
+		default:
+			f.err = CorruptInputError(f.roffset)
+			return
+		}
+		if n > 0 {
+			for f.nb < n {
+				if err = f.moreBits(); err != nil {
+					f.err = err
+					return
+				}
+			}
+			length += int(f.b & uint32(1<<n-1))
+			f.b >>= n
+			f.nb -= n
+		}
+
+		var dist int
+		if f.hd == nil {
+			for f.nb < 5 {
+				if err = f.moreBits(); err != nil {
+					f.err = err
+					return
+				}
+			}
+			dist = int(bits.Reverse8(uint8(f.b & 0x1F << 3)))
+			f.b >>= 5
+			f.nb -= 5
+		} else {
+			if dist, err = f.huffSym(f.hd); err != nil {
+				f.err = err
+				return
+			}
+		}
+
+		switch {
+		case dist < 4:
+			dist++
+		case dist < maxNumDist:
+			nb := uint(dist-2) >> 1
+			extra := (dist & 1) << nb
+			for f.nb < nb {
+				if err = f.moreBits(); err != nil {
+					f.err = err
+					return
+				}
+			}
+			extra |= int(f.b & uint32(1<<nb-1))
+			f.b >>= nb
+			f.nb -= nb
+			dist = 1<<(nb+1) + 1 + extra
+		default:
+			f.err = CorruptInputError(f.roffset)
+			return
+		}
+
+		if dist > f.dict.histSize() {
+			f.err = CorruptInputError(f.roffset)
+			return
+		}
+
+		f.copyLen, f.copyDist = length, dist
+		goto copyHistory
+	}
+
+copyHistory:
+	{
+		cnt := f.dict.tryWriteCopy(f.copyDist, f.copyLen)
+		if cnt == 0 {
+			cnt = f.dict.writeCopy(f.copyDist, f.copyLen)
+		}
+		f.copyLen -= cnt
+
+		if f.dict.availWrite() == 0 || f.copyLen > 0 {
+			f.toRead = f.dict.readFlush()
+			f.step = (*Decompressor).huffmanBlock
+			f.stepState = stateDict
+			return
+		}
+		goto readLiteral
+	}
+}
+
+func (f *Decompressor) dataBlock() {
+	f.nb = 0
+	f.b = 0
+
+	nr, err := io.ReadFull(f.r, f.buf[0:4])
+	f.roffset += int64(nr)
+	if err != nil {
+		f.err = noEOF(err)
+		return
+	}
+	n := int(f.buf[0]) | int(f.buf[1])<<8
+	nn := int(f.buf[2]) | int(f.buf[3])<<8
+	if uint16(nn) != uint16(^n) {
+		f.err = CorruptInputError(f.roffset)
+		return
+	}
+
+	if n == 0 {
+		f.toRead = f.dict.readFlush()
+		f.finishBlock()
+		return
+	}
+
+	f.copyLen = n
+	f.copyData()
+}
+
+func (f *Decompressor) copyData() {
+	buf := f.dict.writeSlice()
+	if len(buf) > f.copyLen {
+		buf = buf[:f.copyLen]
+	}
+
+	cnt, err := io.ReadFull(f.r, buf)
+	f.roffset += int64(cnt)
+	f.copyLen -= cnt
+	f.dict.writeMark(cnt)
+	if err != nil {
+		f.err = noEOF(err)
+		return
+	}
+
+	if f.dict.availWrite() == 0 || f.copyLen > 0 {
+		f.toRead = f.dict.readFlush()
+		f.step = (*Decompressor).copyData
+		return
+	}
+	f.finishBlock()
+}
+
+func (f *Decompressor) finishBlock() {
+	if f.OnBlockEnd != nil {
+		f.OnBlockEnd(f.final)
+	}
+	if f.final {
+		if f.dict.availRead() > 0 {
+			f.toRead = f.dict.readFlush()
+		}
+		f.err = io.EOF
+	}
+	f.step = (*Decompressor).nextBlock
+}
+
+func noEOF(e error) error {
+	if e == io.EOF {
+		return io.ErrUnexpectedEOF
+	}
+	return e
+}
+
+func (f *Decompressor) moreBits() error {
+	c, err := f.r.ReadByte()
+	if err != nil {
+		return noEOF(err)
+	}
+	f.roffset++
+	f.b |= uint32(c) << f.nb
+	f.nb += 8
+	return nil
+}
+
+func (f *Decompressor) huffSym(h *huffmanDecoder) (int, error) {
+	n := uint(h.min)
+	nb, b := f.nb, f.b
+	for {
+		for nb < n {
+			c, err := f.r.ReadByte()
+			if err != nil {
+				f.b = b
+				f.nb = nb
+				return 0, noEOF(err)
+			}
+			f.roffset++
+			b |= uint32(c) << (nb & 31)
+			nb += 8
+		}
+		chunk := h.chunks[b&(huffmanNumChunks-1)]
+		n = uint(chunk & huffmanCountMask)
+		if n > huffmanChunkBits {
+			chunk = h.links[chunk>>huffmanValueShift][(b>>huffmanChunkBits)&h.linkMask]
+			n = uint(chunk & huffmanCountMask)
+		}
+		if n <= nb {
+			if n == 0 {
+				f.b = b
+				f.nb = nb
+				f.err = CorruptInputError(f.roffset)
+				return 0, f.err
+			}
+			f.b = b >> (n & 31)
+			f.nb = nb - n
+			return int(chunk >> huffmanValueShift), nil
+		}
+	}
+}
+
+func (f *Decompressor) makeReader(r io.Reader) {
+	if rr, ok := r.(Reader); ok {
+		f.rBuf = nil
+		f.r = rr
+		return
+	}
+	if f.rBuf != nil {
+		f.rBuf.Reset(r)
+	} else {
+		f.rBuf = bufio.NewReader(r)
+	}
+	f.r = f.rBuf
+}
+
+func fixedHuffmanDecoderInit() {
+	fixedOnce.Do(func() {
+		var bits [288]int
+		for i := 0; i < 144; i++ {
+			bits[i] = 8
+		}
+		for i := 144; i < 256; i++ {
+			bits[i] = 9
+		}
+		for i := 256; i < 280; i++ {
+			bits[i] = 7
+		}
+		for i := 280; i < 288; i++ {
+			bits[i] = 8
+		}
+		fixedHuffmanDecoder.init(bits[:])
+	})
+}
+
+// Reset resets the decompressor to read from r with an optional preset dictionary.
+func (f *Decompressor) Reset(r io.Reader, dict []byte) error {
+	onBlockEnd := f.OnBlockEnd
+	*f = Decompressor{
+		rBuf:     f.rBuf,
+		bits:     f.bits,
+		codebits: f.codebits,
+		dict:     f.dict,
+		step:     (*Decompressor).nextBlock,
+	}
+	f.OnBlockEnd = onBlockEnd
+	f.makeReader(r)
+	f.dict.init(maxMatchOffset, dict)
+	return nil
+}
+
+// NewReader returns a new Decompressor that can be used to read the
+// uncompressed version of r (a raw DEFLATE stream).
+func NewReader(r io.Reader) *Decompressor {
+	fixedHuffmanDecoderInit()
+
+	var f Decompressor
+	f.makeReader(r)
+	f.bits = new([maxNumLit + maxNumDist]int)
+	f.codebits = new([numCodes]int)
+	f.step = (*Decompressor).nextBlock
+	f.dict.init(maxMatchOffset, nil)
+	return &f
+}
+
+// NewReaderDict is like NewReader but initializes the reader with a preset dictionary.
+func NewReaderDict(r io.Reader, dict []byte) *Decompressor {
+	fixedHuffmanDecoderInit()
+
+	var f Decompressor
+	f.makeReader(r)
+	f.bits = new([maxNumLit + maxNumDist]int)
+	f.codebits = new([numCodes]int)
+	f.step = (*Decompressor).nextBlock
+	f.dict.init(maxMatchOffset, dict)
+	return &f
+}
+
+// --- Public accessors for zinfo checkpoint capture ---
+
+// ByteOffset returns the current compressed byte offset, accounting for
+// bits that have been read into the bit buffer but not yet consumed.
+// This matches zlib's compressed offset at a block boundary.
+func (f *Decompressor) ByteOffset() int64 {
+	return f.roffset - int64((f.nb+7)/8)
+}
+
+// BitsState returns the number of unconsumed bits (0-7) from the byte
+// preceding the current compressed offset, and their value.
+// This matches zlib's (data_type & 7) and the partial byte needed by inflatePrime.
+func (f *Decompressor) BitsState() (count uint8, value byte) {
+	count = uint8(f.nb % 8)
+	if count > 0 {
+		value = byte(f.b & ((1 << count) - 1))
+	}
+	return
+}
+
+// Window returns the current 32KB sliding window state.
+func (f *Decompressor) Window() [WindowSize]byte {
+	return f.dict.Window()
+}
+
+// InjectBits sets the bit buffer state, used when resuming decompression
+// from a checkpoint (equivalent to zlib's inflatePrime).
+func (f *Decompressor) InjectBits(count uint8, value byte) {
+	f.b = uint32(value)
+	f.nb = uint(count)
+}
+
+// TotalOut returns the total number of uncompressed bytes emitted via Read.
+func (f *Decompressor) TotalOut() int64 {
+	return f.totalOut
+}
+
+// DecompressedTotal returns the total number of uncompressed bytes written
+// to the internal dictionary, including bytes not yet consumed by Read.
+// This is accurate at OnBlockEnd callback time.
+func (f *Decompressor) DecompressedTotal() int64 {
+	return f.dict.totalWritten
+}

--- a/ztoc/compression/gzip_zinfo.go
+++ b/ztoc/compression/gzip_zinfo.go
@@ -35,6 +35,10 @@ type GzipZinfo struct {
 	cZinfo *C.struct_gzip_zinfo
 }
 
+func NewGzipZinfo(zinfoBytes []byte) (*GzipZinfo, error) {
+	return newGzipZinfo(zinfoBytes)
+}
+
 // newGzipZinfo creates a new instance of `GzipZinfo` from cZinfo byte blob on zTOC.
 func newGzipZinfo(zinfoBytes []byte) (*GzipZinfo, error) {
 	if len(zinfoBytes) == 0 {

--- a/ztoc/compression/gzip_zinfo_compat_test.go
+++ b/ztoc/compression/gzip_zinfo_compat_test.go
@@ -1,0 +1,467 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compression_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/util/testutil"
+	"github.com/awslabs/soci-snapshotter/ztoc/compression"
+	"github.com/awslabs/soci-snapshotter/ztoc/compression/purego"
+)
+
+type compatTestCase struct {
+	name             string
+	entries          []testutil.TarEntry
+	compressionLevel int
+	spanSize         int64
+	opts             []testutil.BuildTarOption
+}
+
+func getCompatTestCases(t *testing.T) []compatTestCase {
+	rng := testutil.NewTestRand(t)
+
+	return []compatTestCase{
+		{
+			name: "small file (< 1 span)",
+			entries: []testutil.TarEntry{
+				testutil.File("small.txt", "Hello, World!"),
+			},
+			compressionLevel: gzip.DefaultCompression,
+			spanSize:         1 << 20,
+		},
+		{
+			name: "medium file (5-10 spans)",
+			entries: []testutil.TarEntry{
+				testutil.File("medium.bin", string(rng.RandomByteData(200000))),
+			},
+			compressionLevel: gzip.DefaultCompression,
+			spanSize:         32768,
+		},
+		{
+			name: "large file (50+ spans)",
+			entries: []testutil.TarEntry{
+				testutil.File("large.bin", string(rng.RandomByteData(500000))),
+			},
+			compressionLevel: gzip.DefaultCompression,
+			spanSize:         8192,
+		},
+		{
+			name: "highly compressible data",
+			entries: []testutil.TarEntry{
+				testutil.File("zeros.bin", strings.Repeat("\x00", 100000)),
+			},
+			compressionLevel: gzip.DefaultCompression,
+			spanSize:         32768,
+		},
+		{
+			name: "compression level 1",
+			entries: []testutil.TarEntry{
+				testutil.File("data.bin", string(rng.RandomByteData(100000))),
+			},
+			compressionLevel: gzip.BestSpeed,
+			spanSize:         32768,
+		},
+		{
+			name: "compression level 9",
+			entries: []testutil.TarEntry{
+				testutil.File("data.bin", string(rng.RandomByteData(100000))),
+			},
+			compressionLevel: gzip.BestCompression,
+			spanSize:         32768,
+		},
+		{
+			name: "empty tar entry",
+			entries: []testutil.TarEntry{
+				testutil.File("empty.txt", ""),
+				testutil.File("notempty.txt", "some content"),
+			},
+			compressionLevel: gzip.DefaultCompression,
+			spanSize:         32768,
+		},
+		{
+			name: "single byte file",
+			entries: []testutil.TarEntry{
+				testutil.File("one.txt", "x"),
+			},
+			compressionLevel: gzip.DefaultCompression,
+			spanSize:         32768,
+		},
+		{
+			name: "multiple files",
+			entries: []testutil.TarEntry{
+				testutil.Dir("dir/"),
+				testutil.File("dir/a.txt", string(rng.RandomByteData(50000))),
+				testutil.File("dir/b.txt", string(rng.RandomByteData(50000))),
+				testutil.File("dir/c.txt", string(rng.RandomByteData(50000))),
+			},
+			compressionLevel: gzip.DefaultCompression,
+			spanSize:         32768,
+		},
+		{
+			name: "with gzip extra fields",
+			entries: []testutil.TarEntry{
+				testutil.File("data.txt", string(rng.RandomByteData(50000))),
+			},
+			compressionLevel: gzip.DefaultCompression,
+			spanSize:         32768,
+			opts: []testutil.BuildTarOption{
+				testutil.WithGzipComment("test comment"),
+				testutil.WithGzipFilename("testfile.tar"),
+				testutil.WithGzipExtra([]byte("extra")),
+			},
+		},
+	}
+}
+
+func writeTarGzToTemp(t *testing.T, tc compatTestCase) (string, []byte, []byte) {
+	t.Helper()
+	tarGzReader := testutil.BuildTarGz(tc.entries, tc.compressionLevel, tc.opts...)
+	tmpFile, gzData, err := testutil.WriteTarToTempFile("compat-*.tar.gz", tarGzReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gz, err := gzip.NewReader(bytes.NewReader(gzData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	uncompressed, err := io.ReadAll(gz)
+	gz.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpFile, gzData, uncompressed
+}
+
+func TestCompatIndexGeneration(t *testing.T) {
+	t.Parallel()
+	for _, tc := range getCompatTestCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpFile, _, _ := writeTarGzToTemp(t, tc)
+			defer os.Remove(tmpFile)
+
+			// C implementation (via exported factory).
+			cZinfo, err := compression.NewZinfoFromFile(compression.Gzip, tmpFile, tc.spanSize)
+			if err != nil {
+				t.Fatalf("C NewZinfoFromFile failed: %v", err)
+			}
+			defer cZinfo.Close()
+
+			// Go implementation.
+			goZinfo, err := purego.NewGzipZinfoFromFile(tmpFile, tc.spanSize)
+			if err != nil {
+				t.Fatalf("Go NewGzipZinfoFromFile failed: %v", err)
+			}
+			defer goZinfo.Close()
+
+			if cZinfo.MaxSpanID() != goZinfo.MaxSpanID() {
+				t.Fatalf("MaxSpanID mismatch: C=%d Go=%d", cZinfo.MaxSpanID(), goZinfo.MaxSpanID())
+			}
+			if cZinfo.SpanSize() != goZinfo.SpanSize() {
+				t.Fatalf("SpanSize mismatch: C=%d Go=%d", cZinfo.SpanSize(), goZinfo.SpanSize())
+			}
+
+			cBlob, err := cZinfo.Bytes()
+			if err != nil {
+				t.Fatalf("C Bytes() failed: %v", err)
+			}
+			goBlob, err := goZinfo.Bytes()
+			if err != nil {
+				t.Fatalf("Go Bytes() failed: %v", err)
+			}
+
+			if !bytes.Equal(cBlob, goBlob) {
+				// Log details for debugging.
+				t.Logf("C blob len=%d, Go blob len=%d", len(cBlob), len(goBlob))
+				t.Logf("C  MaxSpanID=%d, Go MaxSpanID=%d", cZinfo.MaxSpanID(), goZinfo.MaxSpanID())
+				for sid := compression.SpanID(0); sid <= cZinfo.MaxSpanID(); sid++ {
+					t.Logf("C  span %d: startComp=%d startUncomp=%d",
+						sid, cZinfo.StartCompressedOffset(sid), cZinfo.StartUncompressedOffset(sid))
+				}
+				for sid := compression.SpanID(0); sid <= goZinfo.MaxSpanID(); sid++ {
+					t.Logf("Go span %d: startComp=%d startUncomp=%d",
+						sid, goZinfo.StartCompressedOffset(sid), goZinfo.StartUncompressedOffset(sid))
+				}
+				t.Fatalf("serialized blobs differ")
+			}
+		})
+	}
+}
+
+func TestCompatDeserialization(t *testing.T) {
+	t.Parallel()
+	for _, tc := range getCompatTestCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpFile, _, _ := writeTarGzToTemp(t, tc)
+			defer os.Remove(tmpFile)
+
+			cZinfo, err := compression.NewZinfoFromFile(compression.Gzip, tmpFile, tc.spanSize)
+			if err != nil {
+				t.Fatalf("C NewZinfoFromFile failed: %v", err)
+			}
+			defer cZinfo.Close()
+
+			cBlob, err := cZinfo.Bytes()
+			if err != nil {
+				t.Fatalf("C Bytes() failed: %v", err)
+			}
+
+			goZinfo, err := purego.NewGzipZinfo(cBlob)
+			if err != nil {
+				t.Fatalf("Go NewGzipZinfo from C blob failed: %v", err)
+			}
+			defer goZinfo.Close()
+
+			if cZinfo.MaxSpanID() != goZinfo.MaxSpanID() {
+				t.Fatalf("MaxSpanID mismatch: C=%d Go=%d", cZinfo.MaxSpanID(), goZinfo.MaxSpanID())
+			}
+			if cZinfo.SpanSize() != goZinfo.SpanSize() {
+				t.Fatalf("SpanSize mismatch: C=%d Go=%d", cZinfo.SpanSize(), goZinfo.SpanSize())
+			}
+
+			for sid := compression.SpanID(0); sid <= cZinfo.MaxSpanID(); sid++ {
+				if cZinfo.StartCompressedOffset(sid) != goZinfo.StartCompressedOffset(sid) {
+					t.Fatalf("span %d StartCompressedOffset: C=%d Go=%d",
+						sid, cZinfo.StartCompressedOffset(sid), goZinfo.StartCompressedOffset(sid))
+				}
+				if cZinfo.StartUncompressedOffset(sid) != goZinfo.StartUncompressedOffset(sid) {
+					t.Fatalf("span %d StartUncompressedOffset: C=%d Go=%d",
+						sid, cZinfo.StartUncompressedOffset(sid), goZinfo.StartUncompressedOffset(sid))
+				}
+			}
+
+			for _, off := range []compression.Offset{0, 1, 100, 1000, 10000, 50000} {
+				cSid := cZinfo.UncompressedOffsetToSpanID(off)
+				goSid := goZinfo.UncompressedOffsetToSpanID(off)
+				if cSid != goSid {
+					t.Fatalf("UncompressedOffsetToSpanID(%d): C=%d Go=%d", off, cSid, goSid)
+				}
+			}
+		})
+	}
+}
+
+func TestCompatExtraction(t *testing.T) {
+	t.Parallel()
+	for _, tc := range getCompatTestCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpFile, gzData, uncompressed := writeTarGzToTemp(t, tc)
+			defer os.Remove(tmpFile)
+
+			cZinfo, err := compression.NewZinfoFromFile(compression.Gzip, tmpFile, tc.spanSize)
+			if err != nil {
+				t.Fatalf("C NewZinfoFromFile failed: %v", err)
+			}
+			defer cZinfo.Close()
+
+			goZinfo, err := purego.NewGzipZinfoFromFile(tmpFile, tc.spanSize)
+			if err != nil {
+				t.Fatalf("Go NewGzipZinfoFromFile failed: %v", err)
+			}
+			defer goZinfo.Close()
+
+			fileSize := compression.Offset(len(gzData))
+			uncompressedSize := compression.Offset(len(uncompressed))
+
+			for sid := compression.SpanID(0); sid <= cZinfo.MaxSpanID(); sid++ {
+				startComp := cZinfo.StartCompressedOffset(sid)
+				endComp := cZinfo.EndCompressedOffset(sid, fileSize)
+				compBuf := gzData[startComp:endComp]
+
+				startUncomp := cZinfo.StartUncompressedOffset(sid)
+				endUncomp := cZinfo.EndUncompressedOffset(sid, uncompressedSize)
+				size := endUncomp - startUncomp
+
+				if size <= 0 {
+					continue
+				}
+
+				cData, err := cZinfo.ExtractDataFromBuffer(compBuf, size, startUncomp, sid)
+				if err != nil {
+					t.Fatalf("span %d: C ExtractDataFromBuffer failed: %v", sid, err)
+				}
+
+				goData, err := goZinfo.ExtractDataFromBuffer(compBuf, size, startUncomp, sid)
+				if err != nil {
+					t.Fatalf("span %d: Go ExtractDataFromBuffer failed: %v", sid, err)
+				}
+
+				expected := uncompressed[startUncomp:endUncomp]
+				if !bytes.Equal(cData[:len(expected)], expected) {
+					t.Fatalf("span %d: C extraction doesn't match expected", sid)
+				}
+				if !bytes.Equal(goData[:len(expected)], expected) {
+					t.Fatalf("span %d: Go extraction doesn't match expected", sid)
+				}
+			}
+		})
+	}
+}
+
+func TestCompatExtractionFromFile(t *testing.T) {
+	t.Parallel()
+	for _, tc := range getCompatTestCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpFile, _, uncompressed := writeTarGzToTemp(t, tc)
+			defer os.Remove(tmpFile)
+
+			cZinfo, err := compression.NewZinfoFromFile(compression.Gzip, tmpFile, tc.spanSize)
+			if err != nil {
+				t.Fatalf("C NewZinfoFromFile failed: %v", err)
+			}
+			defer cZinfo.Close()
+
+			goZinfo, err := purego.NewGzipZinfoFromFile(tmpFile, tc.spanSize)
+			if err != nil {
+				t.Fatalf("Go NewGzipZinfoFromFile failed: %v", err)
+			}
+			defer goZinfo.Close()
+
+			offsets := []compression.Offset{0, 512, 1024}
+			size := compression.Offset(256)
+
+			for _, off := range offsets {
+				if off+size > compression.Offset(len(uncompressed)) {
+					continue
+				}
+
+				cData, err := cZinfo.ExtractDataFromFile(tmpFile, size, off)
+				if err != nil {
+					t.Fatalf("offset %d: C ExtractDataFromFile failed: %v", off, err)
+				}
+
+				goData, err := goZinfo.ExtractDataFromFile(tmpFile, size, off)
+				if err != nil {
+					t.Fatalf("offset %d: Go ExtractDataFromFile failed: %v", off, err)
+				}
+
+				expected := uncompressed[off : off+size]
+				if !bytes.Equal(cData, expected) {
+					t.Fatalf("offset %d: C extraction mismatch", off)
+				}
+				if !bytes.Equal(goData, expected) {
+					t.Fatalf("offset %d: Go extraction mismatch", off)
+				}
+			}
+		})
+	}
+}
+
+func TestCompatCrossImplementationRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, tc := range getCompatTestCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpFile, gzData, uncompressed := writeTarGzToTemp(t, tc)
+			defer os.Remove(tmpFile)
+
+			fileSize := compression.Offset(len(gzData))
+			uncompressedSize := compression.Offset(len(uncompressed))
+
+			// C → serialize → Go deserialize → Go extract.
+			cZinfo, err := compression.NewZinfoFromFile(compression.Gzip, tmpFile, tc.spanSize)
+			if err != nil {
+				t.Fatalf("C NewZinfoFromFile failed: %v", err)
+			}
+			cBlob, err := cZinfo.Bytes()
+			cZinfo.Close()
+			if err != nil {
+				t.Fatalf("C Bytes() failed: %v", err)
+			}
+
+			goZinfo, err := purego.NewGzipZinfo(cBlob)
+			if err != nil {
+				t.Fatalf("Go NewGzipZinfo from C blob failed: %v", err)
+			}
+
+			for sid := compression.SpanID(0); sid <= goZinfo.MaxSpanID(); sid++ {
+				startComp := goZinfo.StartCompressedOffset(sid)
+				endComp := goZinfo.EndCompressedOffset(sid, fileSize)
+				compBuf := gzData[startComp:endComp]
+
+				startUncomp := goZinfo.StartUncompressedOffset(sid)
+				endUncomp := goZinfo.EndUncompressedOffset(sid, uncompressedSize)
+				size := endUncomp - startUncomp
+				if size <= 0 {
+					continue
+				}
+
+				goData, err := goZinfo.ExtractDataFromBuffer(compBuf, size, startUncomp, sid)
+				if err != nil {
+					t.Fatalf("span %d: Go extract from C index failed: %v", sid, err)
+				}
+
+				expected := uncompressed[startUncomp:endUncomp]
+				if !bytes.Equal(goData[:len(expected)], expected) {
+					t.Fatalf("span %d: C→Go round-trip mismatch", sid)
+				}
+			}
+			goZinfo.Close()
+
+			// Go → serialize → C deserialize → C extract.
+			goZinfo2, err := purego.NewGzipZinfoFromFile(tmpFile, tc.spanSize)
+			if err != nil {
+				t.Fatalf("Go NewGzipZinfoFromFile failed: %v", err)
+			}
+			goBlob, err := goZinfo2.Bytes()
+			goZinfo2.Close()
+			if err != nil {
+				t.Fatalf("Go Bytes() failed: %v", err)
+			}
+
+			cZinfo2, err := compression.NewZinfo(compression.Gzip, goBlob)
+			if err != nil {
+				t.Fatalf("C NewZinfo from Go blob failed: %v", err)
+			}
+			defer cZinfo2.Close()
+
+			for sid := compression.SpanID(0); sid <= cZinfo2.MaxSpanID(); sid++ {
+				startComp := cZinfo2.StartCompressedOffset(sid)
+				endComp := cZinfo2.EndCompressedOffset(sid, fileSize)
+				compBuf := gzData[startComp:endComp]
+
+				startUncomp := cZinfo2.StartUncompressedOffset(sid)
+				endUncomp := cZinfo2.EndUncompressedOffset(sid, uncompressedSize)
+				size := endUncomp - startUncomp
+				if size <= 0 {
+					continue
+				}
+
+				cData, err := cZinfo2.ExtractDataFromBuffer(compBuf, size, startUncomp, sid)
+				if err != nil {
+					t.Fatalf("span %d: C extract from Go index failed: %v", sid, err)
+				}
+
+				expected := uncompressed[startUncomp:endUncomp]
+				if !bytes.Equal(cData[:len(expected)], expected) {
+					t.Fatalf("span %d: Go→C round-trip mismatch", sid)
+				}
+			}
+		})
+	}
+}

--- a/ztoc/compression/purego/gzip_zinfo.go
+++ b/ztoc/compression/purego/gzip_zinfo.go
@@ -1,0 +1,502 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package purego provides a pure Go implementation of GzipZinfo that produces
+// byte-for-byte identical output to the C (zlib-based) implementation.
+package purego
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/awslabs/soci-snapshotter/ztoc/compression"
+	"github.com/awslabs/soci-snapshotter/ztoc/compression/flate"
+)
+
+const (
+	winSize              = flate.WindowSize // 32768
+	packedCheckpointSize = 8 + 8 + 1 + winSize
+	blobHeaderSize       = 4 + 8
+
+	zinfoVersionOne = 1
+	zinfoVersionTwo = 2
+	zinfoVersionCur = zinfoVersionTwo
+)
+
+// gzipCheckpoint stores the state needed to resume decompression at a
+// deflate block boundary.
+type gzipCheckpoint struct {
+	In     int64            // offset in compressed file of first full byte
+	Out    int64            // corresponding offset in uncompressed data
+	Bits   uint8            // number of bits (1-7) from byte at In-1, or 0
+	Window [winSize]byte    // preceding 32K of uncompressed data
+}
+
+// GzipZinfo is a pure Go equivalent of the C struct gzip_zinfo.
+// It implements the compression.Zinfo interface.
+type GzipZinfo struct {
+	version  int32
+	spanSize int64
+	points   []gzipCheckpoint
+}
+
+// NewGzipZinfoFromFile creates a new GzipZinfo by reading a gzip file and
+// building a seek index with checkpoints every spanSize uncompressed bytes.
+func NewGzipZinfoFromFile(gzipFile string, spanSize int64) (*GzipZinfo, error) {
+	f, err := os.Open(gzipFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not open file: %w", err)
+	}
+	defer f.Close()
+	return newGzipZinfoFromReader(f, spanSize)
+}
+
+// newGzipZinfoFromReader builds a seek index from an io.Reader containing
+// gzip data.
+func newGzipZinfoFromReader(r io.Reader, spanSize int64) (*GzipZinfo, error) {
+	// Buffer the input so we can parse the gzip header and feed raw deflate
+	// to our forked decompressor.
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		return nil, fmt.Errorf("could not read input: %w", err)
+	}
+	data := buf.Bytes()
+
+	// Skip gzip header to find where the raw deflate stream starts.
+	headerLen, err := gzipHeaderLen(data)
+	if err != nil {
+		return nil, fmt.Errorf("invalid gzip header: %w", err)
+	}
+
+	deflateData := data[headerLen:]
+	deflateReader := bytes.NewReader(deflateData)
+
+	// The C code (using zlib Z_BLOCK) creates the first checkpoint right
+	// after the gzip header, before any deflate blocks are processed.
+	// We replicate this by manually adding the initial checkpoint.
+	var points []gzipCheckpoint
+	points = append(points, gzipCheckpoint{
+		In:  int64(headerLen),
+		Out: 0,
+	})
+	var last int64 // totout at last checkpoint
+
+	dec := flate.NewReader(deflateReader)
+
+	// Track block boundaries via callback.
+	dec.OnBlockEnd = func(final bool) {
+		// Skip the last block — C code checks !(data_type & 64).
+		if final {
+			return
+		}
+
+		// Use DecompressedTotal for accurate count at callback time
+		// (Read-based totalOut may lag behind).
+		totout := dec.DecompressedTotal()
+
+		if totout-last > spanSize {
+			bitsCount, _ := dec.BitsState()
+			byteOff := dec.ByteOffset()
+
+			// C's totin includes the partial byte; Go's ByteOffset excludes it.
+			// Adjust to match C convention.
+			absIn := int64(headerLen) + byteOff
+			if bitsCount > 0 {
+				absIn++
+			}
+
+			cp := gzipCheckpoint{
+				In:   absIn,
+				Out:  totout,
+				Bits: bitsCount,
+			}
+			cp.Window = dec.Window()
+			points = append(points, cp)
+			last = totout
+		}
+	}
+
+	// Read all decompressed data to drive the decompressor through all blocks.
+	outBuf := make([]byte, 32768)
+	for {
+		_, err := dec.Read(outBuf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decompression error: %w", err)
+		}
+	}
+
+	return &GzipZinfo{
+		version:  zinfoVersionCur,
+		spanSize: spanSize,
+		points:   points,
+	}, nil
+}
+
+// NewGzipZinfo deserializes a GzipZinfo from its binary blob representation.
+func NewGzipZinfo(zinfoBytes []byte) (*GzipZinfo, error) {
+	if len(zinfoBytes) == 0 {
+		return nil, fmt.Errorf("empty checkpoints")
+	}
+	if len(zinfoBytes) < blobHeaderSize {
+		return nil, fmt.Errorf("cannot convert blob to gzip_zinfo")
+	}
+
+	numCheckpoints := int32(binary.LittleEndian.Uint32(zinfoBytes[0:4]))
+	spanSize := int64(binary.LittleEndian.Uint64(zinfoBytes[4:12]))
+
+	claimedSize := int64(packedCheckpointSize)*int64(numCheckpoints) + int64(blobHeaderSize)
+	actualLen := int64(len(zinfoBytes))
+
+	var version int32
+	var firstCheckpointIndex int32
+
+	if claimedSize == actualLen {
+		version = zinfoVersionCur
+	} else if claimedSize-packedCheckpointSize == actualLen {
+		version = zinfoVersionOne
+	} else {
+		return nil, fmt.Errorf("cannot convert blob to gzip_zinfo")
+	}
+
+	points := make([]gzipCheckpoint, numCheckpoints)
+
+	if version == zinfoVersionOne {
+		firstCheckpointIndex = 1
+		points[0] = gzipCheckpoint{
+			In:   10,
+			Out:  0,
+			Bits: 0,
+		}
+	}
+
+	cur := zinfoBytes[blobHeaderSize:]
+	for i := firstCheckpointIndex; i < numCheckpoints; i++ {
+		if len(cur) < packedCheckpointSize {
+			return nil, fmt.Errorf("cannot convert blob to gzip_zinfo")
+		}
+		points[i].In = int64(binary.LittleEndian.Uint64(cur[0:8]))
+		points[i].Out = int64(binary.LittleEndian.Uint64(cur[8:16]))
+		points[i].Bits = cur[16]
+		copy(points[i].Window[:], cur[17:17+winSize])
+		cur = cur[packedCheckpointSize:]
+	}
+
+	return &GzipZinfo{
+		version:  version,
+		spanSize: spanSize,
+		points:   points,
+	}, nil
+}
+
+// Close is a no-op (no C memory to free).
+func (z *GzipZinfo) Close() {}
+
+// Bytes serializes the GzipZinfo to the same binary format as the C implementation.
+func (z *GzipZinfo) Bytes() ([]byte, error) {
+	firstIdx := int32(0)
+	numSerialized := int32(len(z.points))
+	if z.version == zinfoVersionOne {
+		firstIdx = 1
+		numSerialized = int32(len(z.points)) - 1
+	}
+
+	size := int64(blobHeaderSize) + int64(numSerialized)*int64(packedCheckpointSize)
+	buf := make([]byte, size)
+	if size == 0 {
+		return nil, fmt.Errorf("could not allocate byte array of size %d", size)
+	}
+
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(z.points)))
+	binary.LittleEndian.PutUint64(buf[4:12], uint64(z.spanSize))
+
+	cur := buf[blobHeaderSize:]
+	for i := firstIdx; i < int32(len(z.points)); i++ {
+		pt := &z.points[i]
+		binary.LittleEndian.PutUint64(cur[0:8], uint64(pt.In))
+		binary.LittleEndian.PutUint64(cur[8:16], uint64(pt.Out))
+		cur[16] = pt.Bits
+		copy(cur[17:17+winSize], pt.Window[:])
+		cur = cur[packedCheckpointSize:]
+	}
+
+	return buf, nil
+}
+
+// MaxSpanID returns the maximum span ID (number of checkpoints - 1).
+func (z *GzipZinfo) MaxSpanID() compression.SpanID {
+	return compression.SpanID(len(z.points) - 1)
+}
+
+// SpanSize returns the span size used to build this index.
+func (z *GzipZinfo) SpanSize() compression.Offset {
+	return compression.Offset(z.spanSize)
+}
+
+// UncompressedOffsetToSpanID returns the ID of the span containing the given
+// uncompressed offset.
+func (z *GzipZinfo) UncompressedOffsetToSpanID(offset compression.Offset) compression.SpanID {
+	res := 0
+	for i := 1; i < len(z.points); i++ {
+		if z.points[i].Out <= int64(offset) {
+			res = i
+		} else {
+			break
+		}
+	}
+	return compression.SpanID(res)
+}
+
+// ExtractDataFromBuffer decompresses data from a compressed buffer starting at
+// the given checkpoint.
+func (z *GzipZinfo) ExtractDataFromBuffer(compressedBuf []byte, uncompressedSize, uncompressedOffset compression.Offset, spanID compression.SpanID) ([]byte, error) {
+	if len(compressedBuf) == 0 {
+		return nil, fmt.Errorf("empty compressed buffer")
+	}
+	if uncompressedSize < 0 {
+		return nil, fmt.Errorf("invalid uncompressed size: %d", uncompressedSize)
+	}
+	if uncompressedSize == 0 {
+		return []byte{}, nil
+	}
+
+	cp := &z.points[spanID]
+	data := compressedBuf
+
+	// If checkpoint has bits, first byte contains partial bits.
+	var bitsCount uint8
+	var bitsVal byte
+	if cp.Bits > 0 {
+		fullByte := data[0]
+		data = data[1:]
+		// Reconstruct the bits value: the high bits of the byte are the ones
+		// that were already consumed; the low (8-bits) bits are what we
+		// need to feed to inflatePrime.
+		// C code: inflatePrime(strm, bits, ret >> (8 - bits))
+		bitsCount = cp.Bits
+		bitsVal = fullByte >> (8 - cp.Bits)
+	}
+
+	reader := bytes.NewReader(data)
+	dec := flate.NewReaderDict(reader, cp.Window[:])
+	if bitsCount > 0 {
+		dec.InjectBits(bitsCount, bitsVal)
+	}
+
+	// Skip bytes until we reach the desired offset within this span.
+	skip := int64(uncompressedOffset) - cp.Out
+	discard := make([]byte, 32768)
+	for skip > 0 {
+		toRead := min(int64(len(discard)), skip)
+		n, err := dec.Read(discard[:toRead])
+		skip -= int64(n)
+		if err != nil {
+			break
+		}
+	}
+
+	// Read the requested data. The buffer may end at a deflate block boundary,
+	// causing unexpected EOF when the decompressor tries to read the next
+	// block header. This is normal — C's inflate stops when avail_out is
+	// filled. We stop on any error once we have data.
+	result := make([]byte, uncompressedSize)
+	total := 0
+	for total < int(uncompressedSize) {
+		n, err := dec.Read(result[total:])
+		total += n
+		if err != nil {
+			break
+		}
+	}
+	if total == 0 {
+		return result, fmt.Errorf("error extracting data; return code: 0")
+	}
+
+	return result, nil
+}
+
+// ExtractDataFromFile decompresses data from a gzip file.
+func (z *GzipZinfo) ExtractDataFromFile(fileName string, uncompressedSize, uncompressedOffset compression.Offset) ([]byte, error) {
+	if uncompressedSize < 0 {
+		return nil, fmt.Errorf("invalid uncompressed size: %d", uncompressedSize)
+	}
+	if uncompressedSize == 0 {
+		return []byte{}, nil
+	}
+
+	// Find the right checkpoint.
+	spanID := z.UncompressedOffsetToSpanID(uncompressedOffset)
+	cp := &z.points[spanID]
+
+	f, err := os.Open(fileName)
+	if err != nil {
+		return nil, fmt.Errorf("could not open file: %w", err)
+	}
+	defer f.Close()
+
+	// Seek to the compressed position.
+	seekPos := cp.In
+	if cp.Bits > 0 {
+		seekPos--
+	}
+	if _, err := f.Seek(seekPos, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seek failed: %w", err)
+	}
+
+	var bitsCount uint8
+	var bitsVal byte
+	if cp.Bits > 0 {
+		var b [1]byte
+		if _, err := io.ReadFull(f, b[:]); err != nil {
+			return nil, fmt.Errorf("could not read bits byte: %w", err)
+		}
+		bitsCount = cp.Bits
+		bitsVal = b[0] >> (8 - cp.Bits)
+	}
+
+	dec := flate.NewReaderDict(f, cp.Window[:])
+	if bitsCount > 0 {
+		dec.InjectBits(bitsCount, bitsVal)
+	}
+
+	// Skip to offset.
+	skip := int64(uncompressedOffset) - cp.Out
+	discard := make([]byte, 32768)
+	for skip > 0 {
+		toRead := min(int64(len(discard)), skip)
+		n, err := dec.Read(discard[:toRead])
+		skip -= int64(n)
+		if err != nil {
+			break
+		}
+	}
+
+	// Read requested data.
+	result := make([]byte, uncompressedSize)
+	total := 0
+	for total < int(uncompressedSize) {
+		n, err := dec.Read(result[total:])
+		total += n
+		if err != nil {
+			break
+		}
+	}
+	if total == 0 {
+		return nil, fmt.Errorf("unable to extract data; return code = 0")
+	}
+
+	return result, nil
+}
+
+// StartCompressedOffset returns the start offset of the span in the compressed stream.
+func (z *GzipZinfo) StartCompressedOffset(spanID compression.SpanID) compression.Offset {
+	start := z.points[spanID].In
+	if z.points[spanID].Bits > 0 {
+		start--
+	}
+	return compression.Offset(start)
+}
+
+// EndCompressedOffset returns the end offset of the span in the compressed stream.
+func (z *GzipZinfo) EndCompressedOffset(spanID compression.SpanID, fileSize compression.Offset) compression.Offset {
+	if spanID == z.MaxSpanID() {
+		return fileSize
+	}
+	return compression.Offset(z.points[spanID+1].In)
+}
+
+// StartUncompressedOffset returns the start offset of the span in the uncompressed stream.
+func (z *GzipZinfo) StartUncompressedOffset(spanID compression.SpanID) compression.Offset {
+	return compression.Offset(z.points[spanID].Out)
+}
+
+// EndUncompressedOffset returns the end offset of the span in the uncompressed stream.
+func (z *GzipZinfo) EndUncompressedOffset(spanID compression.SpanID, fileSize compression.Offset) compression.Offset {
+	if spanID == z.MaxSpanID() {
+		return fileSize
+	}
+	return compression.Offset(z.points[spanID+1].Out)
+}
+
+// VerifyHeader checks if the given reader contains a valid gzip header.
+func (z *GzipZinfo) VerifyHeader(r io.Reader) error {
+	gz, err := gzip.NewReader(r)
+	if gz != nil {
+		gz.Close()
+	}
+	return err
+}
+
+// gzipHeaderLen parses a gzip header and returns its length in bytes.
+func gzipHeaderLen(data []byte) (int, error) {
+	if len(data) < 10 {
+		return 0, fmt.Errorf("data too short for gzip header")
+	}
+	if data[0] != 0x1f || data[1] != 0x8b {
+		return 0, fmt.Errorf("invalid gzip magic number")
+	}
+	if data[2] != 8 {
+		return 0, fmt.Errorf("unsupported compression method: %d", data[2])
+	}
+
+	flg := data[3]
+	pos := 10 // Skip past the fixed 10-byte header
+
+	// FEXTRA
+	if flg&0x04 != 0 {
+		if pos+2 > len(data) {
+			return 0, fmt.Errorf("truncated gzip header (FEXTRA length)")
+		}
+		xlen := int(data[pos]) | int(data[pos+1])<<8
+		pos += 2 + xlen
+	}
+
+	// FNAME
+	if flg&0x08 != 0 {
+		for pos < len(data) && data[pos] != 0 {
+			pos++
+		}
+		pos++ // skip null terminator
+	}
+
+	// FCOMMENT
+	if flg&0x10 != 0 {
+		for pos < len(data) && data[pos] != 0 {
+			pos++
+		}
+		pos++ // skip null terminator
+	}
+
+	// FHCRC
+	if flg&0x02 != 0 {
+		pos += 2
+	}
+
+	if pos > len(data) {
+		return 0, fmt.Errorf("truncated gzip header")
+	}
+
+	return pos, nil
+}
+
+// Compile-time check that GzipZinfo implements compression.Zinfo.
+var _ compression.Zinfo = (*GzipZinfo)(nil)

--- a/ztoc/compression/purego/gzip_zinfo_test.go
+++ b/ztoc/compression/purego/gzip_zinfo_test.go
@@ -1,0 +1,284 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package purego
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/util/testutil"
+	"github.com/awslabs/soci-snapshotter/ztoc/compression"
+)
+
+func TestSerializationRoundTrip(t *testing.T) {
+	t.Parallel()
+	// Build a small gzip file.
+	tarGzReader := testutil.BuildTarGz(
+		[]testutil.TarEntry{
+			testutil.File("hello.txt", "Hello, World!"),
+		},
+		gzip.DefaultCompression,
+	)
+
+	tmpFile, _, err := testutil.WriteTarToTempFile("purego-test-*.tar.gz", tarGzReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile)
+
+	z, err := NewGzipZinfoFromFile(tmpFile, 1024)
+	if err != nil {
+		t.Fatalf("NewGzipZinfoFromFile failed: %v", err)
+	}
+
+	blob, err := z.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes() failed: %v", err)
+	}
+
+	z2, err := NewGzipZinfo(blob)
+	if err != nil {
+		t.Fatalf("NewGzipZinfo failed: %v", err)
+	}
+
+	if z.MaxSpanID() != z2.MaxSpanID() {
+		t.Fatalf("MaxSpanID mismatch: %d vs %d", z.MaxSpanID(), z2.MaxSpanID())
+	}
+	if z.SpanSize() != z2.SpanSize() {
+		t.Fatalf("SpanSize mismatch: %d vs %d", z.SpanSize(), z2.SpanSize())
+	}
+
+	// Verify checkpoint data matches.
+	for i := range z.points {
+		if z.points[i].In != z2.points[i].In {
+			t.Fatalf("checkpoint %d In mismatch: %d vs %d", i, z.points[i].In, z2.points[i].In)
+		}
+		if z.points[i].Out != z2.points[i].Out {
+			t.Fatalf("checkpoint %d Out mismatch: %d vs %d", i, z.points[i].Out, z2.points[i].Out)
+		}
+		if z.points[i].Bits != z2.points[i].Bits {
+			t.Fatalf("checkpoint %d Bits mismatch: %d vs %d", i, z.points[i].Bits, z2.points[i].Bits)
+		}
+		if z.points[i].Window != z2.points[i].Window {
+			t.Fatalf("checkpoint %d Window mismatch", i)
+		}
+	}
+}
+
+func TestBlobFormat(t *testing.T) {
+	t.Parallel()
+	// Test that serialization produces correct header.
+	z := &GzipZinfo{
+		version:  zinfoVersionCur,
+		spanSize: 65536,
+		points: []gzipCheckpoint{
+			{In: 10, Out: 0, Bits: 0},
+		},
+	}
+
+	blob, err := z.Bytes()
+	if err != nil {
+		t.Fatalf("Bytes() failed: %v", err)
+	}
+
+	// Check header.
+	numCP := int32(binary.LittleEndian.Uint32(blob[0:4]))
+	span := int64(binary.LittleEndian.Uint64(blob[4:12]))
+	if numCP != 1 {
+		t.Fatalf("expected 1 checkpoint in header, got %d", numCP)
+	}
+	if span != 65536 {
+		t.Fatalf("expected span size 65536, got %d", span)
+	}
+
+	expectedSize := blobHeaderSize + packedCheckpointSize
+	if len(blob) != expectedSize {
+		t.Fatalf("expected blob size %d, got %d", expectedSize, len(blob))
+	}
+}
+
+func TestIndexGeneration(t *testing.T) {
+	t.Parallel()
+	rng := testutil.NewTestRand(t)
+
+	// Generate a file large enough for multiple spans.
+	content := string(rng.RandomByteData(100000))
+	tarGzReader := testutil.BuildTarGz(
+		[]testutil.TarEntry{
+			testutil.File("data.bin", content),
+		},
+		gzip.DefaultCompression,
+	)
+
+	tmpFile, _, err := testutil.WriteTarToTempFile("purego-gen-*.tar.gz", tarGzReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile)
+
+	z, err := NewGzipZinfoFromFile(tmpFile, 32768)
+	if err != nil {
+		t.Fatalf("NewGzipZinfoFromFile failed: %v", err)
+	}
+
+	if z.MaxSpanID() < 0 {
+		t.Fatal("expected at least one checkpoint")
+	}
+
+	// Verify first checkpoint.
+	if z.points[0].Out != 0 {
+		t.Fatalf("first checkpoint Out should be 0, got %d", z.points[0].Out)
+	}
+
+	// Verify checkpoints are ordered.
+	for i := 1; i < len(z.points); i++ {
+		if z.points[i].Out <= z.points[i-1].Out {
+			t.Fatalf("checkpoints not in ascending order at index %d", i)
+		}
+	}
+}
+
+func TestExtraction(t *testing.T) {
+	t.Parallel()
+	// Create a tar.gz with known content and verify extraction.
+	content := strings.Repeat("ABCDEFGH", 1000) // 8000 bytes
+	tarGzReader := testutil.BuildTarGz(
+		[]testutil.TarEntry{
+			testutil.File("test.txt", content),
+		},
+		gzip.DefaultCompression,
+	)
+
+	tmpFile, gzData, err := testutil.WriteTarToTempFile("purego-extract-*.tar.gz", tarGzReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile)
+
+	z, err := NewGzipZinfoFromFile(tmpFile, 4096)
+	if err != nil {
+		t.Fatalf("NewGzipZinfoFromFile failed: %v", err)
+	}
+
+	// Get the full uncompressed content for verification.
+	f, err := os.Open(tmpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fullUncompressed, err := io.ReadAll(gz)
+	gz.Close()
+	f.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test extraction from file for a range in the middle.
+	if len(fullUncompressed) > 512 {
+		offset := compression.Offset(512)
+		size := compression.Offset(256)
+		extracted, err := z.ExtractDataFromFile(tmpFile, size, offset)
+		if err != nil {
+			t.Fatalf("ExtractDataFromFile failed: %v", err)
+		}
+		expected := fullUncompressed[offset : offset+size]
+		if !bytes.Equal(extracted, expected) {
+			t.Fatalf("ExtractDataFromFile returned wrong data")
+		}
+	}
+
+	// Test extraction from buffer.
+	spanID := compression.SpanID(0)
+	startComp := z.StartCompressedOffset(spanID)
+	endComp := z.EndCompressedOffset(spanID, compression.Offset(len(gzData)))
+	compBuf := gzData[startComp:endComp]
+
+	startUncomp := z.StartUncompressedOffset(spanID)
+	endUncomp := z.EndUncompressedOffset(spanID, compression.Offset(len(fullUncompressed)))
+	size := endUncomp - startUncomp
+
+	extracted, err := z.ExtractDataFromBuffer(compBuf, size, startUncomp, spanID)
+	if err != nil {
+		t.Fatalf("ExtractDataFromBuffer failed: %v", err)
+	}
+	expected := fullUncompressed[startUncomp:endUncomp]
+	if !bytes.Equal(extracted[:len(expected)], expected) {
+		t.Fatalf("ExtractDataFromBuffer returned wrong data for span 0")
+	}
+}
+
+func TestVerifyHeader(t *testing.T) {
+	t.Parallel()
+	z := &GzipZinfo{}
+
+	// Valid gzip.
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	gw.Write([]byte("test"))
+	gw.Close()
+
+	if err := z.VerifyHeader(bytes.NewReader(buf.Bytes())); err != nil {
+		t.Fatalf("VerifyHeader should succeed on valid gzip: %v", err)
+	}
+
+	// Invalid data.
+	if err := z.VerifyHeader(bytes.NewReader([]byte("not gzip"))); err == nil {
+		t.Fatal("VerifyHeader should fail on invalid data")
+	}
+}
+
+func TestGzipHeaderLen(t *testing.T) {
+	t.Parallel()
+	// Basic gzip header (no optional fields).
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	gw.Write([]byte("x"))
+	gw.Close()
+
+	hdrLen, err := gzipHeaderLen(buf.Bytes())
+	if err != nil {
+		t.Fatalf("gzipHeaderLen failed: %v", err)
+	}
+	if hdrLen != 10 {
+		t.Fatalf("expected header length 10, got %d", hdrLen)
+	}
+
+	// Gzip with extra fields.
+	buf.Reset()
+	gw, _ = gzip.NewWriterLevel(&buf, gzip.DefaultCompression)
+	gw.Extra = []byte("extra data")
+	gw.Name = "test.txt"
+	gw.Comment = "a comment"
+	gw.Write([]byte("x"))
+	gw.Close()
+
+	hdrLen, err = gzipHeaderLen(buf.Bytes())
+	if err != nil {
+		t.Fatalf("gzipHeaderLen with extras failed: %v", err)
+	}
+	if hdrLen <= 10 {
+		t.Fatalf("expected header length > 10 with extras, got %d", hdrLen)
+	}
+}


### PR DESCRIPTION
GzipZinfo was implemented in C because;

1. The original implementation, zran.c was in C
2. compress/flate didn't expose the necessary APIs to implement the logic in Go

This commit ports GzipZinfo to pure Go by forking compress/flate and exposing the APIs we need.

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
