### PR TITLE
feat: allow lazy pull to fallback to parallel pull

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -393,8 +393,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 
 	var deferToContainerRuntime bool
 
-	// remote snapshot prepare
-	// skip if parallel pull is enabled
+	// Attempt lazy load via remote snapshot (SOCI v2, then v1).
 	if !o.skipRemoteSnapshotPrepare(lCtx, base.Labels) {
 		err := o.prepareRemoteSnapshot(lCtx, key, base.Labels)
 		if err == nil {
@@ -430,16 +429,23 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 		return nil, err
 	}
 
-	// If the underlying FileSystem deems that the image is unable to be lazy loaded,
-	// then we should completely fallback to the container runtime to handle
-	// pulling and unpacking all the layers in the image.
-	// The exception is if we are using parallel pull and unpack,
-	// in which case we want to handle all snapshots ourselves.
+	// Lazy loading did not succeed. If no SOCI index was found (ErrNoIndex)
+	// and parallel pull is not enabled, defer to the container runtime for
+	// a sequential pull. If parallel pull is enabled, fall through.
 	if deferToContainerRuntime {
-		log.G(lCtx).WithField(deferredSnapshotLogKey, prepareSucceeded).WithError(err).Warnf("%v; %v", ErrNoIndex, ErrDeferToContainerRuntime)
-		return mounts, nil
+		if o.parallelPullUnpack {
+			log.G(lCtx).WithField("layerDigest", base.Labels[ctdsnapshotters.TargetLayerDigestLabel]).
+				Info("no SOCI index found; falling back to parallel pull/unpack")
+		} else {
+			log.G(lCtx).WithField(deferredSnapshotLogKey, prepareSucceeded).WithError(err).Warnf("%v; %v", ErrNoIndex, ErrDeferToContainerRuntime)
+			return mounts, nil
+		}
 	}
 
+	// Lazy loading did not succeed — either no SOCI index was found
+	// (parallel pull enabled, fell through above) or a SOCI index exists
+	// but this layer has no ztoc (ErrNoZtoc). Use parallel pull if
+	// enabled, otherwise SOCI handles the sequential unpack itself.
 	if o.parallelPullUnpack {
 		log.G(ctx).WithField("layerDigest", base.Labels[ctdsnapshotters.TargetLayerDigestLabel]).Info("preparing snapshot with parallel pull/unpack")
 		err = o.prepareParallelPullSnapshot(lCtx, key, base.Labels, mounts)
@@ -479,9 +485,6 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 }
 
 func (o *snapshotter) skipRemoteSnapshotPrepare(ctx context.Context, labels map[string]string) bool {
-	if o.parallelPullUnpack {
-		return true
-	}
 
 	if o.minLayerSize > 0 {
 		if strVal, ok := labels[source.TargetSizeLabel]; ok {


### PR DESCRIPTION
**Description of changes:** Lazy loading and parallel pull were mutually exclusive. Enabling `parallel_pull_unpack` caused `skipRemoteSnapshotPrepare()` to return early, bypassing lazy load entirely. Users could not get lazy loading for indexed layers and parallel pull for unindexed layers in the same configuration.

This change addresses that. The snapshotter now attempts pull modes in priority order for each layer:
1. Lazy loading (v2, then v1): if a SOCI index exists and the layer has a ztoc, mount via FUSE
2. Parallel pull: if lazy load fails (no SOCI index, or no ztoc for this layer) and `parallel_pull_unpack` is enabled
3. SOCI sequential pull: if a SOCI index exists but the layer has no ztoc and parallel pull is disabled
4. Defer to container runtime: if no SOCI index exists and parallel pull is disabled, return mounts to containerd for sequential pull

**Testing performed:** Tested on `m7i.4xlarge` (AL2023). Used a nginx image in ECR with a sparse SOCI index (2 layers with ztocs, 5 without) and a public ubuntu image with no SOCI index.
1. Lazy load (v1+v2 ON, parallel ON, image with SOCI index): 2 indexed layers showed `remote snapshot successfully prepared`. 5 unindexed layers fell through to parallel pull.
2. Parallel pull fallback (v2 ON, parallel ON, image with no SOCI index): all layers showed `no SOCI index found; falling back to parallel pull/unpack` followed by `preparing snapshot with parallel pull/unpack`.
3. Defer to container runtime (v1+v2 ON, parallel OFF, image with no SOCI index): logs showed `deferring to container runtime`, containerd pulled the layer. No `preparing snapshot with parallel` or `preparing snapshot as local` in logs.
4. SOCI sequential (v1+v2 ON, parallel OFF, image with SOCI index): 2 indexed layers showed `remote snapshot successfully prepared`. 5 unindexed layers showed `preparing snapshot as local snapshot`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.