### PR TITLE
Add errorlint rule to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - revive
     - staticcheck
     - unconvert
+    - errorlint
   settings:
     staticcheck:
       checks:

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -40,6 +40,7 @@ package cache
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -185,7 +186,7 @@ func testBlob(t *testing.T, c BlobCache, key string, offset int64, sample string
 		t.Errorf("missed %v", key)
 		return
 	}
-	if n, err := r.ReadAt(p, offset); err != nil && err != io.EOF {
+	if n, err := r.ReadAt(p, offset); err != nil && !errors.Is(err, io.EOF) {
 		t.Errorf("failed to fetch blob %q: %v", key, err)
 		return
 	} else if n != len(sample) {

--- a/config/config.go
+++ b/config/config.go
@@ -119,7 +119,7 @@ func NewConfigFromToml(cfgPath string) (*Config, error) {
 func parseConfig(cfg *Config, cfgParsers []configParser) error {
 	for _, p := range cfgParsers {
 		if err := p(cfg); err != nil {
-			return fmt.Errorf("failed to parse config: %v", err)
+			return fmt.Errorf("failed to parse config: %w", err)
 		}
 	}
 	return nil

--- a/config/parallel.go
+++ b/config/parallel.go
@@ -94,7 +94,7 @@ func parseSize(sizeStr string) (int64, error) {
 	numStr, unitStr := matches[1], strings.ToLower(strings.TrimSpace(matches[4]))
 	num, err := strconv.ParseFloat(numStr, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse size number: %v", err)
+		return 0, fmt.Errorf("failed to parse size number: %w", err)
 	}
 
 	multiplier, ok := unitMultipliers[unitStr]

--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -150,7 +150,7 @@ func GetContentWithRange(ctx context.Context, realURL string, rt http.RoundTripp
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusPartialContent {
 		return resp, nil
 	}
-	return nil, fmt.Errorf("error getting range: %v", err)
+	return nil, fmt.Errorf("error getting range: %w", err)
 }
 
 // FetchRange returns the response body of the range requested.
@@ -179,17 +179,21 @@ func (r *orasBlobStore) FetchRange(ctx context.Context, reference string, lower,
 }
 
 func cleanFetchErrors(err error) error {
-	switch retErr := err.(type) {
-	// Redact URLs from ORAS errors, as they might have sensitive info cached
-	case *errcode.ErrorResponse:
-		socihttp.RedactHTTPQueryValuesFromURL(retErr.URL)
-		return retErr
-	// Eat URL errors as a malformed URL might still have credentials.
-	case *url.Error:
-		return errors.New("URL error during fetch")
-	// Otherwise it should be safe to print
-	default:
-		return err
+	{
+		var retErr *errcode.ErrorResponse
+		var retErr1 *url.Error
+		switch {
+		// Redact URLs from ORAS errors, as they might have sensitive info cached
+		case errors.As(err, &retErr):
+			socihttp.RedactHTTPQueryValuesFromURL(retErr.URL)
+			return retErr
+		// Eat URL errors as a malformed URL might still have credentials.
+		case errors.As(err, &retErr1):
+			return errors.New("URL error during fetch")
+		// Otherwise it should be safe to print
+		default:
+			return err
+		}
 	}
 }
 
@@ -206,7 +210,7 @@ func (r *orasBlobStore) doInitialFetch(ctx context.Context, reference string) (b
 	url := sociremote.CraftBlobURL(reference, ref)
 	resp, err := sociremote.GetHeaderWithGet(ctx, url, tr)
 	if err != nil {
-		return false, fmt.Errorf("error getting header info: %v", err)
+		return false, fmt.Errorf("error getting header info: %w", err)
 
 	}
 	socihttp.Drain(resp.Body)

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -479,7 +479,7 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 	}
 	diffIDMap, err := fs.getDiffIDMap(ctx, manifest)
 	if err != nil {
-		return fmt.Errorf("error getting uncompressed shasums for image %s: %v", desc.Digest, err)
+		return fmt.Errorf("error getting uncompressed shasums for image %s: %w", desc.Digest, err)
 	}
 
 	ns, ok := namespaces.Namespace(ctx)
@@ -644,7 +644,7 @@ func (fs *filesystem) rebase(ctx context.Context, dgst digest.Digest, imageDiges
 			}
 
 			_, err = f.Readdirnames(1)
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				// If mountpoint is not empty, refuse to rebase to location
 				f.Close()
 				if err == nil {
@@ -684,7 +684,7 @@ func (fs *filesystem) getDiffIDMap(ctx context.Context, imageManifest *ocispec.M
 	imgConfig := ocispec.Image{}
 	err = json.Unmarshal(buf, &imgConfig)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling image config JSON: %v", err)
+		return nil, fmt.Errorf("error unmarshalling image config JSON: %w", err)
 	}
 
 	uncompressedShas := imgConfig.RootFS.DiffIDs
@@ -793,7 +793,7 @@ func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels 
 	}
 	diffIDMap, err := fs.getDiffIDMap(ctx, manifest)
 	if err != nil {
-		return fmt.Errorf("error getting uncompressed shasums for image %s: %v", desc.Digest, err)
+		return fmt.Errorf("error getting uncompressed shasums for image %s: %w", desc.Digest, err)
 	}
 	uncompressedDigest, ok := diffIDMap[desc.Digest.String()]
 	if !ok {
@@ -1226,7 +1226,7 @@ func (fs *filesystem) check(ctx context.Context, l layer.Layer, labels map[strin
 			}
 			log.G(ctx).WithError(err).Warnf("failed to refresh the layer %q from %q",
 				s.Target.Digest, s.Name)
-			rErr = fmt.Errorf("failed(layer:%q, ref:%q): %v: %w",
+			rErr = fmt.Errorf("failed(layer:%q, ref:%q): %w: %w",
 				s.Target.Digest, s.Name, err, rErr)
 		}
 	}

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -350,7 +350,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, ref
 
 	spanManager, err := spanmanager.New(ztoc, sr, spanCache, r.config.BlobConfig.MaxSpanVerificationRetries, cache.Direct())
 	if err != nil {
-		return nil, fmt.Errorf("error creating span manager: %v", err)
+		return nil, fmt.Errorf("error creating span manager: %w", err)
 	}
 	var bgLayerResolver backgroundfetcher.Resolver
 	if r.bgFetcher != nil {

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -355,7 +355,7 @@ func (n *node) readdir() ([]fuse.DirEntry, syscall.Errno) {
 		})
 		return true
 	}); err != nil || lastErr != nil {
-		n.fs.reportFailure(fuseOpReaddir, fmt.Errorf("%s: err = %v; lastErr = %v", fuseOpReaddir, err, lastErr))
+		n.fs.reportFailure(fuseOpReaddir, fmt.Errorf("%s: err = %w; lastErr = %w", fuseOpReaddir, err, lastErr))
 		return nil, syscall.EIO
 	}
 
@@ -364,7 +364,7 @@ func (n *node) readdir() ([]fuse.DirEntry, syscall.Errno) {
 		if !normalEnts[w[len(whiteoutPrefix):]] {
 			ino, err := n.fs.inodeOfID(id)
 			if err != nil {
-				n.fs.reportFailure(fuseOpReaddir, fmt.Errorf("%s: err = %v; lastErr = %v", fuseOpReaddir, err, lastErr))
+				n.fs.reportFailure(fuseOpReaddir, fmt.Errorf("%s: err = %w; lastErr = %w", fuseOpReaddir, err, lastErr))
 				return nil, syscall.EIO
 			}
 			ents = append(ents, fuse.DirEntry{
@@ -410,14 +410,14 @@ func (n *node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fu
 		case *node:
 			ino, err := n.fs.inodeOfID(tn.id)
 			if err != nil {
-				n.fs.reportFailure(fuseOpLookup, fmt.Errorf("%s: %v", fuseOpLookup, err))
+				n.fs.reportFailure(fuseOpLookup, fmt.Errorf("%s: %w", fuseOpLookup, err))
 				return nil, syscall.EIO
 			}
 			n.entryToAttr(ino, tn.attr, &out.Attr)
 		case *whiteout:
 			ino, err := n.fs.inodeOfID(tn.id)
 			if err != nil {
-				n.fs.reportFailure(fuseOpLookup, fmt.Errorf("%s: %v", fuseOpLookup, err))
+				n.fs.reportFailure(fuseOpLookup, fmt.Errorf("%s: %w", fuseOpLookup, err))
 				return nil, syscall.EIO
 			}
 			n.entryToAttr(ino, tn.attr, &out.Attr)
@@ -450,7 +450,7 @@ func (n *node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fu
 		if whID, wh, err := n.fs.r.Metadata().GetChild(n.id, fmt.Sprintf("%s%s", whiteoutPrefix, name)); err == nil {
 			ino, err := n.fs.inodeOfID(whID)
 			if err != nil {
-				n.fs.reportFailure(fuseOpLookup, fmt.Errorf("%s: %v", fuseOpLookup, err))
+				n.fs.reportFailure(fuseOpLookup, fmt.Errorf("%s: %w", fuseOpLookup, err))
 				return nil, syscall.EIO
 			}
 			return n.NewInode(ctx, &whiteout{
@@ -465,7 +465,7 @@ func (n *node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fu
 
 	ino, err := n.fs.inodeOfID(id)
 	if err != nil {
-		n.fs.reportFailure(fuseOpLookup, fmt.Errorf("%s: %v", fuseOpLookup, err))
+		n.fs.reportFailure(fuseOpLookup, fmt.Errorf("%s: %w", fuseOpLookup, err))
 		return nil, syscall.EIO
 	}
 	return n.NewInode(ctx, &node{
@@ -483,7 +483,7 @@ func (n *node) Open(ctx context.Context, flags uint32) (fh fusefs.FileHandle, fu
 
 	ra, err := n.fs.r.OpenFile(n.id)
 	if err != nil {
-		n.fs.reportFailure(fuseOpOpen, fmt.Errorf("%s: %v", fuseOpOpen, err))
+		n.fs.reportFailure(fuseOpOpen, fmt.Errorf("%s: %w", fuseOpOpen, err))
 		return nil, 0, syscall.EIO
 	}
 	return &file{
@@ -499,7 +499,7 @@ func (n *node) Getattr(ctx context.Context, f fusefs.FileHandle, out *fuse.AttrO
 
 	ino, err := n.fs.inodeOfID(n.id)
 	if err != nil {
-		n.fs.reportFailure(fuseOpGetattr, fmt.Errorf("%s: %v", fuseOpGetattr, err))
+		n.fs.reportFailure(fuseOpGetattr, fmt.Errorf("%s: %w", fuseOpGetattr, err))
 		return syscall.EIO
 	}
 	n.entryToAttr(ino, n.attr, &out.Attr)
@@ -585,7 +585,7 @@ func (f *file) Read(ctx context.Context, dest []byte, off int64) (fuse.ReadResul
 	defer commonmetrics.IncOperationCount(commonmetrics.SynchronousReadCount, f.n.fs.layerDigest)                   // increment the counter for synchronous file reads
 	n, err := f.ra.ReadAt(dest, off)
 	if err != nil && err != io.EOF {
-		f.n.fs.reportFailure(fuseOpFileRead, fmt.Errorf("%s: %v", fuseOpFileRead, err))
+		f.n.fs.reportFailure(fuseOpFileRead, fmt.Errorf("%s: %w", fuseOpFileRead, err))
 		return nil, syscall.EIO
 	}
 	return fuse.ReadResultData(dest[:n]), 0
@@ -598,7 +598,7 @@ func (f *file) Getattr(ctx context.Context, out *fuse.AttrOut) syscall.Errno {
 
 	ino, err := f.n.fs.inodeOfID(f.n.id)
 	if err != nil {
-		f.n.fs.reportFailure(fuseOpFileGetattr, fmt.Errorf("%s: %v", fuseOpFileGetattr, err))
+		f.n.fs.reportFailure(fuseOpFileGetattr, fmt.Errorf("%s: %w", fuseOpFileGetattr, err))
 		return syscall.EIO
 	}
 	f.n.entryToAttr(ino, f.n.attr, &out.Attr)
@@ -620,7 +620,7 @@ func (w *whiteout) Getattr(ctx context.Context, f fusefs.FileHandle, out *fuse.A
 
 	ino, err := w.fs.inodeOfID(w.id)
 	if err != nil {
-		w.fs.reportFailure(fuseOpWhiteoutGetattr, fmt.Errorf("%s: %v", fuseOpWhiteoutGetattr, err))
+		w.fs.reportFailure(fuseOpWhiteoutGetattr, fmt.Errorf("%s: %w", fuseOpWhiteoutGetattr, err))
 		return syscall.EIO
 	}
 	entryToWhAttr(ino, w.attr, &out.Attr)
@@ -742,7 +742,7 @@ func (sf *statFile) Read(ctx context.Context, f fusefs.FileHandle, dest []byte, 
 		return nil, syscall.EIO
 	}
 	n, err := bytes.NewReader(st).ReadAt(dest, off)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, syscall.EIO
 	}
 	return fuse.ReadResultData(dest[:n]), 0

--- a/fs/layer/util_test.go
+++ b/fs/layer/util_test.go
@@ -709,7 +709,7 @@ func getDirentAndNode(t *testing.T, root *node, path string) (ent fuse.DirEntry,
 		}
 		di, errno := d.Lookup(ctx, name, &eo)
 		if errno != 0 {
-			err = fmt.Errorf("failed to lookup directory %q: %v", name, errno)
+			err = fmt.Errorf("failed to lookup directory %q: %w", name, errno)
 			return
 		}
 		var ok bool
@@ -723,7 +723,7 @@ func getDirentAndNode(t *testing.T, root *node, path string) (ent fuse.DirEntry,
 	// get the target's direntry.
 	ents, errno := d.Readdir(ctx)
 	if errno != 0 {
-		err = fmt.Errorf("failed to open directory %q: %v", path, errno)
+		err = fmt.Errorf("failed to open directory %q: %w", path, errno)
 	}
 	ent, ok := hasEntry(t, base, ents)
 	if !ok {
@@ -733,7 +733,7 @@ func getDirentAndNode(t *testing.T, root *node, path string) (ent fuse.DirEntry,
 	// get the target's node.
 	n, errno = d.Lookup(ctx, base, &eo)
 	if errno != 0 {
-		err = fmt.Errorf("failed to lookup node %q: %v", path, errno)
+		err = fmt.Errorf("failed to lookup node %q: %w", path, errno)
 	}
 
 	return

--- a/fs/parallel_artifact_fetcher.go
+++ b/fs/parallel_artifact_fetcher.go
@@ -210,7 +210,7 @@ func (f *parallelArtifactFetcher) oneRequestFetchWrite(ctx context.Context, desc
 
 	rc, err := f.remoteStore.Fetch(ctx, desc)
 	if err != nil {
-		return fmt.Errorf("error fetching from remote: %v", err)
+		return fmt.Errorf("error fetching from remote: %w", err)
 	}
 	return writeToEntireFile(file, rc)
 }

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -41,6 +41,7 @@ package reader
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -119,7 +120,7 @@ func testFileReadAt(t *testing.T, factory metadata.Store) {
 								// data we want to get.
 								wantData := make([]byte, wantN)
 								_, err := want.ReadAt(wantData, offset)
-								if err != nil && err != io.EOF {
+								if err != nil && !errors.Is(err, io.EOF) {
 									t.Fatalf("want.ReadAt (offset=%d,size=%d): %v", offset, wantN, err)
 								}
 
@@ -130,7 +131,7 @@ func testFileReadAt(t *testing.T, factory metadata.Store) {
 								// read the file
 								respData := make([]byte, size)
 								n, err := f.ReadAt(respData, offset)
-								if err != nil && err != io.EOF {
+								if err != nil && !errors.Is(err, io.EOF) {
 									t.Fatalf("failed to read off=%d, size=%d, filesize=%d: %v", offset, size, filesize, err)
 								}
 								respData = respData[:n]
@@ -244,7 +245,7 @@ func testFailReader(t *testing.T, factory metadata.Store) {
 			// tests for reading file
 			p := make([]byte, len(sampleData1))
 			n, err := fr.ReadAt(p, 0)
-			if (err != nil && err != io.EOF) || n != len(sampleData1) || !bytes.Equal([]byte(sampleData1), p) {
+			if (err != nil && !errors.Is(err, io.EOF)) || n != len(sampleData1) || !bytes.Equal([]byte(sampleData1), p) {
 				t.Errorf("failed to read data but wanted to succeed: %v", err)
 			}
 		})

--- a/fs/remote/blob.go
+++ b/fs/remote/blob.go
@@ -40,6 +40,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -240,7 +241,7 @@ func (b *blob) fetchRegion(reg region, w io.Writer, fetched bool, opts *options)
 
 	for {
 		_, p, err := mr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return fmt.Errorf("failed to read multipart resp: %w", err)

--- a/fs/remote/blob_test.go
+++ b/fs/remote/blob_test.go
@@ -40,6 +40,7 @@ package remote
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -165,7 +166,7 @@ func TestFailReadAt(t *testing.T) {
 	r := makeTestBlob(t, int64(len(sampleData1)), failRoundTripper())
 	respData := make([]byte, len(sampleData1))
 	_, err := r.ReadAt(respData, 0)
-	if err == nil || err == io.EOF {
+	if err == nil || errors.Is(err, io.EOF) {
 		t.Errorf("must be fail for http failure but err=%v", err)
 		return
 	}
@@ -196,7 +197,7 @@ func checkBrokenBody(t *testing.T, allowMultiRange bool) {
 func checkBrokenHeader(t *testing.T, allowMultiRange bool) {
 	r := makeTestBlob(t, int64(len(sampleData1)), brokenHeaderRoundTripper(t, []byte(sampleData1), allowMultiRange))
 	respData := make([]byte, len(sampleData1))
-	if _, err := r.ReadAt(respData[0:len(sampleData1)/2], 0); err == nil || err == io.EOF {
+	if _, err := r.ReadAt(respData[0:len(sampleData1)/2], 0); err == nil || errors.Is(err, io.EOF) {
 		t.Errorf("must be fail for broken multipart header but err=%v (allowMultiRange=%v)", err, allowMultiRange)
 		return
 	}

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -396,7 +396,7 @@ func (m *SpanManager) fetchSpanWithRetries(spanID compression.SpanID) ([]byte, e
 		n, err = m.r.ReadAt(compressedBuf, int64(offset))
 		// if the n = len(p) bytes returned by ReadAt are at the end of the input source,
 		// ReadAt may return either err == EOF or err == nil: https://pkg.go.dev/io#ReaderAt
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return []byte{}, err
 		}
 

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -109,7 +109,7 @@ func TestSpanManager(t *testing.T) {
 				return
 			}
 
-			if tc.expectedError == ErrIncorrectMaxSpanID {
+			if errors.Is(tc.expectedError, ErrIncorrectMaxSpanID) {
 				toc.MaxSpanID++
 			}
 
@@ -198,7 +198,7 @@ func TestSpanManagerCache(t *testing.T) {
 				t.Fatalf("error resolving span from cache")
 			}
 			spanContent, err := io.ReadAll(spanR)
-			if err != nil && err != io.EOF {
+			if err != nil && !errors.Is(err, io.EOF) {
 				t.Fatalf("error reading span content")
 			}
 			if tc.size != compression.Offset(len(spanContent)) {

--- a/fs/unpacker.go
+++ b/fs/unpacker.go
@@ -169,7 +169,7 @@ func AsyncTeeReader(r io.Reader, w io.WriteCloser, bp *bufferPool) io.Reader {
 				_, err = pw.Write((*b)[:n])
 			}
 			if err != nil {
-				if err != io.EOF {
+				if !errors.Is(err, io.EOF) {
 					pw.CloseWithError(err)
 				} else {
 					pw.Close()

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -410,7 +410,7 @@ func TestSociCreateGarbageCollection(t *testing.T) {
 	sh.X(append(imagePullCmd, "--soci-index-digest", indexDigest, imgInfo.ref)...)
 	curlOutput := string(sh.O("curl", tcpMetricsAddress+metricsPath))
 	if err := checkOverlayFallbackCount(curlOutput, 0); err != nil {
-		t.Fatal(fmt.Errorf("resources unexpectedly garbage collected: %v", err))
+		t.Fatal(fmt.Errorf("resources unexpectedly garbage collected: %w", err))
 	}
 }
 

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -393,7 +393,7 @@ func buildIndexByManipulatingZtocData(sh *shell.Shell, indexDigest string, manip
 
 		newZtocReader, newZtocDesc, err := ztoc.Marshal(zt)
 		if err != nil {
-			return "", fmt.Errorf("unable to marshal ztoc %s: %s", newZtocDesc.Digest.String(), err)
+			return "", fmt.Errorf("unable to marshal ztoc %s: %w", newZtocDesc.Digest.String(), err)
 		}
 		err = testutil.InjectContentStoreContentFromReader(sh, config.DefaultContentStoreType, indexDigest, newZtocDesc, newZtocReader)
 		if err != nil {

--- a/integration/util_soci_test.go
+++ b/integration/util_soci_test.go
@@ -281,7 +281,7 @@ func sociIndexFromDigest(sh *shell.Shell, indexDigest string) (index soci.Index,
 		return
 	}
 	if err = soci.UnmarshalIndex(rawSociIndexJSON, &index); err != nil {
-		err = fmt.Errorf("invalid soci index from digest %s: %s", indexDigest, err)
+		err = fmt.Errorf("invalid soci index from digest %s: %w", indexDigest, err)
 	}
 	return
 }

--- a/integration/ztoc_test.go
+++ b/integration/ztoc_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -401,7 +402,7 @@ func TestSociZtocGetFile(t *testing.T) {
 						var contents []byte
 						for {
 							h, err := tarReader.Next()
-							if err == io.EOF {
+							if errors.Is(err, io.EOF) {
 								break
 							}
 							if h.Name == f {

--- a/internal/archive/compression/compression.go
+++ b/internal/archive/compression/compression.go
@@ -234,7 +234,7 @@ func cmdStream(cmd *exec.Cmd, in io.Reader) (io.ReadCloser, error) {
 
 	go func() {
 		if err := cmd.Wait(); err != nil {
-			writer.CloseWithError(fmt.Errorf("%s: %s", err, errBuf.String()))
+			writer.CloseWithError(fmt.Errorf("%w: %s", err, errBuf.String()))
 		} else {
 			writer.Close()
 		}

--- a/service/keychain/kubeconfig/kubeconfig.go
+++ b/service/keychain/kubeconfig/kubeconfig.go
@@ -249,7 +249,7 @@ func (kc *keychain) processNextItem() bool {
 
 	obj, exists, err := kc.informer.GetIndexer().GetByKey(key.(string))
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("failed to get object; don't sync %q: %v", key, err))
+		utilruntime.HandleError(fmt.Errorf("failed to get object; don't sync %q: %w", key, err))
 		return true
 	}
 	if !exists {
@@ -267,7 +267,7 @@ func (kc *keychain) processNextItem() bool {
 	}
 	configFile := dcfile.New("")
 	if err := configFile.LoadFromReader(bytes.NewReader(data)); err != nil {
-		utilruntime.HandleError(fmt.Errorf("broken data; don't sync %q: %v", key, err))
+		utilruntime.HandleError(fmt.Errorf("broken data; don't sync %q: %w", key, err))
 		return true
 	}
 	kc.configMu.Lock()

--- a/service/resolver/client.go
+++ b/service/resolver/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -236,7 +237,8 @@ func shouldAuthenticate(resp *http.Response) bool {
 			return false
 		}
 		for _, e := range errs {
-			if err, ok := e.(docker.Error); ok {
+			var err docker.Error
+			if errors.As(e, &err) {
 				if err.Message == ecrTokenExpiredResponseMessage {
 					// ECR's 403 doesn't return a Www-Authenticate and so doesn't trigger the
 					// basic re-authentication in containerd's docker authorizer.

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -779,7 +779,7 @@ func (o *snapshotter) createSnapshot(ctx context.Context, kind snapshots.Kind, k
 			if path != "" {
 				if err1 := o.cleanupSnapshotDirectory(ctx, path); err1 != nil {
 					log.G(ctx).WithError(err1).WithField("path", path).Error("failed to reclaim snapshot directory, directory may need removal")
-					err = fmt.Errorf("failed to remove path: %v: %w", err1, err)
+					err = fmt.Errorf("failed to remove path: %w: %w", err1, err)
 				}
 			}
 		}

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -552,7 +552,7 @@ func (b *IndexBuilder) build(ctx context.Context, img images.Image, buildCfg bui
 				defer wg.Done()
 				desc, toc, err := b.buildSociLayer(ctx, l)
 				if err != nil {
-					if err != errUnsupportedLayerFormat {
+					if !errors.Is(err, errUnsupportedLayerFormat) {
 						errChan <- err
 					}
 					return
@@ -583,7 +583,7 @@ func (b *IndexBuilder) build(ctx context.Context, img images.Image, buildCfg bui
 	if len(errs) > 0 {
 		errWrap := errors.New("errors encountered while building soci layers")
 		for _, err := range errs {
-			errWrap = fmt.Errorf("%w; %v", errWrap, err)
+			errWrap = fmt.Errorf("%w; %w", errWrap, err)
 		}
 		return nil, errWrap
 	}
@@ -952,7 +952,7 @@ func NewIndex(version IndexVersion, blobs []ocispec.Descriptor, subject *ocispec
 func NewIndexFromReader(reader io.Reader) (*Index, error) {
 	index := new(Index)
 	if err := json.NewDecoder(reader).Decode(index); err != nil {
-		return nil, fmt.Errorf("unable to decode reader into index: %v", err)
+		return nil, fmt.Errorf("unable to decode reader into index: %w", err)
 	}
 	return index, nil
 }

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -264,7 +264,7 @@ func TestBuildSociIndexNotLayer(t *testing.T) {
 					t.Fatalf("%v: should error out as not a layer", tc.name)
 				}
 			} else {
-				if err == errNotLayerType {
+				if errors.Is(err, errNotLayerType) {
 					t.Fatalf("%v: should not error out for any of the layer types", tc.name)
 				}
 			}

--- a/util/dockershell/compose/compose.go
+++ b/util/dockershell/compose/compose.go
@@ -56,7 +56,7 @@ func Supported() error {
 		return err
 	}
 	if err := exec.Command("docker", "compose", "version").Run(); err != nil {
-		return fmt.Errorf("compose version check failed (is Docker Compose installed?); %v", err)
+		return fmt.Errorf("compose version check failed (is Docker Compose installed?); %w", err)
 	}
 	return nil
 }

--- a/util/testutil/shell.go
+++ b/util/testutil/shell.go
@@ -349,7 +349,7 @@ func MonitorStartup() (func(string), chan error) {
 func TempDir(sh *shell.Shell) (string, error) {
 	out, err := sh.Command("mktemp", "-d").Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to run mktemp: %v", err)
+		return "", fmt.Errorf("failed to run mktemp: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
@@ -475,7 +475,7 @@ func CopyInDir(sh *shell.Shell, from, to string) error {
 func KillMatchingProcess(sh *shell.Shell, psLinePattern string) error {
 	data, err := sh.Command("ps", "axo", "pid,command").Output()
 	if err != nil {
-		return fmt.Errorf("failed to run ps command: %v", err)
+		return fmt.Errorf("failed to run ps command: %w", err)
 	}
 	var targets []int
 	scanner := bufio.NewScanner(bytes.NewReader(data))

--- a/util/testutil/util.go
+++ b/util/testutil/util.go
@@ -73,7 +73,7 @@ func GetProjectRoot() (string, error) {
 		if gopath == "" {
 			gopathB, err := exec.Command("go", "env", "GOPATH").Output()
 			if len(gopathB) == 0 || err != nil {
-				return "", fmt.Errorf("project unknown; specify %v or GOPATH: %v", projectRootEnv, err)
+				return "", fmt.Errorf("project unknown; specify %v or GOPATH: %w", projectRootEnv, err)
 			}
 			gopath = strings.TrimSpace(string(gopathB))
 		}

--- a/ztoc/testutil.go
+++ b/ztoc/testutil.go
@@ -39,7 +39,7 @@ func BuildZtocReader(_ *testing.T, ents []testutil.TarEntry, compressionLevel in
 	sr := io.NewSectionReader(bytes.NewReader(tarData), 0, int64(len(tarData)))
 	ztoc, err := NewBuilder("test").BuildZtoc(tarFileName, spanSize)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to build sample ztoc: %v", err)
+		return nil, nil, fmt.Errorf("failed to build sample ztoc: %w", err)
 	}
 	return ztoc, sr, nil
 }

--- a/ztoc/toc_builder.go
+++ b/ztoc/toc_builder.go
@@ -19,6 +19,7 @@ package ztoc
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -97,7 +98,7 @@ func (tb TocBuilder) getFileMetadata(algorithm, filename string) ([]FileMetadata
 	// read compress file and create compress tar reader.
 	compressFile, err := os.Open(filename)
 	if err != nil {
-		return nil, 0, fmt.Errorf("could not open file for reading: %v", err)
+		return nil, 0, fmt.Errorf("could not open file for reading: %w", err)
 	}
 	defer compressFile.Close()
 
@@ -124,7 +125,7 @@ func metadataFromTarReader(r io.Reader) ([]FileMetadata, compression.Offset, err
 	for {
 		hdr, err := tarRdr.Next()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, 0, fmt.Errorf("error while reading tar header: %w", err)

--- a/ztoc/ztoc_marshaler_test.go
+++ b/ztoc/ztoc_marshaler_test.go
@@ -154,7 +154,7 @@ func TestNegativeTOCRoundtrip(t *testing.T) {
 			if err == nil {
 				t.Fatal("toc deserialization did not produce expected error")
 			}
-			if tc.expectedError != anyError && !errors.Is(err, tc.expectedError) {
+			if !errors.Is(tc.expectedError, anyError) && !errors.Is(err, tc.expectedError) {
 				t.Fatalf("toc deserializtion did not produce the correct error. Actual %v, expected %v", err, tc.expectedError)
 			}
 		})


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
I ran into an issue in #1916 where `errors.Is` was not catching the error because the error was not being wrapped properly. Adding this in so that we can ensure our error checks are working properly.

Fix was generated with `golangci-lint run --fix ./...`

**Testing performed:**
`golangci-lint run ./...` had no errors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
