### PR TITLE
Invalidate host creds in case of failure and retry

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -164,6 +164,7 @@ type Option func(*options)
 
 type options struct {
 	getSources        source.GetSources
+	invalidateHosts   source.InvalidateHosts
 	resolveHandlers   map[string]remote.Handler
 	metadataStore     metadata.Store
 	overlayOpaqueType layer.OverlayOpaqueType
@@ -174,6 +175,12 @@ type options struct {
 func WithGetSources(s source.GetSources) Option {
 	return func(opts *options) {
 		opts.getSources = s
+	}
+}
+
+func WithInvalidateHosts(f source.InvalidateHosts) Option {
+	return func(opts *options) {
+		opts.invalidateHosts = f
 	}
 }
 
@@ -320,6 +327,7 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 		ctx:                         ctx,
 		resolver:                    r,
 		getSources:                  getSources,
+		invalidateHosts:             fsOpts.invalidateHosts,
 		debug:                       cfg.Debug,
 		layer:                       make(map[string]layer.Layer),
 		disableVerification:         cfg.DisableVerification,
@@ -414,6 +422,7 @@ type filesystem struct {
 	layerMu                     sync.Mutex
 	disableVerification         bool
 	getSources                  source.GetSources
+	invalidateHosts             source.InvalidateHosts
 	metricsController           *layermetrics.Controller
 	attrTimeout                 time.Duration
 	entryTimeout                time.Duration
@@ -1207,31 +1216,42 @@ func (fs *filesystem) check(ctx context.Context, l layer.Layer, labels map[strin
 	}
 	log.G(ctx).WithError(err).Warn("failed to connect to blob")
 
-	// Check failed. Try to refresh the connection with fresh source information
-	src, err := fs.getSources(labels)
-	if err != nil {
-		return err
-	}
-	var (
-		retrynum = 1
-		rErr     = fmt.Errorf("failed to refresh connection")
-	)
-	for retry := 0; retry < retrynum; retry++ {
-		log.G(ctx).Warnf("refreshing(%d)...", retry)
-		for _, s := range src {
-			err := l.Refresh(ctx, s.Hosts, s.Name, s.Target)
-			if err == nil {
-				log.G(ctx).Debug("Successfully refreshed connection")
-				return nil
-			}
-			log.G(ctx).WithError(err).Warnf("failed to refresh the layer %q from %q",
-				s.Target.Digest, s.Name)
-			rErr = fmt.Errorf("failed(layer:%q, ref:%q): %v: %w",
-				s.Target.Digest, s.Name, err, rErr)
-		}
+	// Try to refresh with current (possibly cached) sources.
+	src, err := fs.refreshLayer(ctx, l, labels)
+	if err == nil {
+		return nil
 	}
 
-	return rErr
+	// Invalidate cached registry hosts and retry with fresh credentials.
+	if fs.invalidateHosts != nil {
+		for _, s := range src {
+			fs.invalidateHosts(s.Name.String())
+		}
+		_, err = fs.refreshLayer(ctx, l, labels)
+		return err
+	}
+
+	return err
+}
+
+// refreshLayer fetches sources and attempts to refresh the layer connection.
+// It returns the sources that were tried (for cache invalidation) and any error.
+func (fs *filesystem) refreshLayer(ctx context.Context, l layer.Layer, labels map[string]string) ([]source.Source, error) {
+	src, err := fs.getSources(labels)
+	if err != nil {
+		return nil, err
+	}
+	var errs []error
+	for _, s := range src {
+		if err := l.Refresh(ctx, s.Hosts, s.Name, s.Target); err == nil {
+			return src, nil
+		} else {
+			log.G(ctx).WithError(err).Warnf("failed to refresh the layer %q from %q",
+				s.Target.Digest, s.Name)
+			errs = append(errs, err)
+		}
+	}
+	return src, errors.Join(errs...)
 }
 
 func isIDMappedDir(mountpoint string) bool {

--- a/fs/source/source.go
+++ b/fs/source/source.go
@@ -96,6 +96,10 @@ const (
 // to reduce package dependency
 type RegistryHosts func(imgRefSpec reference.Spec) ([]docker.RegistryHost, error)
 
+// InvalidateHosts invalidates cached registry host configurations for a given
+// image reference, forcing fresh credentials to be fetched on the next request.
+type InvalidateHosts func(ref string)
+
 // FromDefaultLabels returns a function for converting snapshot labels to
 // source information based on labels.
 func FromDefaultLabels(hosts RegistryHosts) GetSources {

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -35,8 +35,16 @@ package integration
 import (
 	"bufio"
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -48,6 +56,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/awslabs/soci-snapshotter/soci/store"
 	shell "github.com/awslabs/soci-snapshotter/util/dockershell"
+	"github.com/awslabs/soci-snapshotter/util/dockershell/compose"
 	"github.com/awslabs/soci-snapshotter/util/testutil"
 )
 
@@ -874,4 +883,236 @@ func TestRunWithIdMap(t *testing.T) {
 			})
 		}
 	}
+}
+
+// TestCredentialRefreshOnCheckFailure verifies that when registry credentials
+// are rotated, the snapshotter recovers by invalidating its cached registry
+// hosts and creating a fresh AuthClient.
+//
+// The test uses Bearer token auth. When the token server password changes,
+// the old AuthClient's docker.Authorizer has a cached Bearer handler that
+// tries to fetch a new token with the OLD password. The token server rejects
+// it. This error occurs inside doBearerAuth/fetchToken — AddResponses is never
+// called, so the handler is never deleted. The Authorizer is stuck.
+//
+// With InvalidateRegistryHosts, the cache is cleared, a fresh Authorizer
+// (with empty handlers map) is created, and on the next 401 from the registry,
+// AddResponses creates a new handler with fresh credentials from docker config.
+func TestCredentialRefreshOnCheckFailure(t *testing.T) {
+	const containerImage = alpineImage
+
+	regConfig := newRegistryConfig()
+	caCertDir := "/usr/local/share/ca-certificates"
+
+	pRoot, err := testutil.GetProjectRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate RSA cert with both registry host and localhost SANs
+	// (localhost needed for token server realm URL).
+	certPEM, keyPEM, err := generateSelfSignedCertMultiSAN(regConfig.host, "localhost")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hostVolumeMount := t.TempDir()
+	authDir := filepath.Join(hostVolumeMount, "auth")
+	if err := os.MkdirAll(authDir, 0777); err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range map[string][]byte{
+		"domain.crt":   certPEM,
+		"domain.key":   keyPEM,
+		"signing.key":  keyPEM,  // same RSA key for token signing
+		"signing.crt":  certPEM, // registry verifies JWTs with this cert
+		"password.txt": []byte(regConfig.pass),
+	} {
+		if err := os.WriteFile(filepath.Join(authDir, name), data, 0666); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+
+	// Build the token server binary for Linux (test containers are Linux).
+	tokenServerSrc := filepath.Join(pRoot, "integration", "tokenserver")
+	tokenServerBin := filepath.Join(authDir, "tokenserver")
+	buildCmd := exec.Command("go", "build", "-o", tokenServerBin, tokenServerSrc)
+	buildCmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build token server: %v\n%s", err, out)
+	}
+
+	// Zot config (unused for registry:3.0.0 but needed by compose template infra).
+	zotDir := filepath.Join(hostVolumeMount, "etc/zot")
+	if err := os.MkdirAll(zotDir, 0777); err != nil {
+		t.Fatal(err)
+	}
+	zotCfg, err := testutil.ApplyTextTemplate(zotConfigTemplate, zotConfigStruct{Address: regConfig.host})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(zotDir, "config.json"), []byte(zotCfg), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	// Custom compose template: registry with Bearer token auth.
+	// The token realm points to localhost:5001 (token server inside testing container).
+	composeTemplate := fmt.Sprintf(`
+services:
+ testing:
+  image: soci_base:soci_test
+  privileged: true
+  init: true
+  entrypoint: [ "/integ_entrypoint.sh" ]
+  environment:
+   - NO_PROXY=127.0.0.1,localhost,%s:443
+   - GOCOVERDIR=/test_coverage
+  tmpfs:
+   - /tmp:exec,mode=777
+   - /var/lib/containerd
+   - /var/lib/soci-snapshotter-grpc
+  volumes:
+   - /dev/fuse:/dev/fuse
+   - {{.ImageContextDir}}/cov/integration:/test_coverage
+   - {{.HostVolumeMount}}/auth:/auth
+ registry:
+  image: {{.RegistryImageRef}}
+  container_name: %s
+  environment:
+   - REGISTRY_AUTH=token
+   - REGISTRY_AUTH_TOKEN_REALM=https://localhost:5001/token
+   - REGISTRY_AUTH_TOKEN_SERVICE=registry
+   - REGISTRY_AUTH_TOKEN_ISSUER=test-issuer
+   - REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE=/auth/signing.crt
+   - REGISTRY_HTTP_TLS_CERTIFICATE=/auth/domain.crt
+   - REGISTRY_HTTP_TLS_KEY=/auth/domain.key
+   - REGISTRY_HTTP_ADDR=%s:443
+   - REGISTRY_STORAGE_DELETE_ENABLED=true
+  volumes:
+   - {{.HostVolumeMount}}/auth:/auth:ro
+   - {{.HostVolumeMount}}/etc/zot/config.json:/etc/zot/config.json:ro
+`, regConfig.host, regConfig.host, regConfig.host)
+
+	reporter := testutil.NewTestingReporter(t)
+	s, err := testutil.ApplyTextTemplate(composeTemplate, dockerComposeYaml{
+		ImageContextDir:  pRoot,
+		RegistryImageRef: "public.ecr.aws/docker/library/registry:2",
+		HostVolumeMount:  hostVolumeMount,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	buildArgs, err := getBuildArgsFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := compose.Up(s,
+		compose.WithBuildArgs(buildArgs...),
+		compose.WithStdio(reporter.Stdout(), reporter.Stderr()))
+	if err != nil {
+		t.Fatalf("compose up failed: %v", err)
+	}
+	defer c.Cleanup()
+	de, ok := c.Get("testing")
+	if !ok {
+		t.Fatal("failed to get testing shell")
+	}
+	sh := shell.New(de, reporter)
+
+	// Install TLS cert.
+	crtPath := filepath.Join(caCertDir, "domain.crt")
+	if err := testutil.WriteFileContents(sh, crtPath, certPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+	sh.X("trust", "anchor", crtPath)
+
+	// Start the token server inside the testing container.
+	// The binary is built on the host and mounted via the auth volume.
+	sh.Gox("/auth/tokenserver",
+		"--addr", ":5001",
+		"--cert", "/auth/domain.crt",
+		"--key", "/auth/domain.key",
+		"--signing-key", "/auth/signing.key",
+		"--password-file", "/auth/password.txt",
+		"--issuer", "test-issuer")
+	// Wait for token server to start.
+	sh.Retry(30, "curl", "-sk", "https://localhost:5001/token")
+
+	// Login to the registry (fetches Bearer token via token server).
+	sh.Retry(100, "nerdctl", "login", "-u", regConfig.user, "-p", regConfig.pass, regConfig.host)
+
+	// check_always forces check() on every Mounts() call.
+	withCheckAlways := func(cfg *config.Config) {
+		cfg.ServiceConfig.FSConfig.BlobConfig.CheckAlways = true
+	}
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, withCheckAlways, withDisableBgFetcher))
+	copyImage(sh, dockerhub(containerImage), regConfig.mirror(containerImage))
+	image := regConfig.mirror(containerImage).ref
+	indexDigest := buildIndex(sh, regConfig.mirror(containerImage), withMinLayerSize(0), withSpanSize(1<<20))
+	sh.X("soci", "push", "--user", regConfig.creds(), regConfig.mirror(containerImage).ref)
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, withCheckAlways, withDisableBgFetcher))
+	sh.X(append(imagePullCmd, "--soci-index-digest", indexDigest, image)...)
+
+	// First run: warms up registryHostMap cache. The docker.Authorizer creates
+	// a Bearer handler that caches the token server credentials internally.
+	sh.X(append(runSociCmd, "--name", "warmup", "--rm", image, "echo", "ok")...)
+
+	// Rotate the token server password.
+	newPass := "rotatedpass"
+	if err := os.WriteFile(filepath.Join(authDir, "password.txt"), []byte(newPass), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	// Login with the new password (updates docker config keychain).
+	sh.X("nerdctl", "login", "-u", regConfig.user, "-p", newPass, regConfig.host)
+
+	// Second run: check() fires. The cached AuthClient's Bearer handler tries
+	// to fetch a token from the token server using the OLD password (baked into
+	// the handler at creation time). The token server rejects it. This error
+	// occurs inside doBearerAuth → fetchToken, so AddResponses is never called
+	// and the handler is never deleted.
+	//
+	// Without InvalidateRegistryHosts: stuck with stale handler → permanent failure.
+	// With InvalidateRegistryHosts: cache cleared → fresh Authorizer → new handler
+	// with new password from docker config → token server accepts → success.
+	_, err = sh.OLog(append(runSociCmd, "--name", "after-rotation", "--rm", image, "echo", "ok")...)
+	if err != nil {
+		t.Fatalf("expected container run to succeed after credential rotation, got: %v", err)
+	}
+}
+
+func generateSelfSignedCertMultiSAN(hosts ...string) (crt, key []byte, _ error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 60)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+	template := x509.Certificate{
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: hosts[0]},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              hosts,
+	}
+	privatekey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, &template, &template, &privatekey.PublicKey, privatekey)
+	if err != nil {
+		return nil, nil, err
+	}
+	certPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert})
+	privBytes, err := x509.MarshalPKCS8PrivateKey(privatekey)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+	return certPem, keyPem, nil
 }

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -1028,13 +1028,19 @@ services:
 
 	// Start the token server inside the testing container.
 	// The binary is built on the host and mounted via the auth volume.
