### PR TITLE
fix(metrics): Increment SynchronousReadRegistryFetchCount only on registry fetch

### DIFF
--- a/fs/backgroundfetcher/background_fetcher_test.go
+++ b/fs/backgroundfetcher/background_fetcher_test.go
@@ -118,7 +118,7 @@ func TestBackgroundFetcherRun(t *testing.T) {
 					t.Fatalf("error building span manager and section reader: %v", err)
 				}
 				cache := &countingCache{}
-				sm, err := spanmanager.New(ztoc, sr, cache, 0)
+				sm, err := spanmanager.New(ztoc, sr, cache, 0, digest.FromString(""))
 				assert.Nil(t, err)
 				infos = append(infos, testInfo{sm, cache, ztoc})
 			}

--- a/fs/backgroundfetcher/resolver_test.go
+++ b/fs/backgroundfetcher/resolver_test.go
@@ -51,7 +51,7 @@ func TestSequentialResolver(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error build ztoc and section reader: %v", err)
 			}
-			sm, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
+			sm, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0, digest.FromString(""))
 			assert.Nil(t, err)
 			sequentialResolver := NewSequentialResolver(digest.FromString("test"), sm)
 

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -348,7 +348,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, ref
 	ztoc.TOC.FileMetadata = nil
 	log.G(ctx).Debugf("[Resolver.Resolve]Initialized metadata store for layer sha=%v", desc.Digest)
 
-	spanManager, err := spanmanager.New(ztoc, sr, spanCache, r.config.BlobConfig.MaxSpanVerificationRetries, cache.Direct())
+	spanManager, err := spanmanager.New(ztoc, sr, spanCache, r.config.BlobConfig.MaxSpanVerificationRetries, desc.Digest, cache.Direct())
 	if err != nil {
 		return nil, fmt.Errorf("error creating span manager: %w", err)
 	}

