### PR TITLE
Add minimal crictl integration test + setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@
 ARG CONTAINERD_VERSION=1.7.30
 ARG RUNC_VERSION=1.3.3
 ARG NERDCTL_VERSION=2.1.6
+ARG CRICTL_VERSION=1.36.0
 ARG IGZIP_VERSION=2.31.1
 ARG RAPIDGZIP_VERSION=0.14.3
 
@@ -101,6 +102,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS containerd-snapshotter-base
 ARG CONTAINERD_VERSION
 ARG RUNC_VERSION
 ARG NERDCTL_VERSION
+ARG CRICTL_VERSION
 ARG TARGETARCH
 ENV GOPROXY=direct
 ENV GOCOVERDIR=/test_coverage
@@ -141,3 +143,6 @@ RUN curl -sSL --output /tmp/runc https://github.com/opencontainers/runc/releases
 RUN curl -sSL --output /tmp/nerdctl.tgz https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${TARGETARCH:-amd64}.tar.gz \
     && tar zxvf /tmp/nerdctl.tgz -C /usr/local/bin/ \
     && rm -f /tmp/nerdctl.tgz
+RUN curl -sSL --output /tmp/crictl.tgz https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRICTL_VERSION}/crictl-v${CRICTL_VERSION}-linux-${TARGETARCH:-amd64}.tar.gz \
+    && tar zxvf /tmp/crictl.tgz -C /usr/local/bin/ \
+    && rm -f /tmp/crictl.tgz

--- a/integration/cri_test.go
+++ b/integration/cri_test.go
@@ -1,0 +1,46 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/awslabs/soci-snapshotter/util/testutil"
+)
+
+// TestCRIImagePull pulls a SOCI-converted image through containerd's CRI image endpoint
+// and asserts that the layers are mounted as remote SOCI snapshots.
+func TestCRIImagePull(t *testing.T) {
+	regConfig := newRegistryConfig()
+	sh, done := newShellWithRegistry(t, regConfig)
+	defer done()
+
+	image := alpineImage
+
+	rebootContainerd(t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t))
+	copyImage(sh, dockerhub(image), regConfig.mirror(image))
+	buildIndex(sh, regConfig.mirror(image), withMinLayerSize(0))
+	sh.X("soci", "push", "--user", regConfig.creds(), regConfig.mirror(image).ref)
+
+	rsm := testutil.NewRemoteSnapshotMonitor()
+	m := rebootContainerd(t, sh, getCRIContainerdConfigToml(t, false), getSnapshotterConfigToml(t, withCRIKeychain), rsm.MonitorFunc)
+	defer m.Cleanup(t)
+
+	sh.X(append(crictlCmd, "pull", "--creds", regConfig.creds(), regConfig.mirror(image).ref)...)
+
+	rsm.CheckAllRemoteSnapshots(t)
+}