+	// Use short-lived tokens (3s). After expiry, the cached Bearer handler
+	// in docker.Authorizer tries to re-fetch a token from the token server
+	// using the baked-in credentials. If the password has changed, fetchToken
+	// fails inside doBearerAuth — AddResponses is never called, so the handler
+	// is never deleted. The Authorizer is stuck with stale credentials.
 	sh.Gox("/auth/tokenserver",
 		"--addr", ":5001",
 		"--cert", "/auth/domain.crt",
 		"--key", "/auth/domain.key",
 		"--signing-key", "/auth/signing.key",
 		"--password-file", "/auth/password.txt",
-		"--issuer", "test-issuer")
+		"--issuer", "test-issuer",
+		"--token-ttl", "3")
 	// Wait for token server to start.
 	sh.Retry(30, "curl", "-sk", "https://localhost:5001/token")
 
@@ -1056,8 +1062,11 @@ services:
 	sh.X(append(imagePullCmd, "--soci-index-digest", indexDigest, image)...)
 
 	// First run: warms up registryHostMap cache. The docker.Authorizer creates
-	// a Bearer handler that caches the token server credentials internally.
+	// a Bearer handler that caches the token and token server credentials.
 	sh.X(append(runSociCmd, "--name", "warmup", "--rm", image, "echo", "ok")...)
