### PR TITLE
Invalidate cached registry hosts to re-auth on layer check failure

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -165,6 +165,7 @@ type Option func(*options)
 type options struct {
 	getSources        source.GetSources
 	resolveHandlers   map[string]remote.Handler
+	invalidateHosts   source.InvalidateHosts
 	metadataStore     metadata.Store
 	overlayOpaqueType layer.OverlayOpaqueType
 	maxConcurrency    int64
@@ -174,6 +175,12 @@ type options struct {
 func WithGetSources(s source.GetSources) Option {
 	return func(opts *options) {
 		opts.getSources = s
+	}
+}
+
+func WithInvalidateHosts(invalidateHosts source.InvalidateHosts) Option {
+	return func(opts *options) {
+		opts.invalidateHosts = invalidateHosts
 	}
 }
 
@@ -320,6 +327,7 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 		ctx:                         ctx,
 		resolver:                    r,
 		getSources:                  getSources,
+		invalidateHosts:             fsOpts.invalidateHosts,
 		debug:                       cfg.Debug,
 		layer:                       make(map[string]layer.Layer),
 		disableVerification:         cfg.DisableVerification,
@@ -414,6 +422,7 @@ type filesystem struct {
 	layerMu                     sync.Mutex
 	disableVerification         bool
 	getSources                  source.GetSources
+	invalidateHosts             source.InvalidateHosts
 	metricsController           *layermetrics.Controller
 	attrTimeout                 time.Duration
 	entryTimeout                time.Duration
@@ -1207,31 +1216,49 @@ func (fs *filesystem) check(ctx context.Context, l layer.Layer, labels map[strin
 	}
 	log.G(ctx).WithError(err).Warn("failed to connect to blob")
 
-	// Check failed. Try to refresh the connection with fresh source information
-	src, err := fs.getSources(labels)
-	if err != nil {
-		return err
-	}
-	var (
-		retrynum = 1
-		rErr     = fmt.Errorf("failed to refresh connection")
-	)
-	for retry := 0; retry < retrynum; retry++ {
-		log.G(ctx).Warnf("refreshing(%d)...", retry)
-		for _, s := range src {
-			err := l.Refresh(ctx, s.Hosts, s.Name, s.Target)
-			if err == nil {
-				log.G(ctx).Debug("Successfully refreshed connection")
-				return nil
-			}
-			log.G(ctx).WithError(err).Warnf("failed to refresh the layer %q from %q",
-				s.Target.Digest, s.Name)
-			rErr = fmt.Errorf("failed(layer:%q, ref:%q): %v: %w",
-				s.Target.Digest, s.Name, err, rErr)
-		}
+	// Try to refresh with current (possibly cached) sources.
+	src, err := fs.refreshLayer(ctx, l, labels)
+	if err == nil {
+		log.G(ctx).Debug("Successfully refreshed connection")
+		return nil
 	}
 
-	return rErr
+	// Invalidate cached registry hosts and retry with fresh credentials.
+	if fs.invalidateHosts != nil {
+		for _, s := range src {
+			log.G(ctx).Debugf("Invalidating cached registry hosts for source %q", s.Name)
+			fs.invalidateHosts(s.Name.String())
+		}
+		_, err = fs.refreshLayer(ctx, l, labels)
+		if err == nil {
+			log.G(ctx).Debug("Successfully refreshed connection after invalidating hosts")
+			return nil
+		}
+		return err
+	}
+
+	return err
+}
+
+// refreshLayer fetches sources and attempts to refresh the layer connection.
+// It returns the sources that were tried and any error.
+func (fs *filesystem) refreshLayer(ctx context.Context, l layer.Layer, labels map[string]string) ([]source.Source, error) {
+	src, err := fs.getSources(labels)
+	if err != nil {
+		return src, err
+	}
+	var errs []error
+	for _, s := range src {
+		log.G(ctx).Warnf("refreshing connection (layer:%q, ref:%q)", s.Target.Digest, s.Name)
+		if err := l.Refresh(ctx, s.Hosts, s.Name, s.Target); err == nil {
+			return src, nil
+		} else {
+			log.G(ctx).WithError(err).Warnf("failed to refresh the layer %q from %q",
+				s.Target.Digest, s.Name)
+			errs = append(errs, fmt.Errorf("failed(layer:%q, ref:%q): %w", s.Target.Digest, s.Name, err))
+		}
+	}
+	return src, errors.Join(errs...)
 }
 
 func isIDMappedDir(mountpoint string) bool {

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -77,6 +77,48 @@ func TestCheck(t *testing.T) {
 	}
 }
 
+func TestCheckSucceedsAfterInvalidation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	refreshCount := 0
+	var invalidatedRef string
+
+	bl := &breakableLayer{}
+	bl.success = false
+
+	expectedRef := reference.Spec{Locator: "docker.io/library/alpine", Object: "latest"}
+
+	fs := &filesystem{
+		layer: map[string]layer.Layer{
+			"test": bl,
+		},
+		getSources: func(labels map[string]string) ([]source.Source, error) {
+			refreshCount++
+			// After invalidation, let Refresh succeed.
+			if refreshCount == 2 {
+				bl.success = true
+			}
+			return []source.Source{
+				{Name: expectedRef},
+			}, nil
+		},
+		invalidateHosts: func(ref string) {
+			invalidatedRef = ref
+		},
+	}
+
+	if err := fs.Check(ctx, "test", nil); err != nil {
+		t.Errorf("connection failed after invalidation; wanted to succeed: %v", err)
+	}
+	if invalidatedRef != expectedRef.String() {
+		t.Errorf("invalidateHosts called with %q; wanted %q", invalidatedRef, expectedRef.String())
+	}
+	if refreshCount != 2 {
+		t.Errorf("expected 2 refreshLayer calls, got %d", refreshCount)
+	}
+}
+
 type breakableLayer struct {
 	success bool
 }

--- a/fs/source/source.go
+++ b/fs/source/source.go
@@ -96,6 +96,10 @@ const (
 // to reduce package dependency
 type RegistryHosts func(imgRefSpec reference.Spec) ([]docker.RegistryHost, error)
 
+// InvalidateHosts invalidates cached registry host configurations for a given
+// image reference, forcing fresh credentials to be fetched on the next request.
+type InvalidateHosts func(ref string)
+
 // FromDefaultLabels returns a function for converting snapshot labels to
 // source information based on labels.
 func FromDefaultLabels(hosts RegistryHosts) GetSources {

--- a/service/resolver/registry.go
+++ b/service/resolver/registry.go
@@ -178,9 +178,15 @@ func (rm *RegistryManager) AsRegistryHosts() RegistryHosts {
 	}
 }
 
+// InvalidateRegistryHosts removes cached registry host configurations for the
+// given image reference, forcing a fresh AuthClient to be created on the next request.
+func (rm *RegistryManager) InvalidateRegistryHosts(ref string) {
+	rm.registryHostMap.Delete(ref)
+}
+
 // multiCredsFuncs joins a list of credential functions into a single credential function.
 //
-// Note: We close over an image reference so that our invdidual credential providers
+// Note: We close over an image reference so that our individual credential providers
 // can store+index credentials at an image level.
 func multiCredsFuncs(imgRefSpec reference.Spec, credsFuncs ...Credential) func(string) (string, string, error) {
 	return func(host string) (string, string, error) {

--- a/service/resolver/registry_test.go
+++ b/service/resolver/registry_test.go
@@ -1,0 +1,83 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package resolver
+
+import (
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	"github.com/containerd/containerd/reference"
+	"github.com/containerd/containerd/remotes/docker"
+)
+
+func TestAsRegistryHosts(t *testing.T) {
+	rm := NewRegistryManager(config.RetryableHTTPClientConfig{}, config.ResolverConfig{}, nil)
+	hosts := rm.AsRegistryHosts()
+
+	ref := reference.Spec{Locator: "docker.io/library/alpine", Object: "latest"}
+
+	result, err := hosts(ref)
+	if err != nil {
+		t.Fatalf("failed to get registry hosts: %v", err)
+	}
+	if len(result) == 0 {
+		t.Fatal("expected at least one registry host")
+	}
+	if result[0].Client == nil {
+		t.Fatal("expected non-nil Client")
+	}
+	if result[0].Host == "" {
+		t.Fatal("expected non-empty Host")
+	}
+	if result[0].Scheme != "https" {
+		t.Fatalf("expected https scheme, got %q", result[0].Scheme)
+	}
+	if result[0].Capabilities != docker.HostCapabilityPull|docker.HostCapabilityResolve {
+		t.Fatalf("unexpected capabilities: %v", result[0].Capabilities)
+	}
+
+	// Repeated call returns cached result.
+	cached, err := hosts(ref)
+	if err != nil {
+		t.Fatalf("cached call failed: %v", err)
+	}
+	if result[0].Client != cached[0].Client {
+		t.Fatal("expected same Client from cache")
+	}
+}
+
+func TestInvalidateRegistryHostsCausesNewAuthClient(t *testing.T) {
+	rm := NewRegistryManager(config.RetryableHTTPClientConfig{}, config.ResolverConfig{}, nil)
+	hosts := rm.AsRegistryHosts()
+
+	ref := reference.Spec{Locator: "docker.io/library/alpine", Object: "latest"}
+
+	first, err := hosts(ref)
+	if err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+
+	rm.InvalidateRegistryHosts(ref.String())
+
+	refreshed, err := hosts(ref)
+	if err != nil {
+		t.Fatalf("post-invalidation call failed: %v", err)
+	}
+	if first[0].Client == refreshed[0].Client {
+		t.Fatal("expected different Client after invalidation")
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -87,8 +87,11 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	registryConfig := serviceCfg.ResolverConfig
 
 	hosts := sOpts.registryHosts
+	var invalidateHosts source.InvalidateHosts
 	if hosts == nil {
-		hosts = resolver.NewRegistryManager(httpConfig, registryConfig, sOpts.credsFuncs).AsRegistryHosts()
+		rm := resolver.NewRegistryManager(httpConfig, registryConfig, sOpts.credsFuncs)
+		hosts = rm.AsRegistryHosts()
+		invalidateHosts = rm.InvalidateRegistryHosts
 	}
 	userxattr, err := overlayutils.NeedsUserXAttr(snapshotterRoot(root))
 	if err != nil {
@@ -101,6 +104,7 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	// Configure filesystem and snapshotter
 	getSources := source.FromDefaultLabels(source.RegistryHosts(hosts)) // provides source info based on default labels
 	fsOpts := append(sOpts.fsOpts, socifs.WithGetSources(getSources),
+		socifs.WithInvalidateHosts(invalidateHosts),
 		socifs.WithOverlayOpaqueType(opq),
 		socifs.WithPullModes(serviceCfg.PullModes),
 	)


### PR DESCRIPTION
**Issue #, if available:**

Addresses - https://github.com/awslabs/soci-snapshotter/issues/1924 and help with https://github.com/awslabs/soci-snapshotter/issues/522

**Description of changes:**

When a layer check fails and refresh with cached sources also fails, invalidate the cached registry host configurations and retry with fresh credentials. This handles cases where cached auth tokens have expired between the initial pull and a subsequent layer access as seen in the issue https://github.com/awslabs/soci-snapshotter/issues/1924

Prev discussions - 
- https://github.com/awslabs/soci-snapshotter/pull/1925#issuecomment-4185372117
- https://github.com/awslabs/soci-snapshotter/issues/1924

**Testing performed:**

Added Unit tests, and performed a exhaustive integration test as part of the draft testing via https://github.com/awslabs/soci-snapshotter/pull/1925

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