--- a/fs/layer/util_test.go
+++ b/fs/layer/util_test.go
@@ -173,7 +173,7 @@ func makeNodeReader(t *testing.T, contents []byte, spanSize int64, factory metad
 	if err != nil {
 		t.Fatalf("failed to create reader: %v", err)
 	}
-	spanManager, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
+	spanManager, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0, digest.FromString(""))
 	assert.Nil(t, err)
 	r, err := reader.NewReader(mr, digest.FromString(""), spanManager, false)
 	if err != nil {
@@ -335,7 +335,7 @@ func testExistenceWithOpaque(t *testing.T, factory metadata.Store, opaque Overla
 					t.Fatalf("failed to create reader: %v", err)
 				}
 				defer mr.Close()
-				spanManager, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
+				spanManager, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0, digest.FromString(""))
 				assert.Nil(t, err)
 				r, err := reader.NewReader(mr, digest.FromString(""), spanManager, false)
 				if err != nil {
@@ -777,7 +777,7 @@ func testStatfs(t *testing.T, factory metadata.Store) {
 	}
 	defer mr.Close()
 
-	spanManager, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
+	spanManager, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0, digest.FromString(""))
 	assert.Nil(t, err)
 	r, err := reader.NewReader(mr, digest.FromString(""), spanManager, false)
 	if err != nil {

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -39,6 +39,7 @@ import (
 
 	digest "github.com/opencontainers/go-digest"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 const (
@@ -86,7 +87,7 @@ const (
 	BackgroundFetch   = "background_fetch"
 
 	SynchronousReadCount              = "synchronous_read_count"
-	SynchronousReadRegistryFetchCount = "synchronous_read_remote_registry_fetch_count" // TODO revisit (wrong place)
+	SynchronousReadRegistryFetchCount = "synchronous_read_remote_registry_fetch_count"
 	SynchronousBytesServed            = "synchronous_bytes_served"
 
 	// Global fuse failure state
@@ -236,6 +237,15 @@ func MeasureLatencyInMicroseconds(operation string, layer digest.Digest, start t
 // IncOperationCount wraps the labels attachment as well as calling Inc into a single method.
 func IncOperationCount(operation string, layer digest.Digest) {
 	operationCount.WithLabelValues(operation, layer.String()).Inc()
+}
+
+// GetOperationCount returns the current value of an operation count metric for a given layer.
+func GetOperationCount(operation string, layer digest.Digest) float64 {
+	m := &dto.Metric{}
+	if err := operationCount.WithLabelValues(operation, layer.String()).Write(m); err != nil {
+		return 0
+	}
+	return m.GetCounter().GetValue()
 }
 
 // AddBytesCount wraps the labels attachment as well as calling Add into a single method.

--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -178,8 +178,6 @@ func (sf *file) ReadAt(p []byte, offset int64) (int, error) {
 	}
 	defer r.Close()
 
-	// TODO this is not the right place for this metric to be. It needs to go down the BlobReader, when the HTTP request is issued
-	commonmetrics.IncOperationCount(commonmetrics.SynchronousReadRegistryFetchCount, sf.gr.layerSha) // increment the number of on demand file fetches from remote registry
 	sf.gr.setLastReadTime(time.Now())
 
 	n, err := io.ReadFull(r, p[0:expectedSize])

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -163,7 +163,7 @@ func makeFile(t *testing.T, contents []byte, prefix string, factory metadata.Sto
 	if err != nil {
 		t.Fatalf("failed to create reader: %v", err)
 	}
-	spanManager, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
+	spanManager, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0, digest.FromString(""))
 	assert.Nil(t, err)
 	r, err := NewReader(mr, digest.FromString(""), spanManager, false)
 	if err != nil {
@@ -219,7 +219,7 @@ func testFailReader(t *testing.T, factory metadata.Store) {
 			if !found {
 				t.Fatalf("free ID not found")
 			}
-			spanManager, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0)
+			spanManager, err := spanmanager.New(ztoc, sr, cache.NewMemoryCache(), 0, digest.FromString(""))
 			assert.Nil(t, err)
 			r, err := NewReader(mr, digest.FromString(""), spanManager, false)
 			if err != nil {

--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/awslabs/soci-snapshotter/cache"
+	commonmetrics "github.com/awslabs/soci-snapshotter/fs/metrics/common"
 	"github.com/awslabs/soci-snapshotter/util/ioutils"
 	"github.com/awslabs/soci-snapshotter/ztoc"
 	"github.com/awslabs/soci-snapshotter/ztoc/compression"
@@ -51,6 +52,7 @@ type SpanManager struct {
 	r                                 *io.SectionReader // reader for contents of the spans managed by SpanManager
 	spans                             []*span
 	ztoc                              *ztoc.Ztoc
+	layerSha                          digest.Digest
 	maxSpanVerificationFailureRetries int
 	closeOnce                         sync.Once
 }
@@ -71,7 +73,7 @@ type spanInfo struct {
 // New creates a SpanManager with given ztoc and content reader, and builds all
 // spans based on the ztoc.
 
-func New(ztoc *ztoc.Ztoc, r *io.SectionReader, cache cache.BlobCache, retries int, cacheOpt ...cache.Option) (*SpanManager, error) {
+func New(ztoc *ztoc.Ztoc, r *io.SectionReader, cache cache.BlobCache, retries int, layerSha digest.Digest, cacheOpt ...cache.Option) (*SpanManager, error) {
 	index, err := ztoc.Zinfo()
 	if err != nil {
 		return nil, err
@@ -105,6 +107,7 @@ func New(ztoc *ztoc.Ztoc, r *io.SectionReader, cache cache.BlobCache, retries in
 		r:                                 r,
 		spans:                             spans,
 		ztoc:                              ztoc,
+		layerSha:                          layerSha,
 		maxSpanVerificationFailureRetries: retries,
 	}
 	if m.maxSpanVerificationFailureRetries < 0 {
@@ -336,6 +339,7 @@ func (m *SpanManager) getSpanContent(spanID compression.SpanID, offsetStart, off
 
 	// fetch-uncompress-cache span: span state can only be `unrequested` since
 	// no goroutine will release span state lock in `requested` state
+	commonmetrics.IncOperationCount(commonmetrics.SynchronousReadRegistryFetchCount, m.layerSha)
 	uncompBuf, err := m.fetchAndCacheSpan(s.id, true)
 	if err != nil {
 		return nil, err

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -26,9 +26,11 @@ import (
 	"testing"
 
 	"github.com/awslabs/soci-snapshotter/cache"
+	commonmetrics "github.com/awslabs/soci-snapshotter/fs/metrics/common"
 	"github.com/awslabs/soci-snapshotter/util/testutil"
 	"github.com/awslabs/soci-snapshotter/ztoc"
 	"github.com/awslabs/soci-snapshotter/ztoc/compression"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -128,7 +130,7 @@ func TestSpanManager(t *testing.T) {
 
 			cache := cache.NewMemoryCache()
 			defer cache.Close()
-			m, err := New(toc, r, cache, 0)
+			m, err := New(toc, r, cache, 0, digest.FromString(""))
 			if err != nil {
 				return
 			}
@@ -174,7 +176,7 @@ func TestSpanManagerCache(t *testing.T) {
 	}
 	cache := cache.NewMemoryCache()
 	defer cache.Close()
-	m, err := New(toc, r, cache, 0)
+	m, err := New(toc, r, cache, 0, digest.FromString(""))
 	assert.Nil(t, err)
 	spanID := 0
 	err = m.resolveSpan(compression.SpanID(spanID))
@@ -230,7 +232,7 @@ func TestStateTransition(t *testing.T) {
 	}
 	cache := cache.NewMemoryCache()
 	defer cache.Close()
-	m, err := New(toc, r, cache, 0)
+	m, err := New(toc, r, cache, 0, digest.FromString(""))
 	assert.Nil(t, err)
 
 	// check initial span states
@@ -401,7 +403,7 @@ func TestSpanManagerRetries(t *testing.T) {
 			}
 			rdr := newRetryableReaderAt(sr, tc.readerErrors)
 			sr = io.NewSectionReader(rdr, 0, 10000000)
-			sm, err := New(ztoc, sr, cache.NewMemoryCache(), tc.spanManagerRetries)
+			sm, err := New(ztoc, sr, cache.NewMemoryCache(), tc.spanManagerRetries, digest.FromString(""))
 			assert.Nil(t, err)
 
 			for i := 0; i < int(ztoc.MaxSpanID); i++ {
@@ -502,4 +504,56 @@ type readerFn func([]byte, int64) (int, error)
 
 func (f readerFn) ReadAt(b []byte, n int64) (int, error) {
 	return f(b, n)
+}
+
+func TestSynchronousFetchMetricOnlyFiresOnNetworkFetch(t *testing.T) {
+	tRand := testutil.NewTestRand(t)
+	var spanSize compression.Offset = 65536
+	// Create content spanning at least 2 spans
+	content := tRand.RandomByteData(int64(spanSize) * 2)
+	tarEntries := []testutil.TarEntry{
+		testutil.File("metric-test", string(content)),
+	}
+	toc, r, err := ztoc.BuildZtocReader(t, tarEntries, gzip.BestCompression, int64(spanSize))
+	if err != nil {
+		t.Fatalf("failed to create ztoc: %v", err)
+	}
+	c := cache.NewMemoryCache()
+	defer c.Close()
+
+	layerDigest := digest.FromString("metric-test-layer")
+	m, err := New(toc, r, c, 0, layerDigest)
+	assert.Nil(t, err)
+
+	getCount := func() float64 {
+		return commonmetrics.GetOperationCount(commonmetrics.SynchronousReadRegistryFetchCount, layerDigest)
+	}
+
+	// Span 0: unrequested -> should increment metric
+	before := getCount()
+	s := m.spans[0]
+	_, err = m.getSpanContent(0, 0, s.endUncompOffset-s.startUncompOffset)
+	assert.Nil(t, err)
+	after := getCount()
+	assert.Equal(t, before+1, after, "metric should increment on network fetch")
+
+	// Span 0 again: now uncompressed/cached -> should NOT increment
+	before = getCount()
+	_, err = m.getSpanContent(0, 0, s.endUncompOffset-s.startUncompOffset)
+	assert.Nil(t, err)
+	after = getCount()
+	assert.Equal(t, before, after, "metric should not increment on cache hit")
+
+	// Span 1: bg-fetch first, then getSpanContent -> should NOT increment
+	if toc.MaxSpanID >= 1 {
+		err = m.FetchSingleSpan(1)
+		assert.Nil(t, err)
+
+		before = getCount()
+		s1 := m.spans[1]
+		_, err = m.getSpanContent(1, 0, s1.endUncompOffset-s1.startUncompOffset)
+		assert.Nil(t, err)
+		after = getCount()
+		assert.Equal(t, before, after, "metric should not increment when bg fetcher already fetched span")
+	}
 }


### PR DESCRIPTION
**Issue #, if available:** #1016

**Description of changes:** Move `SynchronousReadRegistryFetchCount` metric increment from `reader.go` (fired on every `ReadAt`, including cache hits) to `span_manager.go`'s `getSpanContent` (where it fires only when a span is in `unrequested` state and an actual network fetch to the registry is issued). To preserve the layer digest dimension on the metric, the layer digest is now passed into `SpanManager` at construction time.

**Testing performed:** Added `TestSynchronousFetchMetricOnlyFiresOnNetworkFetch` unit test that verifies:
- Metric increments when `getSpanContent` hits an unrequested span (network fetch)
- Metric does NOT increment on a subsequent read of the same span (cache hit)
- Metric does NOT increment when the background fetcher has already fetched the span

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