+
+	// Wait for the short-lived token to expire (3s TTL + buffer).
+	sh.X("sleep", "5")
 
 	// Rotate the token server password.
 	newPass := "rotatedpass"
@@ -1068,15 +1077,18 @@ services:
 	// Login with the new password (updates docker config keychain).
 	sh.X("nerdctl", "login", "-u", regConfig.user, "-p", newPass, regConfig.host)
 
-	// Second run: check() fires. The cached AuthClient's Bearer handler tries
-	// to fetch a token from the token server using the OLD password (baked into
-	// the handler at creation time). The token server rejects it. This error
-	// occurs inside doBearerAuth → fetchToken, so AddResponses is never called
-	// and the handler is never deleted.
+	// Second run: check() fires (check_always=true). The cached AuthClient's
+	// docker.Authorizer has a Bearer handler whose token has expired.
+	// doBearerAuth calls fetchToken with the OLD password baked into the
+	// handler's TokenOptions. The token server rejects it. This error occurs
+	// inside doBearerAuth — AddResponses is never called, so the handler is
+	// never deleted. The Authorizer is stuck with stale credentials.
 	//
 	// Without InvalidateRegistryHosts: stuck with stale handler → permanent failure.
-	// With InvalidateRegistryHosts: cache cleared → fresh Authorizer → new handler
-	// with new password from docker config → token server accepts → success.
+	// With InvalidateRegistryHosts: cache cleared → fresh Authorizer → empty
+	// handlers map → first request goes unauthenticated → registry returns 401
+	// Bearer challenge → AddResponses creates new handler with fresh password
+	// from docker config → fetchToken succeeds → container runs.
 	_, err = sh.OLog(append(runSociCmd, "--name", "after-rotation", "--rm", image, "echo", "ok")...)
 	if err != nil {
 		t.Fatalf("expected container run to succeed after credential rotation, got: %v", err)

--- a/integration/tokenserver/main.go
+++ b/integration/tokenserver/main.go
@@ -29,6 +29,7 @@ func main() {
 	passwordFile := flag.String("password-file", "", "File containing accepted password")
 	addr := flag.String("addr", ":5001", "Listen address")
 	issuer := flag.String("issuer", "test-issuer", "Token issuer")
+	tokenTTL := flag.Int("token-ttl", 3600, "Token TTL in seconds")
 	flag.Parse()
 
 	signingKeyPEM, err := os.ReadFile(*signingKeyFile)
@@ -64,7 +65,8 @@ func main() {
 		service := r.URL.Query().Get("service")
 		scope := r.URL.Query().Get("scope")
 
-		token, err := makeToken(signingKey, *issuer, service, user, scope)
+		ttl := time.Duration(*tokenTTL) * time.Second
+		token, err := makeToken(signingKey, *issuer, service, user, scope, ttl)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -73,7 +75,7 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"token":      token,
-			"expires_in": 3600,
+			"expires_in": *tokenTTL,
 			"issued_at":  time.Now().UTC().Format(time.RFC3339),
 		})
 	})
