### PR TITLE
fix(http): set Referer header on redirect-cached requests

### DIFF
--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -257,6 +257,7 @@ func (ac *AuthClient) redirected(req *http.Request) *http.Request {
 		return nil
 	}
 	r := req.Clone(ac.getAuthCtx(req.Context()))
+	r.Header.Set("Referer", req.URL.String())
 	r.URL = newURL
 	r.Host = newURL.Host
 	return r

--- a/internal/http/auth_test.go
+++ b/internal/http/auth_test.go
@@ -210,3 +210,69 @@ func SimpleMockAuthClient(tr http.RoundTripper, header http.Header) *AuthClient 
 	ac, _ := NewAuthClient(&emptyAuthHandler{}, WithRetryableClient(rc), WithHeader(header))
 	return ac
 }
+
+// redirectRoundTripper simulates a server that redirects requests.
+// On the first request it returns a response whose Request.URL differs
+// from the original (simulating a followed redirect). On subsequent
+// requests it records the incoming request for inspection.
+type redirectRoundTripper struct {
+	callCount   int
+	redirectURL string
+	lastRequest *http.Request
+}
+
+func (rt *redirectRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.callCount++
+	rt.lastRequest = req
+
+	// Simulate that the HTTP client followed a redirect:
+	// resp.Request.URL is the final URL after redirect.
+	finalURL, _ := http.NewRequest(req.Method, rt.redirectURL, nil)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Request:    finalURL,
+	}, nil
+}
+
+func TestRedirectCacheSetsRefererHeader(t *testing.T) {
+	originalURL := "http://registry.example.com/v2/repo/blobs/sha256:abc123"
+	redirectTarget := "http://storage.example.com/blob?sig=xyz"
+
+	rt := &redirectRoundTripper{redirectURL: redirectTarget}
+	rc := rhttp.NewClient()
+	rc.RetryMax = 0
+	rc.HTTPClient.Transport = rt
+
+	ac, err := NewAuthClient(&emptyAuthHandler{}, WithRetryableClient(rc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ac.CacheRedirects(true)
+
+	ctx := context.Background()
+
+	// First request: populates the redirect cache
+	req1, _ := http.NewRequestWithContext(ctx, "GET", originalURL, nil)
+	_, err = ac.Do(req1)
+	if err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+
+	// Second request: should hit the cache and set Referer
+	req2, _ := http.NewRequestWithContext(ctx, "GET", originalURL, nil)
+	_, err = ac.Do(req2)
+	if err != nil {
+		t.Fatalf("second request failed: %v", err)
+	}
+
+	// Verify the second request was sent to the redirect target
+	if rt.lastRequest.URL.String() != redirectTarget {
+		t.Fatalf("expected request URL %q, got %q", redirectTarget, rt.lastRequest.URL.String())
+	}
+
+	// Verify the Referer header is set to the original URL
+	referer := rt.lastRequest.Header.Get("Referer")
+	if referer != originalURL {
+		t.Fatalf("expected Referer header %q, got %q", originalURL, referer)
+	}
+}


### PR DESCRIPTION
**Issue #:** #1974

**Description of changes:** Set `Referer` header on requests served from the redirect cache.

In parallel-pull-unpack mode, SOCI caches the final URL after a 307 redirect and sends subsequent requests directly to the storage backend, skipping the redirect hop. This avoids redundant round-trips for parallel fetches. However, Go's HTTP client normally sets the `Referer` header automatically when following a redirect. By skipping the redirect, this header is never set. Storage backends that use Referer-based hot-link protection reject these requests with 401, since the missing `Referer` indicates the request didn't originate from the registry.

The fix sets `Referer` to the original registry URL before rewriting the request to the cached target, matching what Go would set during a real redirect. This adds no extra network calls and is safe for all registries (those that don't check `Referer` simply ignore it). Only affects parallel-pull-unpack mode; lazy SOCI mode and standard containerd pulls are unaffected.

**Testing performed:** Unit test added verifying `Referer` is set on cache-hit requests (fails on main, passes with fix). Local E2E with nginx proxy returning 307 to a Referer-checking storage backend confirmed parallel pull sends correct `Referer` on all cached layer fetches. CI will confirm nothing breaks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
