### PR TITLE
Revert "Skip grpc in bump-deps.sh"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,8 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # skip grpc because the current latest not compatible with containerd 1.7
-      # skip k8s deps since they use the latest go version/features that may
-      # not be in the go version soci uses
+      # skip k8s deps since they use the latest go version/features that may not be in the go version soci uses
       # Also ignored in /scripts/bump-deps.sh
-      - dependency-name: "google.golang.org/grpc"
       - dependency-name: "k8s.io/*"
 
   # Automatic upgrade for go modules of cmd package.
@@ -20,12 +17,9 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      # skip grpc because the current latest not compatible with containerd 1.7
-      # skip k8s deps since they use the latest go version/features that may
-      # not be in the go version soci uses
+      # skip k8s deps and soci-snapshotter itself
       # Also ignored in /scripts/bump-deps.sh
       - dependency-name: "github.com/awslabs/soci-snapshotter"
-      - dependency-name: "google.golang.org/grpc"
       - dependency-name: "k8s.io/*"
 
   # Automatic update for base images used in the Dockerfile

--- a/scripts/bump-deps.sh
+++ b/scripts/bump-deps.sh
@@ -22,25 +22,21 @@ SOCI_SNAPSHOTTER_PROJECT_ROOT="${CUR_DIR}/.."
 pushd "${SOCI_SNAPSHOTTER_PROJECT_ROOT}"
 
 # skip k8s deps since they use the latest go version/features that may not be in the go version soci uses
-# skip grpc because it's not compatible with containerd 1.7
 # skip runtime-spec until this issue is resolved: https://github.com/containerd/containerd/issues/12493
 # Also ignored in /dependabot.yml
 # shellcheck disable=SC2046
 go get $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
-    grep -v "^google.golang.org/grpc" | \
     grep -v "^github.com/opencontainers/runtime-spec" | \
     grep -v "^k8s.io/")
 make tidy
 
 pushd ./cmd
 # skip k8s deps and soci-snapshotter itself
-# skip grpc because it's not compatible with containerd 1.7
 # skip runtime-spec until this issue is resolved: https://github.com/containerd/containerd/issues/12493
 # Also ignored in /dependabot.yml
 # shellcheck disable=SC2046
 go get $(go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | \
     grep -v "^github.com/awslabs/soci-snapshotter" | \
-    grep -v "^google.golang.org/grpc" | \
     grep -v "^github.com/opencontainers/runtime-spec" | \
     grep -v "^k8s.io/")
 popd


### PR DESCRIPTION
**Issue #, if available:**
Reverts #826 
In response to #1901

**Description of changes:**
We did this as the latest gRPC at the time was not compatible with the latest containerd at the time. We never left any note for when to revert it so it went unquestioned for years. This undoes this change so we can ensure continued compatibility with the latest gRPC version.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
