### PR TITLE
Run unit tests that require root perms in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,23 @@ jobs:
       - name: Show test coverage
         run: make show-test-coverage
 
+  # This is a temporary workaround to ensure we are testing our packages
+  # that require root (currently only the snapshot package).
+  # ref: https://github.com/awslabs/soci-snapshotter/issues/1878
+  test-root:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        go-version: ['1.25.7', '1.26.0']
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+      # Only snapshot package has tests that require root
+      - run: sudo -E env PATH=$PATH go test ./snapshot -test.root
+
   integration:
     needs: setup
     runs-on: ${{ fromJSON(needs.setup.outputs.runner-labels)[matrix.os] }}


### PR DESCRIPTION
**Issue #, if available:**
Closes #892 

**Description of changes:**
Added the necessary flags to the Makefile to pass `-test.root` to the testing binaries. We can't just use `GO_TEST_ARGS` as passing `-test.root` there will cause an unrecognized flag error in all of our other packages, as only the snapshot package uses the `-test.root` flag, so passing it to the test binary allows all the other tests to just ignore it.

Really I don't think we should be using containerd's `testutil.RequiresRoot` at all. But this is a decent bandaid fix.

This also added a separate commit to fix our failing remote tests as we did not have a namespace attached to the contexts passed in which would cause them to fail.

**Testing performed:**
`GO_TEST_BINARY_FLAGS='-test.root'` make test failed locally but seems like issues with my local setup. Opening as draft to see if runners will have the same issue. If not, will take out of draft state.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
