### PR TITLE
Remove containerd 1.6 from testing suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
         go-version: ['1.25.7', '1.26.0']
-        containerd: ["1.6.39", "1.7.29", "2.0.7", "2.1.5"]
+        containerd: ["1.7.29", "2.0.7", "2.1.5"]
     env:
       DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"
     steps:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Per https://containerd.io/releases, 1.6 was EOL in August 2025 thus we have no reason to keep testing against it.

2.0 is also EOL but as it's a little newer it's probably fine to keep testing against it anyway.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
