### PR TITLE
Add Standalone SOCI Image Convert mode for SOCI index creation using disk based OCI Layouts without containerd

### DIFF
--- a/cmd/soci/commands/convert.go
+++ b/cmd/soci/commands/convert.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -31,6 +32,14 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/reference"
 	"github.com/urfave/cli/v3"
+)
+
+const (
+	standaloneFlag   = "standalone"
+	outputFormatFlag = "format"
+
+	outputFormatOCIArchive = "oci-archive"
+	outputFormatOCIDir     = "oci-dir"
 )
 
 var ErrInvalidDestRef = errors.New(`the destination image must be a tagged ref of the form "registry/repository:tag"`)
@@ -59,34 +68,52 @@ func verifyRef(r string) error {
 // ConvertCommand converts an image into a SOCI enabled image.
 // The new image is added to the containerd content store and can
 // be pushed and deployed like a normal image.
+//
+// In standalone mode, the command reads an OCI image layout (tar or directory)
+// and writes a converted OCI image layout (tar or directory) without requiring containerd.
 var ConvertCommand = &cli.Command{
 	Name:      "convert",
 	Usage:     "convert an OCI image to a SOCI enabled image",
 	ArgsUsage: "[flags] <image_ref> <dest_ref>",
-	Flags:     slices.Concat(internal.PlatformFlags, createZtocFlags, internal.PrefetchFlags),
+	Flags: slices.Concat(
+		internal.PlatformFlags,
+		createZtocFlags,
+		internal.PrefetchFlags,
+		[]cli.Flag{
+			&cli.BoolFlag{
+				Name:  standaloneFlag,
+				Usage: "Run in standalone mode without containerd runtime. In this mode, the command reads an OCI image layout (tar or directory) and writes a converted OCI image layout without requiring a running containerd instance.",
+			},
+			&cli.StringFlag{
+				Name:  outputFormatFlag,
+				Usage: "Output format for standalone mode: oci-archive (tar) or oci-dir (directory).",
+				Value: outputFormatOCIArchive,
+				Validator: func(s string) error {
+					if s != outputFormatOCIArchive && s != outputFormatOCIDir {
+						return fmt.Errorf("unsupported output format %q: must be %q or %q", s, outputFormatOCIArchive, outputFormatOCIDir)
+					}
+					return nil
+				},
+			},
+		}),
 	Action: func(ctx context.Context, cmd *cli.Command) error {
-		srcRef := cmd.Args().Get(0)
-		if srcRef == "" {
+		src := cmd.Args().Get(0)
+		if src == "" {
 			return errors.New("source image needs to be specified")
 		}
 
-		dstRef := cmd.Args().Get(1)
-		if dstRef == "" {
-			return errors.New("destination image needs to be specified")
+		dst := cmd.Args().Get(1)
+		if dst == "" {
+			return errors.New("destination needs to be specified")
 		}
 
-		err := verifyRef(dstRef)
+		if cmd.Bool(standaloneFlag) {
+			return runStandaloneConvert(ctx, cmd, src, dst)
+		}
+
+		err := verifyRef(dst)
 		if err != nil {
 			return fmt.Errorf("%w: %w", ErrInvalidDestRef, err)
-		}
-
-		var optimizations []soci.Optimization
-		for _, o := range cmd.StringSlice(optimizationFlag) {
-			optimization, err := soci.ParseOptimization(o)
-			if err != nil {
-				return err
-			}
-			optimizations = append(optimizations, optimization)
 		}
 
 		client, ctx, cancel, err := internal.NewClient(ctx, cmd)
@@ -97,14 +124,10 @@ var ConvertCommand = &cli.Command{
 
 		cs := client.ContentStore()
 		is := client.ImageService()
-		srcImg, err := is.Get(ctx, srcRef)
+		srcImg, err := is.Get(ctx, src)
 		if err != nil {
 			return err
 		}
-
-		spanSize := cmd.Int64(spanSizeFlag)
-		minLayerSize := cmd.Int64(minLayerSizeFlag)
-		forceRecreateZtocs := cmd.Bool(forceRecreateZtocsFlag)
 
 		blobStore, err := store.NewContentStore(internal.ContentStoreOptions(ctx, cmd)...)
 		if err != nil {
@@ -116,25 +139,13 @@ var ConvertCommand = &cli.Command{
 			return err
 		}
 
-		builderOpts := []soci.BuilderOption{
-			soci.WithMinLayerSize(minLayerSize),
-			soci.WithSpanSize(spanSize),
-			soci.WithBuildToolIdentifier(buildToolIdentifier),
-			soci.WithOptimizations(optimizations),
-			soci.WithArtifactsDb(artifactsDb),
-			soci.WithForceRecreateZtocs(forceRecreateZtocs),
-		}
-
-		allPrefetchFiles, err := internal.ParsePrefetchFiles(cmd)
+		builderOpts, err := parseBuilderOptions(cmd)
 		if err != nil {
-			return fmt.Errorf("failed to parse prefetch files: %w", err)
+			return err
 		}
-		if len(allPrefetchFiles) > 0 {
-			builderOpts = append(builderOpts, soci.WithPrefetchPaths(allPrefetchFiles))
-		}
+		builderOpts = append(builderOpts, soci.WithArtifactsDb(artifactsDb))
 
 		builder, err := soci.NewIndexBuilder(cs, blobStore, builderOpts...)
-
 		if err != nil {
 			return err
 		}
@@ -162,10 +173,10 @@ var ConvertCommand = &cli.Command{
 		}
 
 		im := images.Image{
-			Name:   dstRef,
+			Name:   dst,
 			Target: *desc,
 		}
-		img, err := is.Get(ctx, dstRef)
+		img, err := is.Get(ctx, dst)
 		if err != nil {
 			if !errors.Is(err, errdefs.ErrNotFound) {
 				return err
@@ -178,4 +189,95 @@ var ConvertCommand = &cli.Command{
 
 		return err
 	},
+}
+
+// runStandaloneConvert runs the convert command in standalone mode (without containerd).
+// It reads an OCI image layout (tar or directory), performs the SOCI conversion, and
+// writes the result as an OCI image layout tar or directory based on the --format flag.
+func runStandaloneConvert(ctx context.Context, cmd *cli.Command, inputPath string, outputPath string) error {
+	format := cmd.String(outputFormatFlag)
+
+	ociLayoutDir, err := os.MkdirTemp("", "soci-oci-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(ociLayoutDir)
+
+	imageInfo, err := internal.LoadImage(ctx, inputPath, ociLayoutDir)
+	if err != nil {
+		return err
+	}
+
+	artifactsDir, err := os.MkdirTemp("", "soci-artifacts-*")
+	if err != nil {
+		return fmt.Errorf("failed to create artifacts temp directory: %w", err)
+	}
+	defer os.RemoveAll(artifactsDir)
+
+	artifactsDb, err := soci.NewDB(soci.ArtifactsDbPath(artifactsDir))
+	if err != nil {
+		return fmt.Errorf("failed to create artifacts database: %w", err)
+	}
+
+	builderOpts, err := parseBuilderOptions(cmd)
+	if err != nil {
+		return err
+	}
+	builderOpts = append(builderOpts, soci.WithArtifactsDb(artifactsDb))
+
+	sociStore := &store.SociStore{Store: imageInfo.OrasStore}
+	builder, err := soci.NewIndexBuilder(imageInfo.ContentStore, sociStore, builderOpts...)
+	if err != nil {
+		return err
+	}
+
+	requestedPlatforms, err := internal.GetPlatforms(ctx, cmd, imageInfo.Image, imageInfo.ContentStore)
+	if err != nil {
+		return err
+	}
+
+	batchCtx, done, err := sociStore.BatchOpen(ctx)
+	if err != nil {
+		return err
+	}
+	defer done(ctx)
+
+	convertedDesc, err := builder.Convert(batchCtx, imageInfo.Image, soci.ConvertWithPlatforms(requestedPlatforms...))
+	if err != nil {
+		return err
+	}
+
+	if format == outputFormatOCIDir {
+		return internal.SaveImageToDir(ociLayoutDir, *convertedDesc, outputPath)
+	}
+	return internal.SaveImageToTar(ctx, imageInfo.ContentStore, *convertedDesc, outputPath)
+}
+
+func parseBuilderOptions(cmd *cli.Command) ([]soci.BuilderOption, error) {
+	var optimizations []soci.Optimization
+	for _, o := range cmd.StringSlice(optimizationFlag) {
+		optimization, err := soci.ParseOptimization(o)
+		if err != nil {
+			return nil, err
+		}
+		optimizations = append(optimizations, optimization)
+	}
+
+	builderOpts := []soci.BuilderOption{
+		soci.WithMinLayerSize(cmd.Int64(minLayerSizeFlag)),
+		soci.WithSpanSize(cmd.Int64(spanSizeFlag)),
+		soci.WithBuildToolIdentifier(buildToolIdentifier),
+		soci.WithOptimizations(optimizations),
+		soci.WithForceRecreateZtocs(cmd.Bool(forceRecreateZtocsFlag)),
+	}
+
+	allPrefetchFiles, err := internal.ParsePrefetchFiles(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse prefetch files: %w", err)
+	}
+	if len(allPrefetchFiles) > 0 {
+		builderOpts = append(builderOpts, soci.WithPrefetchPaths(allPrefetchFiles))
+	}
+
+	return builderOpts, nil
 }

--- a/cmd/soci/commands/internal/standalone.go
+++ b/cmd/soci/commands/internal/standalone.go
@@ -1,0 +1,211 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	ctdarchive "github.com/containerd/containerd/archive"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/content/local"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/images/archive"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content/oci"
+)
+
+type StandaloneImageInfo struct {
+	ContentStore content.Store
+	Image        images.Image
+	OrasStore    *oci.Store
+}
+
+// LoadImage loads an OCI image layout (tar or directory) into a writable OCI store
+// and returns image metadata that can be used by IndexBuilder.
+// If inputPath is a directory, it is copied into tmpDir.
+// If inputPath is a tar file, it is extracted as an OCI image layout into tmpDir.
+func LoadImage(ctx context.Context, inputPath string, tmpDir string) (*StandaloneImageInfo, error) {
+	fi, err := os.Stat(inputPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to access input %s: %w", inputPath, err)
+	}
+
+	if fi.IsDir() {
+		if err := os.CopyFS(tmpDir, os.DirFS(inputPath)); err != nil {
+			return nil, fmt.Errorf("failed to copy OCI image layout from %s: %w", inputPath, err)
+		}
+	} else {
+		tarFile, err := os.Open(inputPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open tar %s: %w", inputPath, err)
+		}
+		defer tarFile.Close()
+		if _, err := ctdarchive.Apply(ctx, tmpDir, tarFile); err != nil {
+			return nil, fmt.Errorf("failed to extract OCI tar %s: %w", inputPath, err)
+		}
+	}
+
+	indexData, err := os.ReadFile(filepath.Join(tmpDir, "index.json"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read index.json from %s: %w", inputPath, err)
+	}
+	rootDesc, err := parseRootDescriptor(indexData)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the root descriptor is a manifest list (e.g. from nerdctl save),
+	// resolve it to available platform manifests. This handles partial exports
+	// where the manifest list references all platforms but only a subset of
+	// platform blobs were exported.
+	if images.IsIndexType(rootDesc.MediaType) {
+		rootDesc, err = resolveManifestList(tmpDir, rootDesc)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	orasStore, err := oci.New(tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create writable OCI store: %w", err)
+	}
+
+	contentStore, err := local.NewStore(tmpDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create content store: %w", err)
+	}
+
+	return &StandaloneImageInfo{
+		ContentStore: contentStore,
+		Image:        images.Image{Name: inputPath, Target: rootDesc},
+		OrasStore:    orasStore,
+	}, nil
+}
+
+func SaveImageToTar(ctx context.Context, cs content.Store, desc ocispec.Descriptor, outputTarPath string) error {
+	outFile, err := os.Create(outputTarPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output tar %s: %w", outputTarPath, err)
+	}
+	defer outFile.Close()
+
+	return archive.Export(ctx, cs, outFile,
+		archive.WithManifest(desc),
+		archive.WithSkipDockerManifest(),
+	)
+}
+
+// SaveImageToDir copies the OCI image layout from srcDir to outputPath and writes
+// a clean index.json containing only the given descriptor.
+func SaveImageToDir(srcDir string, desc ocispec.Descriptor, outputPath string) error {
+	if err := os.RemoveAll(outputPath); err != nil {
+		return fmt.Errorf("failed to clean output directory %s: %w", outputPath, err)
+	}
+	if err := os.MkdirAll(outputPath, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory %s: %w", outputPath, err)
+	}
+	if err := os.CopyFS(outputPath, os.DirFS(srcDir)); err != nil {
+		return fmt.Errorf("failed to copy OCI layout to %s: %w", outputPath, err)
+	}
+	indexData, err := json.Marshal(ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{desc},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal index.json: %w", err)
+	}
+	return os.WriteFile(filepath.Join(outputPath, "index.json"), indexData, 0644)
+}
+
+// parseRootDescriptor unmarshals OCI index JSON and returns the manifest descriptor.
+func parseRootDescriptor(indexData []byte) (ocispec.Descriptor, error) {
+	var index ocispec.Index
+	if err := json.Unmarshal(indexData, &index); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to unmarshal index.json: %w", err)
+	}
+	if len(index.Manifests) == 0 {
+		return ocispec.Descriptor{}, errors.New("index.json contains no manifests")
+	}
+	return index.Manifests[0], nil
+}
+
+// resolveManifestList reads a manifest list blob and resolves it based on which
+// platform blobs are actually present in the layout. If all platforms are available,
+// it returns the original manifest list. If only one is available, it returns that
+// platform manifest directly. If multiple (but not all) are available, it writes a
+// filtered manifest list containing only the available platforms. This handles tools
+// like `nerdctl save` that export a manifest list referencing all platforms even when
+// only a subset was pulled.
+func resolveManifestList(layoutDir string, listDesc ocispec.Descriptor) (ocispec.Descriptor, error) {
+	blobPath := filepath.Join(layoutDir, "blobs", listDesc.Digest.Algorithm().String(), listDesc.Digest.Encoded())
+	listData, err := os.ReadFile(blobPath)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to read manifest list blob: %w", err)
+	}
+
+	var manifestList ocispec.Index
+	if err := json.Unmarshal(listData, &manifestList); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to unmarshal manifest list: %w", err)
+	}
+
+	// Find which platform manifests have their blobs present
+	var available []ocispec.Descriptor
+	for _, desc := range manifestList.Manifests {
+		p := filepath.Join(layoutDir, "blobs", desc.Digest.Algorithm().String(), desc.Digest.Encoded())
+		if _, err := os.Stat(p); err == nil {
+			available = append(available, desc)
+		}
+	}
+	if len(available) == 0 {
+		return ocispec.Descriptor{}, errors.New("manifest list contains no manifests with available blobs")
+	}
+
+	// If all platforms are available, keep the original manifest list
+	if len(available) == len(manifestList.Manifests) {
+		return listDesc, nil
+	}
+
+	// If only one platform is available, return it directly as a single manifest
+	if len(available) == 1 {
+		return available[0], nil
+	}
+
+	// Multiple (but not all) platforms available: write a filtered manifest list
+	manifestList.Manifests = available
+	filteredData, err := json.Marshal(manifestList)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to marshal filtered manifest list: %w", err)
+	}
+	filteredDigest := digest.FromBytes(filteredData)
+	filteredPath := filepath.Join(layoutDir, "blobs", filteredDigest.Algorithm().String(), filteredDigest.Encoded())
+	if err := os.WriteFile(filteredPath, filteredData, 0644); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to write filtered manifest list: %w", err)
+	}
+	return ocispec.Descriptor{
+		MediaType: listDesc.MediaType,
+		Digest:    filteredDigest,
+		Size:      int64(len(filteredData)),
+	}, nil
+}

--- a/integration/convert_standalone_test.go
+++ b/integration/convert_standalone_test.go
@@ -1,0 +1,264 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/util/dockershell"
+	"github.com/awslabs/soci-snapshotter/util/testutil"
+	"github.com/containerd/platforms"
+)
+
+func TestStandaloneConvertBasic(t *testing.T) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	imageRef := nginxImage
+	mirrorImg := regConfig.mirror(imageRef)
+	srcRef := mirrorImg.ref
+	srcDigest := getImageDigest(sh, srcRef)
+
+	baseDir, err := testutil.TempDir(sh)
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer sh.X("rm", "-rf", baseDir)
+
+	inputDir := filepath.Join(baseDir, "input")
+	inputTar := filepath.Join(baseDir, "input.tar")
+
+	copyImage(sh, dockerhub(imageRef), mirrorImg)
+
+	exportToOCIDir(sh, srcRef, inputDir)
+	sh.X("tar", "-cf", inputTar, "-C", inputDir, ".")
+
+	testCases := []struct {
+		name   string
+		input  string
+		output string
+		format string
+	}{
+		{"dir-to-tar", inputDir, filepath.Join(baseDir, "dt.tar"), "oci-archive"},
+		{"tar-to-tar", inputTar, filepath.Join(baseDir, "tt.tar"), "oci-archive"},
+		{"dir-to-dir", inputDir, filepath.Join(baseDir, "dd"), "oci-dir"},
+		{"tar-to-dir", inputTar, filepath.Join(baseDir, "td"), "oci-dir"},
+	}
+
+	stopContainerd(t, sh)
+
+	for _, tc := range testCases {
+		sh.X("soci", "convert",
+			"--standalone",
+			"--format", tc.format,
+			"--min-layer-size=0",
+			tc.input,
+			tc.output,
+		)
+	}
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dstRef := srcRef + "-standalone-" + tc.name
+
+			importPath := tc.output
+			if tc.format == "oci-dir" {
+				// ctr images import requires a tar, so tar the directory output first
+				importPath = tc.output + ".tar"
+				sh.X("tar", "-cf", importPath, "-C", tc.output, ".")
+			}
+			sh.X("ctr", "images", "import", "--no-unpack", "--index-name", dstRef, importPath)
+
+			dstDigest := getImageDigest(sh, dstRef)
+			validateConversion(t, sh, srcDigest, dstDigest)
+		})
+	}
+}
+
+func TestStandaloneConvertSpecificPlatform(t *testing.T) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	imageRef := nginxImage
+	mirrorImg := regConfig.mirror(imageRef)
+	platformStr := platforms.Format(mirrorImg.platform)
+
+	srcRef := mirrorImg.ref
+	srcDigest := getImageDigest(sh, srcRef)
+
+	baseDir, err := testutil.TempDir(sh)
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer sh.X("rm", "-rf", baseDir)
+
+	inputDir := filepath.Join(baseDir, "input")
+	outputTar := filepath.Join(baseDir, "output.tar")
+
+	copyImage(sh, dockerhub(imageRef), mirrorImg)
+
+	exportToOCIDir(sh, srcRef, inputDir)
+
+	stopContainerd(t, sh)
+
+	sh.X("soci", "convert",
+		"--standalone",
+		"--platform", platformStr,
+		"--min-layer-size=0",
+		inputDir,
+		outputTar,
+	)
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	dstRef := srcRef + "-standalone-platform"
+	sh.X("ctr", "images", "import", "--no-unpack", "--index-name", dstRef, outputTar)
+
+	dstDigest := getImageDigest(sh, dstRef)
+	validateConversion(t, sh, srcDigest, dstDigest)
+}
+
+func TestStandaloneInvalidConversion(t *testing.T) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	t.Run("nonexistent input", func(t *testing.T) {
+		output, err := sh.CombinedOLog("soci", "convert",
+			"--standalone",
+			"/tmp/nonexistent-input",
+			"/tmp/output.tar",
+		)
+		if err == nil {
+			t.Fatal("expected error for nonexistent input")
+		}
+
+		outputStr := string(output)
+		if !strings.Contains(outputStr, "failed to access input") {
+			t.Fatalf("expected error about failed input access, got: %s", outputStr)
+		}
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		output, err := sh.CombinedOLog("soci", "convert",
+			"--standalone",
+			"--format", "invalid",
+			"/tmp/some-input.tar",
+			"/tmp/output.tar",
+		)
+		if err == nil {
+			t.Fatal("expected error for invalid format")
+		}
+
+		outputStr := string(output)
+		if !strings.Contains(outputStr, "unsupported output format") {
+			t.Fatalf("expected error about unsupported format, got: %s", outputStr)
+		}
+	})
+
+	t.Run("missing destination", func(t *testing.T) {
+		output, err := sh.CombinedOLog("soci", "convert",
+			"--standalone",
+			"/tmp/some-input.tar",
+		)
+		if err == nil {
+			t.Fatal("expected error for missing destination")
+		}
+
+		outputStr := string(output)
+		if !strings.Contains(outputStr, "destination needs to be specified") {
+			t.Errorf("expected error about missing destination, got: %s", outputStr)
+		}
+	})
+}
+
+func TestStandaloneConvertIdempotent(t *testing.T) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	imageRef := nginxImage
+	mirrorImg := regConfig.mirror(imageRef)
+
+	srcRef := mirrorImg.ref
+
+	baseDir, err := testutil.TempDir(sh)
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer sh.X("rm", "-rf", baseDir)
+
+	inputDir := filepath.Join(baseDir, "input")
+	outputTar1 := filepath.Join(baseDir, "output1.tar")
+	outputTar2 := filepath.Join(baseDir, "output2.tar")
+
+	copyImage(sh, dockerhub(imageRef), mirrorImg)
+
+	exportToOCIDir(sh, srcRef, inputDir)
+
+	stopContainerd(t, sh)
+
+	// First conversion
+	sh.X("soci", "convert",
+		"--standalone",
+		"--min-layer-size=0",
+		inputDir,
+		outputTar1,
+	)
+
+	// Second conversion of the already-converted image
+	sh.X("soci", "convert",
+		"--standalone",
+		"--min-layer-size=0",
+		outputTar1,
+		outputTar2,
+	)
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	dstRef1 := srcRef + "-standalone-soci1"
+	dstRef2 := srcRef + "-standalone-soci2"
+	sh.X("ctr", "images", "import", "--no-unpack", "--index-name", dstRef1, outputTar1)
+	sh.X("ctr", "images", "import", "--no-unpack", "--index-name", dstRef2, outputTar2)
+
+	digest1 := getImageDigest(sh, dstRef1)
+	digest2 := getImageDigest(sh, dstRef2)
+
+	if digest1 != digest2 {
+		t.Errorf("converting a SOCI-enabled image should be idempotent, but digests differ: %s vs %s", digest1, digest2)
+	}
+}
+
+func exportToOCIDir(sh *dockershell.Shell, imageRef, outputDir string) {
+	exportTar := outputDir + ".export.tar"
+	sh.X("nerdctl", "save", "-o", exportTar, imageRef)
+	sh.X("mkdir", "-p", outputDir)
+	sh.X("tar", "-xf", exportTar, "-C", outputDir)
+	sh.X("rm", "-f", exportTar)
+}

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -858,6 +858,13 @@ func getReferrers(sh *shell.Shell, regConfig registryConfig, imgName, digest str
 	return &index, nil
 }
 
