### PR TITLE
Upgrade to go 1.25.9

### DIFF
--- a/.github/workflows/benchmark-visualization.yml
+++ b/.github/workflows/benchmark-visualization.yml
@@ -19,7 +19,7 @@ permissions:
   deployments: write
 
 env:
-  GO_VERSION: '1.25.8'
+  GO_VERSION: '1.25.9'
 
 jobs:
   benchmark:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
-        go-version: ['1.25.8', '1.26.0']
+        go-version: ['1.25.9', '1.26.0']
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ['1.25.8', '1.26.0']
+        go-version: ['1.25.9', '1.26.0']
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
-        go-version: ['1.25.8', '1.26.0']
+        go-version: ['1.25.9', '1.26.0']
         containerd: ["1.7.30", "2.1.6", "2.2.2"]
     env:
       DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"

--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.25.8'
+  GO_VERSION: '1.25.9'
 
 permissions:
   contents: write

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -11,7 +11,7 @@ on:
       - 'Makefile'
 
 env:
-  GO_VERSION: '1.25.8'
+  GO_VERSION: '1.25.9'
 
 jobs:
   check:

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -7,7 +7,7 @@ on:
     branches: ['main', 'release/**']
 
 env:
-  GO_VERSION: '1.25.8'
+  GO_VERSION: '1.25.9'
   GOLANGCI_LINT_VERSION: '2.5.0'
 
 jobs:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,7 +12,7 @@ on:
       - 'Makefile'
 
 env:
-  GO_VERSION: '1.25.8'
+  GO_VERSION: '1.25.9'
 
 permissions:
   contents: write


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Upgrade go version to latest 1.25.9 as it fixes a lot of CVEs (this was being flagged by our systems as this old version of go had a lot of critical CVEs)

Few CVEs - 
- https://nvd.nist.gov/vuln/detail/CVE-2026-27143
- https://nvd.nist.gov/vuln/detail/CVE-2026-32281
- https://nvd.nist.gov/vuln/detail/CVE-2026-32283
-  \+ 3 more

**Testing performed:**

```
prafulg@lima-default:/Volumes/git/prafulg/soci-snapshotter$ sudo make test
test-lib
ok      github.com/awslabs/soci-snapshotter/cache       1.016s
ok      github.com/awslabs/soci-snapshotter/config      1.011s
ok      github.com/awslabs/soci-snapshotter/fs  2.763s
ok      github.com/awslabs/soci-snapshotter/fs/backgroundfetcher        22.558s
ok      github.com/awslabs/soci-snapshotter/fs/layer    9.042s
?       github.com/awslabs/soci-snapshotter/fs/metrics/common   [no test files]
?       github.com/awslabs/soci-snapshotter/fs/metrics/layer    [no test files]
ok      github.com/awslabs/soci-snapshotter/fs/reader   7.354s
ok      github.com/awslabs/soci-snapshotter/fs/remote   8.140s
?       github.com/awslabs/soci-snapshotter/fs/source   [no test files]
ok      github.com/awslabs/soci-snapshotter/fs/span-manager     19.149s
ok      github.com/awslabs/soci-snapshotter/idtools     1.006s
ok      github.com/awslabs/soci-snapshotter/integration 1.019s
ok      github.com/awslabs/soci-snapshotter/internal/archive/compression        1.012s
ok      github.com/awslabs/soci-snapshotter/internal/http       1.007s
ok      github.com/awslabs/soci-snapshotter/internal/os 1.007s
ok      github.com/awslabs/soci-snapshotter/metadata    4.932s
?       github.com/awslabs/soci-snapshotter/service     [no test files]
?       github.com/awslabs/soci-snapshotter/service/keychain/cri/v1     [no test files]
?       github.com/awslabs/soci-snapshotter/service/keychain/cri/v1alpha        [no test files]
?       github.com/awslabs/soci-snapshotter/service/keychain/dockerconfig       [no test files]
?       github.com/awslabs/soci-snapshotter/service/keychain/kubeconfig [no test files]
?       github.com/awslabs/soci-snapshotter/service/plugin      [no test files]
ok      github.com/awslabs/soci-snapshotter/service/resolver    1.011s
ok      github.com/awslabs/soci-snapshotter/snapshot    1.019s
ok      github.com/awslabs/soci-snapshotter/soci        1.026s
ok      github.com/awslabs/soci-snapshotter/soci/store  1.017s
?       github.com/awslabs/soci-snapshotter/util/dbutil [no test files]
?       github.com/awslabs/soci-snapshotter/util/dockershell    [no test files]
?       github.com/awslabs/soci-snapshotter/util/dockershell/compose    [no test files]
?       github.com/awslabs/soci-snapshotter/util/dockershell/exec       [no test files]
ok      github.com/awslabs/soci-snapshotter/util/ioutils        1.006s
ok      github.com/awslabs/soci-snapshotter/util/lrucache       1.006s
?       github.com/awslabs/soci-snapshotter/util/namedmutex     [no test files]
ok      github.com/awslabs/soci-snapshotter/util/ociutil        1.007s
?       github.com/awslabs/soci-snapshotter/util/testutil       [no test files]
ok      github.com/awslabs/soci-snapshotter/version     1.007s
ok      github.com/awslabs/soci-snapshotter/ztoc        46.250s
ok      github.com/awslabs/soci-snapshotter/ztoc/compression    1.007s
?       github.com/awslabs/soci-snapshotter/ztoc/compression/fbs/zinfo  [no test files]
?       github.com/awslabs/soci-snapshotter/ztoc/fbs/ztoc       [no test files]
test-cmd
?       github.com/awslabs/soci-snapshotter/cmd/soci    [no test files]
?       github.com/awslabs/soci-snapshotter/cmd/soci/commands   [no test files]
?       github.com/awslabs/soci-snapshotter/cmd/soci/commands/global    [no test files]
?       github.com/awslabs/soci-snapshotter/cmd/soci/commands/index     [no test files]
?       github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal  [no test files]
?       github.com/awslabs/soci-snapshotter/cmd/soci/commands/prefetch  [no test files]
?       github.com/awslabs/soci-snapshotter/cmd/soci/commands/ztoc      [no test files]
ok      github.com/awslabs/soci-snapshotter/cmd/soci-snapshotter-grpc   1.155s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
