### PR TITLE
feat: add parallel_pull_as_fallback config option

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -73,6 +73,7 @@ skip_check_snapshotter_supported = false
     max_concurrent_unpacks_per_image = 1
     discard_unpacked_layers = false
     enable = false
+    experimental_parallel_pull_as_fallback = false
 
 [kubeconfig_keychain]
   enable_keychain = false

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -47,6 +47,11 @@ func TestConfigDefaults(t *testing.T) {
 			actual:   cfg.PullModes.Parallel.Enable,
 		},
 		{
+			name:     "parallel pull as fallback",
+			expected: DefaultExperimentalParallelPullAsFallback,
+			actual:   cfg.PullModes.Parallel.ExperimentalParallelPullAsFallback,
+		},
+		{
 			name:     "metrics network",
 			expected: defaultMetricsNetwork,
 			actual:   cfg.MetricsNetwork,
@@ -284,6 +289,39 @@ concurrent_download_chunk_size = "badchunksize"
 			assert: func(t *testing.T, actual *Config, err error) {
 				if err == nil {
 					t.Error("Expected error, got none")
+				}
+			},
+		},
+		{
+			name: "ParallelPullAsFallback",
+			config: []byte(`
+[pull_modes.soci_v2]
+enable = true
+
+[pull_modes.parallel_pull_unpack]
+enable = false
+experimental_parallel_pull_as_fallback = true
+max_concurrent_downloads_per_image = 10
+concurrent_download_chunk_size = "16mb"
+`),
+			assert: func(t *testing.T, actual *Config, err error) {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+				if !actual.PullModes.SOCIv2.Enable {
+					t.Error("Expected soci_v2 to be enabled")
+				}
+				if actual.PullModes.Parallel.Enable {
+					t.Error("Expected parallel_pull_unpack.enable to be false")
+				}
+				if !actual.PullModes.Parallel.ExperimentalParallelPullAsFallback {
+					t.Error("Expected experimental_parallel_pull_as_fallback to be true")
+				}
+				if actual.PullModes.Parallel.MaxConcurrentDownloadsPerImage != 10 {
+					t.Errorf("Expected max_concurrent_downloads_per_image to be 10, got %d", actual.PullModes.Parallel.MaxConcurrentDownloadsPerImage)
+				}
+				if actual.PullModes.Parallel.ConcurrentDownloadChunkSize != 16*1024*1024 {
+					t.Errorf("Expected concurrent_download_chunk_size to be %d, got %d", 16*1024*1024, actual.PullModes.Parallel.ConcurrentDownloadChunkSize)
 				}
 			},
 		},

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -123,6 +123,12 @@ const (
 	// DefaultParallelPullEnable is the default value for whether parallel pull and unpack is enabled
 	DefaultParallelPullUnpackEnable = false
 
+	// DefaultParallelPullAsFallback is the default value for whether parallel pull is used
+	// as a fallback when lazy-load finds no SOCI index.
+	// This is EXPERIMENTAL — lazy-load with containerd content store may have
+	// garbage collection edge cases. See https://github.com/awslabs/soci-snapshotter/issues/1843
+	DefaultExperimentalParallelPullAsFallback = false
+
 	// Defaults for ParallelPullUnpack.
 	// The default values should mirror default containerd values.
 

--- a/config/pull_modes.go
+++ b/config/pull_modes.go
@@ -44,6 +44,19 @@ type V2 struct {
 type Parallel struct {
 	ParallelConfig
 	Enable bool `toml:"enable"`
+
+	// ParallelPullAsFallback enables parallel-pull as an automatic fallback
+	// when lazy-load is the primary mode but no SOCI index is found for an image.
+	// When true (and Enable is false), the snapshotter will first attempt lazy-load;
+	// if no SOCI index exists, it falls back to parallel-pull instead of deferring
+	// to the container runtime's slower sequential pull.
+	// If Enable is true, this option is a no-op (parallel-pull is already the primary mode).
+	//
+	// EXPERIMENTAL: This requires the containerd content store for both lazy-load
+	// and parallel-pull (unless discard_unpacked_layers = true).
+	// Lazy-load with the containerd content store may have
+	// garbage collection edge cases. See https://github.com/awslabs/soci-snapshotter/issues/1843
+	ExperimentalParallelPullAsFallback bool `toml:"experimental_parallel_pull_as_fallback"`
 }
 
 func defaultPullModes(cfg *Config) error {

--- a/docs/config.md
+++ b/docs/config.md
@@ -97,6 +97,24 @@ This set of variables must be at the top of your TOML file due to not belonging 
 
 ## config/service.go
 
+## config/pull_modes.go
+
+### [pull_modes.soci_v1]
+- `enable` (bool) — Enables SOCI v1 index discovery via the OCI Referrers API. Default: false.
+
+### [pull_modes.soci_v2]
+- `enable` (bool) — Enables SOCI v2 index discovery via image manifest annotations. Default: true.
+
+### [pull_modes.parallel_pull_unpack]
+- `enable` (bool) — Enables parallel pull and unpack as the primary pull mode. When true, lazy-load is skipped entirely. Default: false.
+- `experimental_parallel_pull_as_fallback` (bool) — **[EXPERIMENTAL]** When true (and `enable` is false), uses parallel-pull as an automatic fallback when lazy-load is the primary mode but no SOCI index is found for an image. Requires containerd content store (unless `discard_unpacked_layers = true`). Lazy-load with the containerd content store may have garbage collection edge cases. See [#1843](https://github.com/awslabs/soci-snapshotter/issues/1843). Ignored when `enable` is true. Default: false.
+- `max_concurrent_downloads` (int) — Max concurrent downloads across all images. -1 for unlimited. Default: -1.
+- `max_concurrent_downloads_per_image` (int) — Max concurrent downloads per image. Default: 3.
+- `concurrent_download_chunk_size` (string) — Size of each download chunk (e.g. "8mb", "16mb"). Empty means full layer. Default: "".
+- `max_concurrent_unpacks` (int) — Max concurrent unpacks across all images. -1 for unlimited. Default: -1.
+- `max_concurrent_unpacks_per_image` (int) — Max concurrent unpacks per image. Default: 1.
+- `discard_unpacked_layers` (bool) — Discard layer blobs after unpacking to save disk space. Default: false.
+
 ### [snapshotter]
 - `min_layer_size` (int) — Sets the minimum threshold for lazy loading a layer. Any layer smaller than this value will ignore the zTOC for the layer and pull the entire layer ahead of time. We generally recommend setting it to 10MiB (10000000). Default: 0.
 - `allow_invalid_mounts_on_restart` (bool) — Allows the snapshotter to start even if preexisting snapshots cannot connect to their data source on startup. Useful on unexpected daemon crashes/corruption. Default: false.

--- a/docs/parallel-mode.md
+++ b/docs/parallel-mode.md
@@ -94,6 +94,32 @@ If you have any questions or need further assistance, please don't hesitate to r
 
 ## Known Limitations
 
+### Parallel Pull as Fallback for Lazy-Load
+
+When using lazy-load as the primary pull mode (`soci_v2.enable = true` or `soci_v1.enable = true`), images without a SOCI index normally fall back to the container runtime's sequential pull, which can be slower than a standard image pull. To avoid this behavior, you can enable `experimental_parallel_pull_as_fallback`:
+
+```toml
+[pull_modes.soci_v2]
+  enable = true
+
+[pull_modes.parallel_pull_unpack]
+  enable = false
+  experimental_parallel_pull_as_fallback = true
+  max_concurrent_downloads_per_image = 10
+  concurrent_download_chunk_size = "16mb"
+  max_concurrent_unpacks_per_image = 10
+  discard_unpacked_layers = true
+```
+
+With this configuration:
+- Images **with** a SOCI index use lazy-load
+- Images **without** a SOCI index use parallel-pull
+- No image falls through to the slow sequential containerd pull
+
+> **EXPERIMENTAL**: This option requires the containerd content store (`type = "containerd"` under `[content_store]`) for both lazy-load and parallel-pull. Lazy-load with the containerd content store may have garbage collection edge cases and does not carry the same stability guarantees as using either mode independently. See [#1843](https://github.com/awslabs/soci-snapshotter/issues/1843) for details.
+
+Note: `experimental_parallel_pull_as_fallback` is ignored when `enable = true`, since parallel-pull is already the primary mode in that case.
+
 ### Registries
 
 Any registry that supports ranged GET requests and has sufficient request limits should work with parallel pull mode. If a registry is rate limiting image pull requests, users can attempt to lower `max_concurrent_downloads` or `max_concurrent_downloads_per_image` and see if it alleviates the issue, however this will result in less of a performance benefit compared to regular pulling.

--- a/fs/adaptive_fetch_image_layers.go
+++ b/fs/adaptive_fetch_image_layers.go
@@ -162,7 +162,7 @@ func checkParallelPullUnpack(cfg *config.Parallel) error {
 	if cfg == nil {
 		return errors.New("parallel pull config is nil")
 	}
-	if !cfg.Enable {
+	if !cfg.Enable && !cfg.ExperimentalParallelPullAsFallback {
 		return ErrParallelPullIsDisabled
 	}
 	// If global concurrent downloads/unpacks are unlimited, any value for per-image concurrent downloads/unpacks are valid

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -242,7 +242,12 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 	if pullModes.Parallel.Enable &&
 		cfg.ContentStoreConfig.Type != config.ContainerdContentStoreType &&
 		!pullModes.Parallel.DiscardUnpackedLayers {
-		return nil, errors.New("parallel_pull_unpack mode requires containerd content store (type=\"containerd\" under [content_store])")
+		return nil, errors.New("parallel_pull_unpack mode requires containerd content store (type=\"containerd\" under [content_store] or discard_unpacked_layers = true)")
+	}
+	if pullModes.Parallel.ExperimentalParallelPullAsFallback &&
+		cfg.ContentStoreConfig.Type != config.ContainerdContentStoreType &&
+		!pullModes.Parallel.DiscardUnpackedLayers {
+		return nil, errors.New("experimental_parallel_pull_as_fallback requires containerd content store (type=\"containerd\" under [content_store] or discard_unpacked_layers = true)")
 	}
 	client := store.NewContainerdClient(cfg.ContentStoreConfig.ContainerdAddress)
 
@@ -339,7 +344,7 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 }
 
 func createParallelPullStructs(ctx context.Context, storage LayerUnpackJobStorage, parallelConfig *config.Parallel) (*unpackJobs, error) {
-	if !parallelConfig.Enable {
+	if !parallelConfig.Enable && !parallelConfig.ExperimentalParallelPullAsFallback {
 		return nil, nil
 	}
 
@@ -430,7 +435,7 @@ type filesystem struct {
 }
 
 func (fs *filesystem) MountParallel(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
-	if !fs.pullModes.Parallel.Enable {
+	if !fs.pullModes.Parallel.Enable && !fs.pullModes.Parallel.ExperimentalParallelPullAsFallback {
 		return ErrParallelPullIsDisabled
 	}
 
@@ -727,7 +732,7 @@ func (fs *filesystem) getImageManifest(ctx context.Context, dgst string) (*ocisp
 // CleanImage stops all parallel operations for the specific image.
 // Generally this will be called when removing a snapshot for an image.
 func (fs *filesystem) CleanImage(ctx context.Context, imgDigest string) error {
-	if !fs.pullModes.Parallel.Enable {
+	if !fs.pullModes.Parallel.Enable && !fs.pullModes.Parallel.ExperimentalParallelPullAsFallback {
 		return nil
 	}
 

--- a/integration/pull_modes_test.go
+++ b/integration/pull_modes_test.go
@@ -364,3 +364,159 @@ func testDanglingV2Annotation(t *testing.T, imgName string) {
 		t.Fatalf("expected v2 index digest %s, got %s", v2IndexDigest, indexDigestUsed)
 	}
 }
+
+func TestExperimentalParallelPullAsFallback(t *testing.T) {
+	for _, imgName := range pullModesImages {
+		t.Run(imgName, func(t *testing.T) {
+			testExperimentalParallelPullAsFallback(t, imgName)
+		})
+	}
+}
+
+func testExperimentalParallelPullAsFallback(t *testing.T, imgName string) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	srcInfo := dockerhub(imgName)
+	dstInfo := regConfig.mirror(imgName)
+	sh.X("nerdctl", "login", "-u", regConfig.user, "-p", regConfig.pass, dstInfo.ref)
+
+	// Create a SOCI-indexed version of the image for lazy-load tests
+	rebootContainerd(t, sh, "", "")
+	v2IndexDigest := createAndPushV2Index(t, sh, srcInfo, dstInfo)
+
+	// Also push the original (non-indexed) image to a separate tag for fallback tests
+	rebootContainerd(t, sh, "", "")
+	noIndexInfo := regConfig.mirror(imgName)
+	noIndexRef, err := reference.Parse(noIndexInfo.ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noIndexRef.Object = "no-soci-index"
+	sh.X("nerdctl", "pull", "-q", srcInfo.ref)
+	sh.X("nerdctl", "image", "tag", srcInfo.ref, noIndexRef.String())
+	sh.X("nerdctl", "push", noIndexRef.String())
+
+	tests := []struct {
+		name             string
+		pullModes        config.PullModes
+		contentStoreType store.ContentStoreType
+		imageRef         string
+		expectedDigest   string
+		// checkLocal means we expect local/parallel snapshots (not remote/lazy)
+		checkLocal bool
+		// checkDeferred means we expect deferred-to-runtime snapshots
+		checkDeferred bool
+	}{
+		{
+			// Fallback enabled + image WITH SOCI index → lazy-load should be used
+			name: "fallback enabled with indexed image uses lazy-load",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{Enable: false},
+				SOCIv2: config.V2{Enable: true},
+				Parallel: config.Parallel{
+					ExperimentalParallelPullAsFallback: true,
+				},
+			},
+			contentStoreType: store.ContainerdContentStoreType,
+			imageRef:         dstInfo.ref,
+			expectedDigest:   v2IndexDigest,
+		},
+		{
+			// Fallback enabled + image WITHOUT SOCI index → parallel-pull fallback
+			name: "fallback enabled with non-indexed image uses parallel pull",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{Enable: false},
+				SOCIv2: config.V2{Enable: true},
+				Parallel: config.Parallel{
+					ExperimentalParallelPullAsFallback: true,
+				},
+			},
+			contentStoreType: store.ContainerdContentStoreType,
+			imageRef:         noIndexRef.String(),
+			expectedDigest:   "",
+			checkLocal:       true,
+		},
+		{
+			// Fallback disabled + image WITHOUT SOCI index → defers to container runtime
+			name: "fallback disabled with non-indexed image defers to runtime",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{Enable: false},
+				SOCIv2: config.V2{Enable: true},
+			},
+			imageRef:       noIndexRef.String(),
+			expectedDigest: "",
+			checkDeferred:  true,
+		},
+		{
+			// enable=true takes precedence over fallback — parallel pull is primary
+			name: "enable true takes precedence over fallback",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{Enable: false},
+				SOCIv2: config.V2{Enable: true},
+				Parallel: config.Parallel{
+					Enable:                             true,
+					ExperimentalParallelPullAsFallback: true,
+				},
+			},
+			contentStoreType: store.ContainerdContentStoreType,
+			imageRef:         dstInfo.ref,
+			expectedDigest:   "",
+			checkLocal:       true,
+		},
+		{
+			// Fallback with SOCI content store + discard_unpacked_layers works
+			name: "fallback with soci content store and discard unpacked layers",
+			pullModes: config.PullModes{
+				SOCIv1: config.V1{Enable: false},
+				SOCIv2: config.V2{Enable: true},
+				Parallel: config.Parallel{
+					ExperimentalParallelPullAsFallback: true,
+					ParallelConfig: config.ParallelConfig{
+						DiscardUnpackedLayers: true,
+					},
+				},
+			},
+			// No contentStoreType set — defaults to SOCI content store
+			imageRef:       noIndexRef.String(),
+			expectedDigest: "",
+			checkLocal:     true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opts := []snapshotterConfigOpt{withPullModes(test.pullModes)}
+			if test.contentStoreType == store.ContainerdContentStoreType {
+				opts = append(opts, withContainerdContentStore())
+			}
+			var indexDigestUsed string
+			monitorFunc := func(s string) {
+				structuredLog := make(map[string]string)
+				err := json.Unmarshal([]byte(s), &structuredLog)
+				if err != nil {
+					return
+				}
+				if structuredLog["msg"] == "fetching SOCI artifacts using index descriptor" {
+					indexDigestUsed = structuredLog["digest"]
+				}
+			}
+			rsm := testutil.NewRemoteSnapshotMonitor()
+			m := rebootContainerd(t, sh, "", getSnapshotterConfigToml(t, opts...), rsm.MonitorFunc, monitorFunc)
+			defer m.Cleanup(t)
+			sh.X(append(imagePullCmd, test.imageRef)...)
+
+			if test.expectedDigest != "" {
+				rsm.CheckAllRemoteSnapshots(t)
+			} else if test.checkLocal {
+				rsm.CheckAllLocalSnapshots(t)
+			} else if test.checkDeferred {
+				rsm.CheckAllDeferredSnapshots(t)
+			}
+			if indexDigestUsed != test.expectedDigest {
+				t.Fatalf("expected digest %s, got %s", test.expectedDigest, indexDigestUsed)
+			}
+		})
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -124,6 +124,15 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	if serviceCfg.PullModes.Parallel.Enable {
 		snOpts = append(snOpts, snbase.ParallelPullUnpack)
 	}
+	if serviceCfg.PullModes.Parallel.ExperimentalParallelPullAsFallback && !serviceCfg.PullModes.Parallel.Enable {
+		log.G(ctx).Warn("EXPERIMENTAL: experimental_parallel_pull_as_fallback is enabled. " +
+			"Lazy-load and parallel-pull will coexist using the same content store. " +
+			"When using the containerd content store, this combination may have " +
+			"garbage collection edge cases and does not carry the same stability " +
+			"guarantees as using either mode independently. " +
+			"See https://github.com/awslabs/soci-snapshotter/issues/1843")
+		snOpts = append(snOpts, snbase.ParallelPullAsFallback)
+	}
 
 	snapshotter, err = snbase.NewSnapshotter(ctx, snapshotterRoot(root), fs, snOpts...)
 	if err != nil {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -125,6 +125,7 @@ type SnapshotterConfig struct {
 	minLayerSize                int64
 	allowInvalidMountsOnRestart bool
 	parallelPullUnpack          bool
+	parallelPullAsFallback      bool
 }
 
 // Opt is an option to configure the remote snapshotter
@@ -157,6 +158,15 @@ func ParallelPullUnpack(config *SnapshotterConfig) error {
 	return nil
 }
 
+// ParallelPullAsFallback configures the snapshotter to use parallel-pull as an
+// automatic fallback when lazy-load is the primary mode but no SOCI index is
+// found for an image. This avoids the slow sequential containerd pull that
+// occurs when lazy-load is enabled and no SOCI index exists.
+func ParallelPullAsFallback(config *SnapshotterConfig) error {
+	config.parallelPullAsFallback = true
+	return nil
+}
+
 type snapshotter struct {
 	root        string
 	ms          *storage.MetaStore
@@ -168,6 +178,7 @@ type snapshotter struct {
 	minLayerSize                int64 // minimum layer size for remote mounting
 	allowInvalidMountsOnRestart bool
 	parallelPullUnpack          bool
+	parallelPullAsFallback      bool
 	idmapped                    *sync.Map
 }
 
@@ -223,6 +234,7 @@ func NewSnapshotter(ctx context.Context, root string, targetFs FileSystem, opts 
 		allowInvalidMountsOnRestart: config.allowInvalidMountsOnRestart,
 		idmapped:                    idMap,
 		parallelPullUnpack:          config.parallelPullUnpack,
+		parallelPullAsFallback:      config.parallelPullAsFallback,
 	}
 
 	if err := o.restoreRemoteSnapshot(ctx); err != nil {
@@ -433,14 +445,28 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 	// If the underlying FileSystem deems that the image is unable to be lazy loaded,
 	// then we should completely fallback to the container runtime to handle
 	// pulling and unpacking all the layers in the image.
-	// The exception is if we are using parallel pull and unpack,
+	// The exception is if we are using parallel pull and unpack (or parallel-pull-as-fallback),
 	// in which case we want to handle all snapshots ourselves.
+	// If no SOCI index was found and neither parallel pull nor parallel-pull-as-fallback
+	// is enabled, defer to the container runtime for a sequential pull.
+	// Otherwise, fall through to parallel pull.
 	if deferToContainerRuntime {
-		log.G(lCtx).WithField(deferredSnapshotLogKey, prepareSucceeded).WithError(err).Warnf("%v; %v", ErrNoIndex, ErrDeferToContainerRuntime)
-		return mounts, nil
+		if o.parallelPullUnpack || o.parallelPullAsFallback {
+			log.G(lCtx).WithField("layerDigest", base.Labels[ctdsnapshotters.TargetLayerDigestLabel]).
+				Info("no SOCI index found; falling back to parallel pull/unpack")
+		} else {
+			log.G(lCtx).WithField(deferredSnapshotLogKey, prepareSucceeded).WithError(err).Warnf("%v; %v", ErrNoIndex, ErrDeferToContainerRuntime)
+			return mounts, nil
+		}
 	}
 
-	if o.parallelPullUnpack {
+	// Lazy loading did not succeed — either no SOCI index was found
+	// (parallel pull enabled, fell through above) or a SOCI index exists
+	// but this layer has no ztoc (ErrNoZtoc). Use parallel pull if
+	// enabled as primary or if falling back from a missing SOCI index.
+	// For ErrNoZtoc (sparse index), always use local snapshot to handle
+	// the individual layer — parallel pull would re-pull the entire image.
+	if o.parallelPullUnpack || (o.parallelPullAsFallback && deferToContainerRuntime) {
 		log.G(ctx).WithField("layerDigest", base.Labels[ctdsnapshotters.TargetLayerDigestLabel]).Info("preparing snapshot with parallel pull/unpack")
 		err = o.prepareParallelPullSnapshot(lCtx, key, base.Labels, mounts)
 	} else {
@@ -465,7 +491,7 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 		return nil, err
 	}
 	log.G(lCtx).WithField(remoteSnapshotLogKey, prepareFailed).WithError(err).Debug("skipped preparing remote snapshot")
-	if o.parallelPullUnpack {
+	if o.parallelPullUnpack || (o.parallelPullAsFallback && deferToContainerRuntime) {
 		// If parallel pull/unpack fails, then we should not defer to the container runtime
 		// and just return the error.
 		return nil, err


### PR DESCRIPTION
## Summary

Adds `parallel_pull_as_fallback` option under `[pull_modes.parallel_pull_unpack]` that enables parallel-pull as an automatic fallback when lazy-load finds no SOCI index - instead of deferring to the container runtime's slower sequential pull.

## Problem

Lazy-load and parallel-pull are mutually exclusive today. When lazy-load is enabled and no SOCI index exists, the snapshotter defers to containerd's sequential pull (5-40% slower than Docker). This forces operators to choose one mode for all images.

## Solution

With `parallel_pull_as_fallback = true` (and `enable = false`):
- Images **with** a SOCI index → lazy-load
- Images **without** a SOCI index → parallel-pull fallback
- No image hits the slow sequential path

Defaults to `false` - zero behavior change for existing users.

With parallel_pull_as_fallback = true (and enable = false), the snapshotter first attempts lazy-load for every image. Only when no SOCI index is found does it fall back to parallel-pull instead of the slow sequential path. This gives optimal performance for both cases - images with and without SOCI index.

The option defaults to false, preserving existing behavior for all current users. When enable = true, the fallback is a no-op since parallel-pull is already the primary mode.

## Config Example

```toml
[pull_modes.soci_v2]
  enable = true

[pull_modes.parallel_pull_unpack]
  enable = false
  parallel_pull_as_fallback = true
  max_concurrent_downloads_per_image = 10
  concurrent_download_chunk_size = "16mb"
  max_concurrent_unpacks_per_image = 10
  discard_unpacked_layers = true
```

## Testing
Tested on AL2 and AL2023 instances with both small (nginx) and large (20GB+) container images. All existing unit tests pass.

| `enable` | `parallel_pull_as_fallback` | Result |
|---|---|---|
| `false` | `false` (default) | Default behavior - lazy-load, sequential fallback on no index |
| `false` | `true` | **New behavior** - lazy-load, parallel-pull fallback on no index |
| `true` | `false` (default) | Parallel-pull primary, skips lazy-load entirely (existing) |
| `true` | `true` | Same as above - `enable` wins, fallback flag is ignored |


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