@@ -84,7 +86,7 @@ func main() {
 	}
 }
 
-func makeToken(key *rsa.PrivateKey, issuer, service, subject, scope string) (string, error) {
+func makeToken(key *rsa.PrivateKey, issuer, service, subject, scope string, ttl time.Duration) (string, error) {
 	now := time.Now().UTC()
 
 	var access []map[string]interface{}
@@ -108,7 +110,7 @@ func makeToken(key *rsa.PrivateKey, issuer, service, subject, scope string) (str
 		"iss":    issuer,
 		"sub":    subject,
 		"aud":    service,
-		"exp":    now.Add(time.Hour).Unix(),
+		"exp":    now.Add(ttl).Unix(),
 		"nbf":    now.Add(-time.Second).Unix(),
 		"iat":    now.Unix(),
 		"jti":    fmt.Sprintf("%d", now.UnixNano()),

--- a/integration/tokenserver/main.go
+++ b/integration/tokenserver/main.go
@@ -1,0 +1,160 @@
+// Package main implements a minimal Docker registry token server for integration testing.
+// It validates Basic auth credentials against a password file and issues JWTs
+// compatible with Docker Distribution's token verification.
+package main
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base32"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	certFile := flag.String("cert", "", "TLS certificate file")
+	keyFile := flag.String("key", "", "TLS key file")
+	signingKeyFile := flag.String("signing-key", "", "Token signing key (PEM, RSA)")
+	passwordFile := flag.String("password-file", "", "File containing accepted password")
+	addr := flag.String("addr", ":5001", "Listen address")
+	issuer := flag.String("issuer", "test-issuer", "Token issuer")
+	flag.Parse()
+
+	signingKeyPEM, err := os.ReadFile(*signingKeyFile)
+	if err != nil {
+		log.Fatalf("failed to read signing key: %v", err)
+	}
+	block, _ := pem.Decode(signingKeyPEM)
+	signingKeyRaw, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		log.Fatalf("failed to parse signing key: %v", err)
+	}
+	signingKey := signingKeyRaw.(*rsa.PrivateKey)
+
+	http.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user == "" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="token"`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		currentPass, err := os.ReadFile(*passwordFile)
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if strings.TrimSpace(string(currentPass)) != pass {
+			w.Header().Set("WWW-Authenticate", `Basic realm="token"`)
+			http.Error(w, "bad credentials", http.StatusUnauthorized)
+			return
+		}
+
+		service := r.URL.Query().Get("service")
+		scope := r.URL.Query().Get("scope")
+
+		token, err := makeToken(signingKey, *issuer, service, user, scope)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"token":      token,
+			"expires_in": 3600,
+			"issued_at":  time.Now().UTC().Format(time.RFC3339),
+		})
+	})
+
+	log.Printf("token server listening on %s", *addr)
+	if err := http.ListenAndServeTLS(*addr, *certFile, *keyFile, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func makeToken(key *rsa.PrivateKey, issuer, service, subject, scope string) (string, error) {
+	now := time.Now().UTC()
+
+	var access []map[string]interface{}
+	if scope != "" {
+		parts := strings.SplitN(scope, ":", 3)
+		if len(parts) == 3 {
+			access = append(access, map[string]interface{}{
+				"type":    parts[0],
+				"name":    parts[1],
+				"actions": strings.Split(parts[2], ","),
+			})
+		}
+	}
+
+	header := map[string]interface{}{
+		"typ": "JWT",
+		"alg": "RS256",
+		"kid": keyID(&key.PublicKey),
+	}
+	claims := map[string]interface{}{
+		"iss":    issuer,
+		"sub":    subject,
+		"aud":    service,
+		"exp":    now.Add(time.Hour).Unix(),
+		"nbf":    now.Add(-time.Second).Unix(),
+		"iat":    now.Unix(),
+		"jti":    fmt.Sprintf("%d", now.UnixNano()),
+		"access": access,
+	}
+
+	hdr, err := encodeJSON(header)
+	if err != nil {
+		return "", err
+	}
+	clm, err := encodeJSON(claims)
+	if err != nil {
+		return "", err
+	}
+
+	payload := hdr + "." + clm
+	hash := sha256.Sum256([]byte(payload))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hash[:])
+	if err != nil {
+		return "", err
+	}
+
+	return payload + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+func encodeJSON(v interface{}) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// keyID generates a Key ID matching Docker Distribution's libtrust format:
+// base32(SHA256(DER(pubkey))[:30]) formatted as XXXX:XXXX:XXXX:...
+func keyID(pub *rsa.PublicKey) string {
+	der, _ := x509.MarshalPKIXPublicKey(pub)
+	hash := sha256.Sum256(der)
+	s := strings.TrimRight(base32.StdEncoding.EncodeToString(hash[:30]), "=")
+	var groups []string
+	for i := 0; i < len(s); i += 4 {
+		end := i + 4
+		if end > len(s) {
+			end = len(s)
+		}
+		groups = append(groups, s[i:end])
+	}
+	return strings.Join(groups, ":")
+}

--- a/service/resolver/registry.go
+++ b/service/resolver/registry.go
@@ -178,6 +178,12 @@ func (rm *RegistryManager) AsRegistryHosts() RegistryHosts {
 	}
 }
 
+// InvalidateRegistryHosts removes cached registry host configurations for the
+// given image reference, forcing a fresh AuthClient to be created on the next request.
+func (rm *RegistryManager) InvalidateRegistryHosts(ref string) {
+	rm.registryHostMap.Delete(ref)
+}
+
 // multiCredsFuncs joins a list of credential functions into a single credential function.
 //
 // Note: We close over an image reference so that our invdidual credential providers

--- a/service/resolver/registry_test.go
+++ b/service/resolver/registry_test.go
@@ -1,0 +1,97 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package resolver
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/containerd/containerd/reference"
+)
+
+func TestRegistryHostsCachesAndReturnsHosts(t *testing.T) {
+	cred := func(_ reference.Spec, _ string) (string, string, error) {
+		return "user", "pass1", nil
+	}
+	rm := NewRegistryManager(config.RetryableHTTPClientConfig{}, config.ResolverConfig{}, []Credential{cred})
+	hosts := rm.AsRegistryHosts()
+	ref, _ := reference.Parse("docker.io/library/alpine:latest")
+
+	h1, err := hosts(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := hosts(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Cached — same slice returned.
+	if &h1[0] != &h2[0] {
+		t.Fatal("expected cached hosts")
+	}
+}
+
+func TestInvalidateRegistryHostsForcesFreshHosts(t *testing.T) {
+	var version atomic.Int32
+	version.Store(1)
+	cred := func(_ reference.Spec, _ string) (string, string, error) {
+		return "user", string(rune('0' + version.Load())), nil
+	}
+	rm := NewRegistryManager(config.RetryableHTTPClientConfig{}, config.ResolverConfig{}, []Credential{cred})
+	hosts := rm.AsRegistryHosts()
+	ref, _ := reference.Parse("docker.io/library/alpine:latest")
+
+	h1, err := hosts(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rotate credentials.
+	version.Store(2)
+
+	// Without invalidation — still returns cached (stale) hosts.
+	h2, err := hosts(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if &h1[0] != &h2[0] {
+		t.Fatal("expected stale cached hosts without invalidation")
+	}
+
+	// Invalidate.
+	rm.InvalidateRegistryHosts(ref.String())
+
+	// After invalidation — returns fresh hosts (new AuthClient).
+	h3, err := hosts(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if &h1[0] == &h3[0] {
+		t.Fatal("expected fresh hosts after invalidation, got cached")
+	}
+}
+
+func TestInvalidateIsNoOpForUnknownRef(t *testing.T) {
+	cred := func(_ reference.Spec, _ string) (string, string, error) {
+		return "user", "pass", nil
+	}
+	rm := NewRegistryManager(config.RetryableHTTPClientConfig{}, config.ResolverConfig{}, []Credential{cred})
+
+	// Invalidating a ref that was never cached should not panic.
+	rm.InvalidateRegistryHosts("docker.io/library/nonexistent:latest")
+}

--- a/service/service.go
+++ b/service/service.go
@@ -87,8 +87,11 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	registryConfig := serviceCfg.ResolverConfig
 
 	hosts := sOpts.registryHosts
+	var invalidateHosts source.InvalidateHosts
 	if hosts == nil {
-		hosts = resolver.NewRegistryManager(httpConfig, registryConfig, sOpts.credsFuncs).AsRegistryHosts()
+		rm := resolver.NewRegistryManager(httpConfig, registryConfig, sOpts.credsFuncs)
+		hosts = rm.AsRegistryHosts()
+		invalidateHosts = rm.InvalidateRegistryHosts
 	}
 	userxattr, err := overlayutils.NeedsUserXAttr(snapshotterRoot(root))
 	if err != nil {
@@ -101,6 +104,7 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	// Configure filesystem and snapshotter
 	getSources := source.FromDefaultLabels(source.RegistryHosts(hosts)) // provides source info based on default labels
 	fsOpts := append(sOpts.fsOpts, socifs.WithGetSources(getSources),
+		socifs.WithInvalidateHosts(invalidateHosts),
 		socifs.WithOverlayOpaqueType(opq),
 		socifs.WithPullModes(serviceCfg.PullModes),
 	)


### PR DESCRIPTION
**Issue #, if available:**

Related to https://github.com/awslabs/soci-snapshotter/issues/1924
Disclaimer - Coded by AI

**Description of changes:**

**Testing performed:**

 Proof:
  - InvalidateRegistryHosts is real → integration test PASSES (container runs after credential rotation)
  - InvalidateRegistryHosts is no-op → integration test FAILS with layer "5" unavailable: unavailable (exact same error as your production issue)

The mechanism: Short-lived Bearer tokens expire → docker.Authorizer's cached handler tries fetchToken with old password baked in TokenOptions → token server rejects → error inside doBearerAuth (before AddResponses) → handler never deleted → Authorizer stuck → our fix invalidates the registryHostMap → fresh Authorizer with empty handlers → re-authenticates with new password from docker config → works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