+func stopContainerd(t *testing.T, sh *shell.Shell) {
+	t.Helper()
+	if err := testutil.KillMatchingProcess(sh, "containerd"); err != nil {
+		sh.Fatal("failed to kill containerd: %v", err)
+	}
+}
+
 func rebootContainerd(t *testing.T, sh *shell.Shell, customContainerdConfig, customSnapshotterConfig string, monitorFuncs ...func(string)) *testutil.LogMonitor {
 	var (
 		containerdRoot    = "/var/lib/containerd"
@@ -867,11 +874,8 @@ func rebootContainerd(t *testing.T, sh *shell.Shell, customContainerdConfig, cus
 	)
 
 	// cleanup directories
-	err := testutil.KillMatchingProcess(sh, "containerd")
-	if err != nil {
-		sh.Fatal("failed to kill containerd: %v", err)
-	}
-	err = testutil.KillMatchingProcess(sh, "soci-snapshotter-grpc")
+	stopContainerd(t, sh)
+	err := testutil.KillMatchingProcess(sh, "soci-snapshotter-grpc")
 	if err != nil {
 		sh.Fatal("failed to kill soci: %v", err)
 	}


### PR DESCRIPTION
**Issue #, if available:**
Closes https://github.com/awslabs/soci-snapshotter/issues/1057

**Description of changes:**
This PR adds standalone mode to the `soci convert` command, enabling SOCI index creation without requiring a running containerd daemon. This is particularly useful for CI/CD pipelines and environments where running containerd is impractical without privileged mode.

  ### Key Features

  - **Standalone Mode (`--standalone`)**: Reads an OCI image layout (tar or directory) from disk, creates SOCI indexes, and writes the converted image back to disk
  - **Output Format (`--format`)**: Supports `oci-archive` (tar, default) and `oci-dir` (directory) output formats
     -  This follows the same convention used by tools like [Podman](https://docs.podman.io/en/latest/markdown/podman-save.1.html) (`--format oci-archive` / `oci-dir`), [Skopeo](https://github.com/containers/skopeo) (`copy oci-archive:` / `oci:`), and [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane_pull.md) using `--format oci` for directory output.

  ### Usage Example


  **Tar output (oci-archive, default):**
```
# Pull an image as OCI layout
crane pull --format oci myregistry.com/myimage:latest /tmp/my-image

# Convert to SOCI-enabled image (tar output)
soci convert --standalone /tmp/my-image /tmp/my-soci-image.tar

# Import into containerd
ctr images import --no-unpack --index-name myregistry.com/myimage:latest-soci /tmp/my-soci-image.tar

--- or push with crane like - (crane only supports dir for oci layout pushing)

mkdir -p /tmp/my-soci-image-dir
tar -xf /tmp/my-soci-image.tar -C /tmp/my-soci-image-dir
crane push /tmp/my-soci-image-dir myregistry.com/myimage:latest-soci
```


  **Directory output (oci-dir):**
  ```
# Pull an image as OCI layout
crane pull --format oci myregistry.com/myimage:latest /tmp/my-image

# Convert to SOCI-enabled image (directory output)
soci convert --standalone --format oci-dir /tmp/my-image /tmp/my-soci-image

# Push back to registry
crane push /tmp/my-soci-image myregistry.com/myimage:latest-soc

```


**Testing performed:**

  -  Added new Integration test and all integration tests pass (TestStandaloneConvert*)
    - Basic conversion with validation (all permutation of input (tar/dir) and output (tar/dir)
    - Specific platform selection (--platform)
    - Error handling (nonexistent images, missing arguments, wrong output format)
    - Idempotency verification
  - Tested on ARM64 architecture (linux/arm64/v8) (lima on macOs)
     - `lima sudo GO_TEST_FLAGS="-run TestStandalone -count=1" make integration`
     - `lima sudo make test`
  - Manual verification of image download, conversion, and push workflow


Standalone Convert with oci-archive output - 
```
crane auth login source-registry.com --username $REPOSITORY --password $TOKEN
crane pull --format oci source-registry.com/myimage:latest /tmp/my-crane-image-dir

sudo ./out/soci convert --standalone /tmp/my-crane-image-dir /tmp/my-soci-image.tar

ztoc skipped - layer sha256:7511aa994dfed5f54c697fcec6db7176449e7d87317b3f6ad093185182ce01c7 (application/vnd.oci.image.layer.v1.tar+gzip) size 3222 is less than min-layer-size 10485760
ztoc skipped - layer sha256:12bb71ceae3401038ce93aa7ce3a115f4a5cb3e9a85277ef4a97718c0fc9298e (application/vnd.oci.image.layer.v1.tar+gzip) size 221568 is less than min-layer-size 10485760
....
layer sha256:3e9c02b40ec11c1a3cc84f775102e2a3b100700fc7753098adc6d62e3fc6563b -> ztoc sha256:0aa198e2f2f6ff02675b7f7dc27e008a1b81bc15a87a5e4d5f868259a3cdc5f0
layer sha256:d8c6b361b623cabb0a89fad4a7d491d7d543f0834ca0c581e0176e1b76a68a15 -> ztoc sha256:ea8f91d2a57139b053186c8a1ae1901684bc06fda5b7d00aef0bd3d6d4e9e4c1



mkdir -p /tmp/my-soci-image-dir
tar -xf /tmp/my-soci-image.tar -C /tmp/my-soci-image-dir
crane push /tmp/my-soci-image-dir dest-registry.com/myimage:latest-soci 

2026/03/01 17:51:41 existing manifest: sha256:fe64b32c84403bd29758342ac0f78a384961bf6788d5de22b9fea1e7c7f1c84a
2026/03/01 17:51:41 existing manifest: sha256:c60d93f19b8a3dd886faa3b455ea809d0055173aa0e501fb0926f196d736a984
2026/03/01 17:51:41 dest-registry.com/myimage:latest-soci : digest: sha256:f265a1fddffc035eb949ac3ff03a597ce4c823b8bde2ae6cb63a0c85f69d0de9 size: 803
dest-registry.com/myimage@sha256:f265a1fddffc035eb949ac3ff03a597ce4c823b8bde2ae6cb63a0c85f69d0de9

```


Standalone Convert with oci-dir output - 

```
sudo ./out/soci convert --standalone /tmp/my-crane-image-dir /tmp/my-soci-image --format oci-dir

ztoc skipped - layer sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 (application/vnd.oci.image.layer.v1.tar+gzip) size 32 is less than min-layer-size 10485760
ztoc skipped - layer sha256:7511aa994dfed5f54c697fcec6db7176449e7d87317b3f6ad093185182ce01c7 (application/vnd.oci.image.layer.v1.tar+gzip) size 3222 is less than min-layer-size 10485760
...
ztoc skipped - layer sha256:f6a26d16afc76b03f36290b56770ae0db2ab11aab759d2c7bd49bdfc865b3b87 (application/vnd.oci.image.layer.v1.tar+gzip) size 10395600 is less than min-layer-size 10485760
ztoc skipped - layer sha256:ef6465a1674b258144bd7eac86347823926436a5d53f100cadfe098c82e4c4d4 (application/vnd.oci.image.layer.v1.tar+gzip) size 78 is less than min-layer-size 10485760


crane push /tmp/my-soci-image dest-registry.com/myimage:latest-soci 
2026/03/01 20:50:51 existing manifest: sha256:fe64b32c84403bd29758342ac0f78a384961bf6788d5de22b9fea1e7c7f1c84a
2026/03/01 20:50:51 existing manifest: sha256:c60d93f19b8a3dd886faa3b455ea809d0055173aa0e501fb0926f196d736a984
2026/03/01 20:50:51 dest-registry.com/myimage:latest-soci : digest: sha256:f265a1fddffc035eb949ac3ff03a597ce4c823b8bde2ae6cb63a0c85f69d0de9 size: 803
dest-registry.com/myimage:@sha256:f265a1fddffc035eb949ac3ff03a597ce4c823b8bde2ae6cb63a0c85f69d0de9
```

Integration tests - 

```
sudo GO_TEST_FLAGS="-run TestStandalone -count=1" make integration

SOCI_SNAPSHOTTER_PROJECT_ROOT=/Volumes/git/prafulg/soci-snapshotter
=== RUN   TestStandaloneConvertBasic
=== RUN   TestStandaloneConvertBasic/dir-to-tar
=== RUN   TestStandaloneConvertBasic/tar-to-tar
=== RUN   TestStandaloneConvertBasic/dir-to-dir
=== RUN   TestStandaloneConvertBasic/tar-to-dir
--- PASS: TestStandaloneConvertBasic (31.63s)
    --- PASS: TestStandaloneConvertBasic/dir-to-tar (2.92s)
    --- PASS: TestStandaloneConvertBasic/tar-to-tar (2.65s)
    --- PASS: TestStandaloneConvertBasic/dir-to-dir (2.71s)
    --- PASS: TestStandaloneConvertBasic/tar-to-dir (2.69s)
=== RUN   TestStandaloneConvertSpecificPlatform
--- PASS: TestStandaloneConvertSpecificPlatform (18.89s)
=== RUN   TestStandaloneInvalidConversion
=== RUN   TestStandaloneInvalidConversion/nonexistent_input
=== RUN   TestStandaloneInvalidConversion/invalid_format
=== RUN   TestStandaloneInvalidConversion/missing_destination
--- PASS: TestStandaloneInvalidConversion (1.19s)
    --- PASS: TestStandaloneInvalidConversion/nonexistent_input (0.02s)
    --- PASS: TestStandaloneInvalidConversion/invalid_format (0.03s)
    --- PASS: TestStandaloneInvalidConversion/missing_destination (0.03s)
=== RUN   TestStandaloneConvertIdempotent
--- PASS: TestStandaloneConvertIdempotent (19.88s)
PASS
ok      github.com/awslabs/soci-snapshotter/integration 193.187s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
