### PR TITLE
Add retry mechanism for failing integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ on:
       - 'ztoc/**' # Includes flatbuf + C files
       - '!benchmark/**'
 
+env:
+  GOTESTSUM_VERSION: 1.13.0
 
 jobs:
   setup:
@@ -64,6 +66,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v${{ env.GOTESTSUM_VERSION }}
       - name: Install zlib static on AL2 ARM instances
         if: matrix.os == 'al2-arm'
         run: dnf install zlib-static.aarch64 -y

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ $(COVDIR)/unit: $(COVDIR)
 integration: build
 	@echo "$@"
 	@echo "SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT)"
-	@GO111MODULE=$(GO111MODULE_VALUE) SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT) ENABLE_INTEGRATION_TEST=true go test $(GO_TEST_FLAGS) -v -timeout=0 ./integration
+	@GO111MODULE=$(GO111MODULE_VALUE) SOCI_SNAPSHOTTER_PROJECT_ROOT=$(SOCI_SNAPSHOTTER_PROJECT_ROOT) ENABLE_INTEGRATION_TEST=true gotestsum --rerun-fails --format standard-verbose --packages ./integration -- -timeout 0 $(GO_TEST_FLAGS)
 
 show-integration-coverage: $(COVDIR)/unit
 	go tool covdata percent -i $(COVDIR)/integration


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Our integration tests have become flakier for networking reasons. I decided to add a wrapper script to catch failing tests and retry only the ones that have failed.

This isn't perfect as the `-run` flag in `go test` takes regex, so if the failing test name happens to be the prefix for another test, it will run more tests than necessary (e.g. `-run TestConvert` would also run `TestConvertWithForceRecreateZtocs` and `TestConvertAndPush`). However, this is still better than what we have currently, so I guess it's fine for now.

**Testing performed:**
Ran `./scripts/integration-with-retries 3` locally and ensured it passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