--- a/integration/util_test.go
+++ b/integration/util_test.go
@@ -84,6 +84,11 @@ const (
 var (
 	runSociCmd   = []string{"nerdctl", "run", "--pull", "never", "--net", "none", "--snapshotter", "soci"}
 	imagePullCmd = []string{"nerdctl", "pull", "-q", "--snapshotter", "soci"}
+	crictlCmd    = []string{
+		"crictl",
+		"--runtime-endpoint", "unix:///run/containerd/containerd.sock",
+		"--image-endpoint", "unix:///run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock",
+	}
 )
 
 // These are images that we use in our integration tests
@@ -125,6 +130,44 @@ disabled_plugins = [
 	"io.containerd.internal.v1.tracing",
 	"io.containerd.grpc.v1.cri",
 ]
+
+[plugins."io.containerd.snapshotter.v1.soci"]
+root_path = "/var/lib/soci-snapshotter-grpc/"
+disable_verification = {{.DisableVerification}}
+
+[plugins."io.containerd.snapshotter.v1.soci".blob]
+check_always = true
+
+[debug]
+format = "json"
+level = "{{.LogLevel}}"
+
+{{.AdditionalConfig}}
+`
+
+// criContainerdConfigTemplate is the CRI counterpart to `containerdConfigTemplate`: it
+// leaves the containerd CRI plugin enabled and points it at the SOCI snapshotter.
+const criContainerdConfigTemplate = `
+version = 2
+
+disabled_plugins = [
+	"io.containerd.snapshotter.v1.aufs",
+	"io.containerd.snapshotter.v1.btrfs",
+	"io.containerd.snapshotter.v1.devmapper",
+	"io.containerd.snapshotter.v1.zfs",
+	"io.containerd.tracing.processor.v1.otlp",
+	"io.containerd.internal.v1.tracing",
+]
+
+# containerd 1.7.x
+[plugins."io.containerd.grpc.v1.cri".containerd]
+snapshotter = "soci"
+disable_snapshot_annotations = false
+
+# containerd 2.x
+[plugins."io.containerd.cri.v1.images"]
+snapshotter = "soci"
+disable_snapshot_annotations = false
 
 [plugins."io.containerd.snapshotter.v1.soci"]
 root_path = "/var/lib/soci-snapshotter-grpc/"
@@ -314,6 +357,27 @@ func getContainerdConfigToml(t *testing.T, disableVerification bool, additionalC
 	return s
 }
 
+// getCRIContainerdConfigToml is the CRI counterpart to `getContainerdConfigToml`,
+// rendering `criContainerdConfigTemplate` instead.
+func getCRIContainerdConfigToml(t *testing.T, disableVerification bool, additionalConfigs ...string) string {
+	if !isTestingBuiltinSnapshotter() {
+		additionalConfigs = append(additionalConfigs, proxySnapshotterConfig)
+	}
+	s, err := testutil.ApplyTextTemplate(criContainerdConfigTemplate, struct {
+		LogLevel            string
+		DisableVerification bool
+		AdditionalConfig    string
+	}{
+		LogLevel:            containerdLogLevel,
+		DisableVerification: disableVerification,
+		AdditionalConfig:    strings.Join(additionalConfigs, "\n"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
 type snapshotterConfigOpt func(*config.Config)
 
 func withTCPMetrics(cfg *config.Config) {
@@ -333,6 +397,10 @@ func withMaxConcurrency(m int64) snapshotterConfigOpt {
 
 func withDisableBgFetcher(cfg *config.Config) {
 	cfg.ServiceConfig.FSConfig.BackgroundFetchConfig.Disable = true
+}
+
+func withCRIKeychain(cfg *config.Config) {
+	cfg.ServiceConfig.CRIKeychainConfig.EnableKeychain = true
 }
 
 func withMinLayerSizeConfig(minLayerSize int64) snapshotterConfigOpt {


### PR DESCRIPTION
**Issue #, if available:**

Helps with initializing the infra and basic test for - https://github.com/awslabs/soci-snapshotter/issues/1572

**Description of changes:**

Initializing the testing setup for crictl to get more closer to mimicking the behavior of k8s, in future we can choose to refactor/extend this as we require. This PR is just a initial setup with a basic passing test verifying the remote snapshot creation.

**Testing performed:**

```
sudo GO_TEST_FLAGS="-run TestCRIImagePull -count=1 -v" make integration

cd cmd/ ; GO111MODULE=auto go build -o /Volumes/git/prafulg/soci-snapshotter/out/soci-snapshotter-grpc  -ldflags '-X github.com/awslabs/soci-snapshotter/version.Version=07f7d54d.m -X github.com/awslabs/soci-snapshotter/version.Revision=07f7d54d55101c04799ef63e7ff64a13805d326e.m  -s -w '  ./soci-snapshotter-grpc
cd cmd/ ; GO111MODULE=auto go build -o /Volumes/git/prafulg/soci-snapshotter/out/soci  -ldflags '-X github.com/awslabs/soci-snapshotter/version.Version=07f7d54d.m -X github.com/awslabs/soci-snapshotter/version.Revision=07f7d54d55101c04799ef63e7ff64a13805d326e.m  -s -w '  ./soci
integration
SOCI_SNAPSHOTTER_PROJECT_ROOT=/Volumes/git/prafulg/soci-snapshotter
=== RUN   TestCRIImagePull
    shell.go:279: all layers have been reported as remote snapshots (remote:1,local:0,deferred:0)
--- PASS: TestCRIImagePull (7.40s)
PASS
ok      github.com/awslabs/soci-snapshotter/integration 104.789s

DONE 1 tests in 96.760s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
