### PR TITLE
Properly find preload files with absolute path

### DIFF
--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -332,56 +332,73 @@ func TestSociCreate(t *testing.T) {
 
 func TestSociCreateWithPrefetchArtifacts(t *testing.T) {
 	const (
-		// Tar headers record file paths without a leading slash, so the prefetch flag uses the tar path.
-		prefetchTarPath     = "etc/alpine-release"
-		runtimePrefetchPath = "/etc/alpine-release"
+		relativePath = "etc/alpine-release"
+		absolutePath = "/etc/alpine-release"
 	)
+	// Test both absolute and relative paths
+	paths := []string{relativePath, absolutePath}
 
-	regConfig := newRegistryConfig()
-	sh, done := newShellWithRegistry(t, regConfig)
-	defer done()
-
-	rebootContainerd(t, sh, "", "")
-
-	mirrorImg := regConfig.mirror(alpineImage)
-	copyImage(sh, dockerhub(alpineImage), mirrorImg)
-
-	indexDigest := buildIndex(sh, mirrorImg, withMinLayerSize(0), withPrefetchPaths(prefetchTarPath))
-	if indexDigest == "" {
-		t.Fatal("failed to build SOCI index with prefetch artifacts")
-	}
-
-	if err := assertPrefetchArtifactCreated(sh, indexDigest, mirrorImg, prefetchTarPath); err != nil {
-		t.Fatal(err)
-	}
-
-	sh.X("soci", "push", "--user", regConfig.creds(), mirrorImg.ref)
-
-	prefetchLogCh := make(chan struct{}, 1)
-	m := rebootContainerd(
-		t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, withPrefetch()),
-		func(line string) {
-			if strings.Contains(line, "Successfully loaded prefetch artifact") {
-				select {
-				case prefetchLogCh <- struct{}{}:
-				default:
-				}
+	for _, prefetchTarPath := range paths {
+		createName := "relative path"
+		if prefetchTarPath == absolutePath {
+			createName = "absolute path"
+		}
+		for _, runtimePrefetchPath := range paths {
+			runtimeName := "relative path"
+			if runtimePrefetchPath == absolutePath {
+				runtimeName = "absolute path"
 			}
-		},
-	)
-	defer m.Cleanup(t)
 
-	sh.X(append(imagePullCmd, "--soci-index-digest", indexDigest, mirrorImg.ref)...)
+			t.Run(fmt.Sprintf("created with %s, run with %s", createName, runtimeName), func(t *testing.T) {
+				regConfig := newRegistryConfig()
+				sh, done := newShellWithRegistry(t, regConfig)
+				defer done()
 
-	releaseContents := sh.O(append(runSociCmd, "--rm", mirrorImg.ref, "cat", runtimePrefetchPath)...)
-	if strings.TrimSpace(string(releaseContents)) == "" {
-		t.Fatalf("unexpected empty output when reading %s", runtimePrefetchPath)
-	}
+				rebootContainerd(t, sh, "", "")
 
-	select {
-	case <-prefetchLogCh:
-	case <-time.After(30 * time.Second):
-		t.Fatalf("did not observe snapshotter loading prefetch artifact")
+				mirrorImg := regConfig.mirror(alpineImage)
+				copyImage(sh, dockerhub(alpineImage), mirrorImg)
+
+				indexDigest := buildIndex(sh, mirrorImg, withMinLayerSize(0), withPrefetchPaths(prefetchTarPath))
+				if indexDigest == "" {
+					t.Fatal("failed to build SOCI index with prefetch artifacts")
+				}
+
+				if err := assertPrefetchArtifactCreated(sh, indexDigest, mirrorImg, prefetchTarPath); err != nil {
+					t.Fatal(err)
+				}
+
+				sh.X("soci", "push", "--user", regConfig.creds(), mirrorImg.ref)
+
+				prefetchLogCh := make(chan struct{}, 1)
+				m := rebootContainerd(
+					t, sh, getContainerdConfigToml(t, false), getSnapshotterConfigToml(t, withPrefetch()),
+					func(line string) {
+						if strings.Contains(line, "Successfully loaded prefetch artifact") {
+							select {
+							case prefetchLogCh <- struct{}{}:
+							default:
+							}
+						}
+					},
+				)
+				defer m.Cleanup(t)
+
+				sh.X(append(imagePullCmd, "--soci-index-digest", indexDigest, mirrorImg.ref)...)
+
+				releaseContents := sh.O(append(runSociCmd, "--rm", mirrorImg.ref, "cat", runtimePrefetchPath)...)
+				if strings.TrimSpace(string(releaseContents)) == "" {
+					t.Fatalf("unexpected empty output when reading %s", runtimePrefetchPath)
+				}
+
+				select {
+				case <-prefetchLogCh:
+				case <-time.After(30 * time.Second):
+					t.Fatalf("did not observe snapshotter loading prefetch artifact")
+				}
+			})
+
+		}
 	}
 }
 

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -590,7 +590,10 @@ func (b *IndexBuilder) build(ctx context.Context, img images.Image, buildCfg bui
 
 	var prefetchDescs []*ocispec.Descriptor
 	if len(b.config.prefetchPaths) > 0 && len(builtZtocs) > 0 {
-		prefetchDescs = b.buildPrefetchLayer(ctx, builtZtocs, manifest.Layers)
+		prefetchDescs, err = b.buildPrefetchLayer(ctx, builtZtocs, manifest.Layers)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build prefetch layers: %w", err)
+		}
 	}
 
 	ztocsDesc := make([]ocispec.Descriptor, 0, len(sociLayersDesc)+len(prefetchDescs))
@@ -752,9 +755,9 @@ func (b *IndexBuilder) buildSociLayer(ctx context.Context, desc ocispec.Descript
 }
 
 // buildPrefetchLayer builds and stores prefetch artifacts for layers that contain prefetch files
-func (b *IndexBuilder) buildPrefetchLayer(ctx context.Context, builtZtocs []*ztocWithLayer, layers []ocispec.Descriptor) []*ocispec.Descriptor {
+func (b *IndexBuilder) buildPrefetchLayer(ctx context.Context, builtZtocs []*ztocWithLayer, layers []ocispec.Descriptor) ([]*ocispec.Descriptor, error) {
 	if len(b.config.prefetchPaths) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	layerZtocMap := make(map[string]*ztocWithLayer, len(builtZtocs))
@@ -765,6 +768,9 @@ func (b *IndexBuilder) buildPrefetchLayer(ctx context.Context, builtZtocs []*zto
 	layerPrefetchSpansMap := make(map[string][]PrefetchSpan)
 	for _, prefetchPath := range b.config.prefetchPaths {
 		found := false
+		// Strip leading slash if absolute path is given in prefetchPaths
+		// Copied from cleanEntryPath in metadata/reader.go
+		prefetchPath = strings.TrimPrefix(filepath.Clean(string(os.PathSeparator)+prefetchPath), string(os.PathSeparator))
 	PrefetchPathLoop:
 		for i := len(layers) - 1; i >= 0; i-- {
 			layer := layers[i]
@@ -775,9 +781,12 @@ func (b *IndexBuilder) buildPrefetchLayer(ctx context.Context, builtZtocs []*zto
 			}
 
 			for _, metadata := range zwl.ztoc.TOC.FileMetadata {
-				if filepath.Clean(metadata.Name) == prefetchPath {
+				// metadata name should already be cleaned when stored so we don't need to re-clean it
+				if metadata.Name == prefetchPath {
 					gz, err := zwl.ztoc.Zinfo()
 					if err != nil {
+						// The layer has issues but the prefetech path is potentially still findable.
+						// Proceed to search the next layer for the file.
 						log.G(ctx).WithError(err).Warnf("failed to get zinfo for layer %s", layerDigest)
 						break PrefetchPathLoop
 					}
@@ -806,7 +815,7 @@ func (b *IndexBuilder) buildPrefetchLayer(ctx context.Context, builtZtocs []*zto
 	}
 
 	if len(layerPrefetchSpansMap) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	prefetchDescs := make([]*ocispec.Descriptor, 0, len(layerPrefetchSpansMap))
@@ -819,13 +828,13 @@ func (b *IndexBuilder) buildPrefetchLayer(ctx context.Context, builtZtocs []*zto
 
 		prefetchDesc, err := b.storePrefetchLayer(ctx, layerDigest, prefetchSpans)
 		if err != nil {
-			log.G(ctx).WithError(err).Warnf("failed to store prefetch artifact for layer %s", layerDigest)
+			return nil, fmt.Errorf("failed to store prefetch artifact for layer %s: %w", layerDigest, err)
 		} else if prefetchDesc != nil {
 			prefetchDescs = append(prefetchDescs, prefetchDesc)
 		}
 	}
 
-	return prefetchDescs
+	return prefetchDescs, nil
 }
 
 func (b *IndexBuilder) addSociLayerAnnotations(layerDesc *ocispec.Descriptor, ztocDesc *ocispec.Descriptor, toc *ztoc.Ztoc) {

--- a/soci/soci_index_test.go
+++ b/soci/soci_index_test.go
@@ -512,6 +512,11 @@ func TestBuildPrefetchLayer(t *testing.T) {
 			expectedPrefetchDesc: 0, // Will depend on whether files are found in ztoc
 		},
 		{
+			name:                 "successfully build prefetch layer with valid absolute paths",
+			prefetchPaths:        []string{"/test/file1.txt", "/test/file2.txt"},
+			expectedPrefetchDesc: 0, // Will depend on whether files are found in ztoc
+		},
+		{
 			name:                 "no prefetch layer when prefetchPaths is empty",
 			prefetchPaths:        []string{},
 			expectedPrefetchDesc: 0,
@@ -546,7 +551,10 @@ func TestBuildPrefetchLayer(t *testing.T) {
 			builtZtocs := []*ztocWithLayer{}
 			layers := []ocispec.Descriptor{}
 
-			prefetchDescs := builder.buildPrefetchLayer(ctx, builtZtocs, layers)
+			prefetchDescs, err := builder.buildPrefetchLayer(ctx, builtZtocs, layers)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if len(prefetchDescs) != tc.expectedPrefetchDesc {
 				t.Fatalf("expected %d prefetch descriptors, got %d", tc.expectedPrefetchDesc, len(prefetchDescs))


### PR DESCRIPTION
**Issue #, if available:**
Closes #1944

**Description of changes:**
`filepath.Clean` does not remove the leading slash, so we would previously fail to add files to preloading if an absolute path was specified during the index creation process. Removing the leading slash manually should fix this behavior.

Added integration testing to vet this behavior as well. For completion's sake I also added unit testing but it is frankly not a very useful test as it always passes. We should allow the tests to catch and test these errors more rigorously, but this should at least make sure that in the future if we choose to do so, that the code is in place to accept these changes.

**Testing performed:**
Checked that the changes to `TestSociCreateWithPrefetchArtifacts` fails without the other changes and passes with them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
