### PR TITLE
Enforce monotonic checkpoint offsets

### DIFF
--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -36,10 +36,11 @@ import (
 
 // Specific error types raised by SpanManager.
 var (
-	ErrSpanNotAvailable    = errors.New("span not available in cache")
-	ErrIncorrectSpanDigest = errors.New("span digests do not match")
-	ErrExceedMaxSpan       = errors.New("span id larger than max span id")
-	ErrIncorrectMaxSpanID  = errors.New("given max span ID differs from calculated max span ID")
+	ErrSpanNotAvailable        = errors.New("span not available in cache")
+	ErrIncorrectSpanDigest     = errors.New("span digests do not match")
+	ErrExceedMaxSpan           = errors.New("span id larger than max span id")
+	ErrNonMonotonicCheckpoints = errors.New("span offsets are non-monotonic")
+	ErrIncorrectMaxSpanID      = errors.New("given max span ID differs from calculated max span ID")
 )
 
 // SpanManager fetches and caches spans of a given layer.
@@ -109,7 +110,11 @@ func New(ztoc *ztoc.Ztoc, r *io.SectionReader, cache cache.BlobCache, retries in
 	if m.maxSpanVerificationFailureRetries < 0 {
 		m.maxSpanVerificationFailureRetries = defaultSpanVerificationFailureRetries
 	}
-	m.buildAllSpans()
+	err = m.buildAllSpans()
+	if err != nil {
+		m.Close()
+		return nil, err
+	}
 	runtime.SetFinalizer(m, func(m *SpanManager) {
 		m.Close()
 	})
@@ -117,7 +122,7 @@ func New(ztoc *ztoc.Ztoc, r *io.SectionReader, cache cache.BlobCache, retries in
 	return m, nil
 }
 
-func (m *SpanManager) buildAllSpans() {
+func (m *SpanManager) buildAllSpans() error {
 	var i compression.SpanID
 	for i = 0; i <= m.ztoc.MaxSpanID; i++ {
 		s := span{
@@ -130,7 +135,16 @@ func (m *SpanManager) buildAllSpans() {
 
 		m.spans[i] = &s
 		m.spans[i].state.Store(unrequested)
+
+		// Ensure all offsets are larger than the previous offset
+		if i < m.ztoc.MaxSpanID {
+			if s.startCompOffset >= s.endCompOffset ||
+				s.startUncompOffset >= s.endUncompOffset {
+				return ErrNonMonotonicCheckpoints
+			}
+		}
 	}
+	return nil
 }
 
 // FetchSingleSpan invokes the reader to fetch the span in the background and cache

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -19,6 +19,7 @@ package spanmanager
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -52,6 +53,11 @@ func TestSpanManager(t *testing.T) {
 			name:          "bad MaxSpanID",
 			maxSpans:      5,
 			expectedError: ErrIncorrectMaxSpanID,
+		},
+		{
+			name:          "bad span start/end",
+			maxSpans:      3,
+			expectedError: ErrNonMonotonicCheckpoints,
 		},
 		{
 			name:     "header verification fails",
@@ -109,8 +115,11 @@ func TestSpanManager(t *testing.T) {
 				return
 			}
 
+			// Make TOC mutations as needed
 			if errors.Is(tc.expectedError, ErrIncorrectMaxSpanID) {
 				toc.MaxSpanID++
+			} else if errors.Is(tc.expectedError, ErrNonMonotonicCheckpoints) {
+				corruptCheckpoints(toc)
 			}
 
 			if tc.sectionReader != nil {
@@ -438,6 +447,37 @@ func (r *retryableReaderAt) ReadAt(buf []byte, off int64) (int, error) {
 		}
 	}
 	return n, err
+}
+
+// corruptCheckpoint will corrupt a particular checkpoint to create a non-monotonic offset list
+// (i.e. checkpoint 1 -> offset 0, checkpoint 2 -> offset 100, checkpoint 3 -> offset 10)
+// This is separated out from the main test function just to put a lot of text
+// without making it hard to read for all the other test cases.
+func corruptCheckpoints(toc *ztoc.Ztoc) {
+	// Numbers below are from gzip_zinfo.h, copy-pasting for clarity
+
+	/* Since gzip is compressed with 32 KiB window size, WINDOW_SIZE is fixed
+		#define WINSIZE 32768U
+
+	    -  8 bytes, compressed offset
+	    -  8 bytes, uncompressed offset
+	    -  1 byte, bits
+	    -  32768 bytes, window
+
+		#define PACKED_CHECKPOINT_SIZE (8 + 8 + 1 + WINSIZE)
+
+		-  4 bytes, number of checkpoints
+	    -  8 bytes, span size
+		#define BLOB_HEADER_SIZE (4 + 8)
+	*/
+	const (
+		blobHeaderSize       = 4 + 8
+		packedCheckpointSize = 8 + 8 + 1 + 32768
+	)
+
+	startChkpt2 := blobHeaderSize + 2*packedCheckpointSize
+	// 0x1 is arbitrary, any value reasonably less than the previous checkpoint's offest will do
+	binary.LittleEndian.PutUint64(toc.Checkpoints[startChkpt2:startChkpt2+8], 0x1)
 }
 
 func getFileContentFromSpans(m *SpanManager, toc *ztoc.Ztoc, fileName string) ([]byte, error) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Our zTOC logic assumes monotonic checkpoint offsets for its logic to change but never enforced it. This change enforces this logic by forcing strictly increasing start and end of checkpoints.

There's technically no reason a checkpoint can't be zero length so we can maybe make the change to allow that but it's probably more sensical to not allow it to begin with.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
