### PR TITLE
Fix multi-platform soci standalone convert

### DIFF
--- a/cmd/soci/commands/internal/standalone.go
+++ b/cmd/soci/commands/internal/standalone.go
@@ -70,20 +70,9 @@ func LoadImage(ctx context.Context, inputPath string, tmpDir string) (*Standalon
 	if err != nil {
 		return nil, fmt.Errorf("failed to read index.json from %s: %w", inputPath, err)
 	}
-	rootDesc, err := parseRootDescriptor(indexData)
+	rootDesc, err := resolveLayoutRoot(tmpDir, indexData)
 	if err != nil {
 		return nil, err
-	}
-
-	// If the root descriptor is a manifest list (e.g. from nerdctl save),
-	// resolve it to available platform manifests. This handles partial exports
-	// where the manifest list references all platforms but only a subset of
-	// platform blobs were exported.
-	if images.IsIndexType(rootDesc.MediaType) {
-		rootDesc, err = resolveManifestList(tmpDir, rootDesc)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	orasStore, err := oci.New(tmpDir)
@@ -139,73 +128,81 @@ func SaveImageToDir(srcDir string, desc ocispec.Descriptor, outputPath string) e
 	return os.WriteFile(filepath.Join(outputPath, "index.json"), indexData, 0644)
 }
 
-// parseRootDescriptor unmarshals OCI index JSON and returns the manifest descriptor.
-func parseRootDescriptor(indexData []byte) (ocispec.Descriptor, error) {
-	var index ocispec.Index
-	if err := json.Unmarshal(indexData, &index); err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("failed to unmarshal index.json: %w", err)
+// resolveLayoutRoot returns a root descriptor for the OCI image layout. The result
+// is either a single image manifest descriptor or a manifest list descriptor.
+//
+// It accepts index.json shapes produced by common tools: a single image manifest,
+// a single descriptor pointing at a nested manifest list (e.g. nerdctl save), or
+// a flat list of per-platform manifests (e.g. go-containerregistry layout.Write).
+// If some children are missing their blobs, they are filtered out and a new
+// manifest list blob is written into layoutDir.
+func resolveLayoutRoot(layoutDir string, indexData []byte) (ocispec.Descriptor, error) {
+	var top ocispec.Index
+	if err := json.Unmarshal(indexData, &top); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("unmarshal index.json: %w", err)
 	}
-	if len(index.Manifests) == 0 {
+	if len(top.Manifests) == 0 {
 		return ocispec.Descriptor{}, errors.New("index.json contains no manifests")
 	}
-	return index.Manifests[0], nil
-}
-
-// resolveManifestList reads a manifest list blob and resolves it based on which
-// platform blobs are actually present in the layout. If all platforms are available,
-// it returns the original manifest list. If only one is available, it returns that
-// platform manifest directly. If multiple (but not all) are available, it writes a
-// filtered manifest list containing only the available platforms. This handles tools
-// like `nerdctl save` that export a manifest list referencing all platforms even when
-// only a subset was pulled.
-func resolveManifestList(layoutDir string, listDesc ocispec.Descriptor) (ocispec.Descriptor, error) {
-	blobPath := filepath.Join(layoutDir, "blobs", listDesc.Digest.Algorithm().String(), listDesc.Digest.Encoded())
-	listData, err := os.ReadFile(blobPath)
-	if err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("failed to read manifest list blob: %w", err)
+	// Single non-index entry: a plain single-platform image.
+	if len(top.Manifests) == 1 && !images.IsIndexType(top.Manifests[0].MediaType) {
+		return top.Manifests[0], nil
 	}
 
-	var manifestList ocispec.Index
-	if err := json.Unmarshal(listData, &manifestList); err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("failed to unmarshal manifest list: %w", err)
+	// Locate the manifest list to walk. Either index.json points at a nested list
+	// blob, or index.json is itself the list.
+	var (
+		listBytes = indexData
+		mediaType = top.MediaType
+	)
+	if len(top.Manifests) == 1 {
+		mediaType = top.Manifests[0].MediaType
+		b, err := os.ReadFile(blobPath(layoutDir, top.Manifests[0].Digest))
+		if err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("read manifest list: %w", err)
+		}
+		listBytes = b
+	}
+	if mediaType == "" {
+		mediaType = ocispec.MediaTypeImageIndex
 	}
 
-	// Find which platform manifests have their blobs present
-	var available []ocispec.Descriptor
-	for _, desc := range manifestList.Manifests {
-		p := filepath.Join(layoutDir, "blobs", desc.Digest.Algorithm().String(), desc.Digest.Encoded())
-		if _, err := os.Stat(p); err == nil {
-			available = append(available, desc)
+	var list ocispec.Index
+	if err := json.Unmarshal(listBytes, &list); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("unmarshal manifest list: %w", err)
+	}
+
+	available := make([]ocispec.Descriptor, 0, len(list.Manifests))
+	for _, d := range list.Manifests {
+		if _, err := os.Stat(blobPath(layoutDir, d.Digest)); err == nil {
+			available = append(available, d)
 		}
 	}
-	if len(available) == 0 {
-		return ocispec.Descriptor{}, errors.New("manifest list contains no manifests with available blobs")
-	}
-
-	// If all platforms are available, keep the original manifest list
-	if len(available) == len(manifestList.Manifests) {
-		return listDesc, nil
-	}
-
-	// If only one platform is available, return it directly as a single manifest
-	if len(available) == 1 {
+	switch {
+	case len(available) == 0:
+		return ocispec.Descriptor{}, errors.New("manifest list contains no entries with available blobs")
+	case len(available) == 1 && images.IsManifestType(available[0].MediaType):
 		return available[0], nil
+	case len(top.Manifests) == 1 && len(available) == len(list.Manifests):
+		return top.Manifests[0], nil
 	}
 
-	// Multiple (but not all) platforms available: write a filtered manifest list
-	manifestList.Manifests = available
-	filteredData, err := json.Marshal(manifestList)
+	list.MediaType = mediaType
+	list.Manifests = available
+	data, err := json.Marshal(list)
 	if err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("failed to marshal filtered manifest list: %w", err)
+		return ocispec.Descriptor{}, fmt.Errorf("marshal manifest list: %w", err)
 	}
-	filteredDigest := digest.FromBytes(filteredData)
-	filteredPath := filepath.Join(layoutDir, "blobs", filteredDigest.Algorithm().String(), filteredDigest.Encoded())
-	if err := os.WriteFile(filteredPath, filteredData, 0644); err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("failed to write filtered manifest list: %w", err)
+	dgst := digest.FromBytes(data)
+	if err := os.MkdirAll(filepath.Dir(blobPath(layoutDir, dgst)), 0755); err != nil {
+		return ocispec.Descriptor{}, err
 	}
-	return ocispec.Descriptor{
-		MediaType: listDesc.MediaType,
-		Digest:    filteredDigest,
-		Size:      int64(len(filteredData)),
-	}, nil
+	if err := os.WriteFile(blobPath(layoutDir, dgst), data, 0644); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return ocispec.Descriptor{MediaType: mediaType, Digest: dgst, Size: int64(len(data))}, nil
+}
+
+func blobPath(layoutDir string, dgst digest.Digest) string {
+	return filepath.Join(layoutDir, "blobs", dgst.Algorithm().String(), dgst.Encoded())
 }

--- a/integration/convert_standalone_test.go
+++ b/integration/convert_standalone_test.go
@@ -17,13 +17,16 @@
 package integration
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/awslabs/soci-snapshotter/soci"
 	"github.com/awslabs/soci-snapshotter/util/dockershell"
 	"github.com/awslabs/soci-snapshotter/util/testutil"
 	"github.com/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestStandaloneConvertBasic(t *testing.T) {
@@ -255,10 +258,98 @@ func TestStandaloneConvertIdempotent(t *testing.T) {
 	}
 }
 
-func exportToOCIDir(sh *dockershell.Shell, imageRef, outputDir string) {
+func exportToOCIDir(sh *dockershell.Shell, imageRef, outputDir string, saveArgs ...string) {
 	exportTar := outputDir + ".export.tar"
-	sh.X("nerdctl", "save", "-o", exportTar, imageRef)
+	sh.X(append(append([]string{"nerdctl", "save"}, saveArgs...), "-o", exportTar, imageRef)...)
 	sh.X("mkdir", "-p", outputDir)
 	sh.X("tar", "-xf", exportTar, "-C", outputDir)
 	sh.X("rm", "-f", exportTar)
+}
+
+func TestStandaloneConvertAllPlatforms(t *testing.T) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	// Pull and save the multi-arch image directly from its public registry.
+	srcRef := dockerhub(nginxImage).ref
+
+	baseDir, err := testutil.TempDir(sh)
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer sh.X("rm", "-rf", baseDir)
+
+	inputDir := filepath.Join(baseDir, "input")
+	outputTar := filepath.Join(baseDir, "output.tar")
+
+	sh.X("nerdctl", "pull", "-q", "--all-platforms", srcRef)
+	exportToOCIDir(sh, srcRef, inputDir, "--all-platforms")
+
+	srcDigest := getImageDigest(sh, srcRef)
+	var srcPlatforms []string
+	for _, m := range readIndex(t, sh, srcDigest).Manifests {
+		if m.Platform != nil {
+			srcPlatforms = append(srcPlatforms, platforms.Format(*m.Platform))
+		}
+	}
+	if len(srcPlatforms) < 2 {
+		t.Skipf("expected multi-arch input, got %d platforms", len(srcPlatforms))
+	}
+
+	stopContainerd(t, sh)
+
+	sh.X("soci", "convert",
+		"--standalone",
+		"--all-platforms",
+		"--min-layer-size=0",
+		inputDir,
+		outputTar,
+	)
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+
+	dstRef := srcRef + "-standalone-allplatforms"
+	sh.X("ctr", "images", "import", "--no-unpack", "--index-name", dstRef, outputTar)
+
+	dstDigest := getImageDigest(sh, dstRef)
+	validateConversion(t, sh, srcDigest, dstDigest)
+
+	imgs, sociIdx := map[string]bool{}, map[string]bool{}
+	for _, m := range readIndex(t, sh, dstDigest).Manifests {
+		if m.Platform == nil {
+			continue
+		}
+		key := platforms.Format(*m.Platform)
+		switch m.ArtifactType {
+		case soci.SociIndexArtifactTypeV2:
+			sociIdx[key] = true
+		case "":
+			imgs[key] = true
+		}
+	}
+	for _, p := range srcPlatforms {
+		if !imgs[p] {
+			t.Errorf("converted output missing image manifest for %s", p)
+		}
+		if !sociIdx[p] {
+			t.Errorf("converted output missing SOCI index for %s", p)
+		}
+	}
+}
+
+// readIndex fetches an OCI image index from the content store, unwrapping a
+// single-manifest wrapper (as produced by `ctr images import --index-name`).
+func readIndex(t *testing.T, sh *dockershell.Shell, indexDigest string) ocispec.Index {
+	t.Helper()
+	var idx ocispec.Index
+	if err := json.Unmarshal(sh.O("ctr", "content", "get", indexDigest), &idx); err != nil {
+		t.Fatalf("parse index %s: %v", indexDigest, err)
+	}
+	if len(idx.Manifests) == 1 && idx.Manifests[0].MediaType == ocispec.MediaTypeImageIndex {
+		return readIndex(t, sh, idx.Manifests[0].Digest.String())
+	}
+	return idx
 }


### PR DESCRIPTION
**Issue #, if available:**

Fixes - https://github.com/awslabs/soci-snapshotter/issues/1948

**Description of changes:**

The standalone layout loader parsed only index.json.manifests[0], so any input whose top-level index listed multiple per-platform manifests directly (e.g. from go-containerregistry's layout.Write) lost every platform after the first silently when using --all-platforms, or with a misleading "manifest not found" when using --platform.

Replace the single-element parse with resolveLayoutRoot, which handles all three shapes index.json (single image, nested manifest list, flat per-platform list), filters out children whose blobs are missing, and promotes the top-level index to a content-addressable blob when it is itself the manifest list.



Running the reproduction steps here now gives correct results - https://github.com/awslabs/soci-snapshotter/issues/1948

```
SOCI_BIN=/Users/prafulg/projects/prafulg/soci-snapshotter/out/soci ./reproduce.sh


=== INPUT platforms ===
{
  "platform": {
    "architecture": "arm64",
    "os": "linux"
  },
  "digest": "sha256:7094b474ca994e198cf92414e0c552a315eb48237053292756425c1f24e819ce"
}
{
  "platform": {
    "architecture": "amd64",
    "os": "linux"
  },
  "digest": "sha256:965a4be6edf9b4658f854d042d21f92fc4158871547fc769be7a1150cc677ad8"
}
{
  "platform": {
    "architecture": "arm",
    "os": "linux",
    "variant": "v7"
  },
  "digest": "sha256:2381361da9d2c687488804c23e41b3aaf99101609d6d985b9c4b8f26eb5517f6"
}

=== convert --all-platforms ===
layer sha256:fee30871cd8cc89f6c3e6ed53bede46c1f08bb1d8051cd6384517d756099d454 -> ztoc sha256:34d0ce07a2d20dc49ac1459cf1448d2a2dafc1f9660f4d149ac44b6475333cdd
layer sha256:552ed30d0b0dfa9ae77aab6a08c2e1dbc8b3cef6243e9c9fc9715f566b08f202 -> ztoc sha256:4396be51bf34bb3d58192c7a4adb355585e4fbe770c3248949d4b235a9b76122
layer sha256:9fa8a8506df39d5a95b9b2e12bd982f79f31a71e8b238b757fc04e3b53e06673 -> ztoc sha256:8c5a21917a338c59324b0c66d1f5bdadf3342a5a6a76c7309da9cbe4ed9bb869
(exit 0)
{
  "platform": {
    "architecture": "arm64",
    "os": "linux"
  },
  "artifactType": null
}
{
  "platform": {
    "architecture": "amd64",
    "os": "linux"
  },
  "artifactType": null
}
{
  "platform": {
    "architecture": "arm",
    "os": "linux",
    "variant": "v7"
  },
  "artifactType": null
}
{
  "platform": {
    "architecture": "arm64",
    "os": "linux"
  },
  "artifactType": "application/vnd.amazon.soci.index.v2+json"
}
{
  "platform": {
    "architecture": "amd64",
    "os": "linux"
  },
  "artifactType": "application/vnd.amazon.soci.index.v2+json"
}
{
  "platform": {
    "architecture": "arm",
    "os": "linux",
    "variant": "v7"
  },
  "artifactType": "application/vnd.amazon.soci.index.v2+json"
}

=== convert --platform linux/amd64 (not first) ===
layer sha256:552ed30d0b0dfa9ae77aab6a08c2e1dbc8b3cef6243e9c9fc9715f566b08f202 -> ztoc sha256:4396be51bf34bb3d58192c7a4adb355585e4fbe770c3248949d4b235a9b76122
(exit 0)
{
  "platform": {
    "architecture": "arm64",
    "os": "linux"
  },
  "artifactType": null
}
{
  "platform": {
    "architecture": "amd64",
    "os": "linux"
  },
  "artifactType": null
}
{
  "platform": {
    "architecture": "arm",
    "os": "linux",
    "variant": "v7"
  },
  "artifactType": null
}
{
  "platform": {
    "architecture": "amd64",
    "os": "linux"
  },
  "artifactType": "application/vnd.amazon.soci.index.v2+json"
}
```

**Testing performed:**

Added Integration test for multiple platform image.

```
lima sudo GO_TEST_FLAGS="-run TestStandalone -count=1" make integration 2>&1 | tail -25)
  ⎿  === RUN   TestStandaloneConvertBasic/tar-to-tar
     --- PASS: TestStandaloneConvertBasic/tar-to-tar (0.22s)
     === RUN   TestStandaloneConvertBasic/dir-to-dir
     --- PASS: TestStandaloneConvertBasic/dir-to-dir (0.28s)
     === RUN   TestStandaloneConvertBasic/tar-to-dir
     --- PASS: TestStandaloneConvertBasic/tar-to-dir (0.27s)
     --- PASS: TestStandaloneConvertBasic (24.86s)
     === RUN   TestStandaloneConvertSpecificPlatform
     --- PASS: TestStandaloneConvertSpecificPlatform (21.11s)
     === RUN   TestStandaloneInvalidConversion
     === RUN   TestStandaloneInvalidConversion/nonexistent_input
     --- PASS: TestStandaloneInvalidConversion/nonexistent_input (0.03s)
     === RUN   TestStandaloneInvalidConversion/invalid_format
     --- PASS: TestStandaloneInvalidConversion/invalid_format (0.03s)
     === RUN   TestStandaloneInvalidConversion/missing_destination
     --- PASS: TestStandaloneInvalidConversion/missing_destination (0.03s)
     --- PASS: TestStandaloneInvalidConversion (1.58s)
     === RUN   TestStandaloneConvertIdempotent
     --- PASS: TestStandaloneConvertIdempotent (20.65s)
     === RUN   TestStandaloneConvertAllPlatforms
     --- PASS: TestStandaloneConvertAllPlatforms (38.93s)
     PASS
     ok         github.com/awslabs/soci-snapshotter/integration 200.444s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
