### PR TITLE
Fix automated doc update workflow

### DIFF
--- a/.github/workflows/update-version-in-docs.yml
+++ b/.github/workflows/update-version-in-docs.yml
@@ -116,8 +116,8 @@ jobs:
       - name: Create PR
         uses: peter-evans/create-pull-request@v8
         with:
-          title: 'Update version in docs to ${{ env.TAG_NAME }}'
-          commit-message: 'Update version in docs to ${{ env.TAG_NAME }}'
+          title: 'Update version in docs to ${{ env.TAG_NAME }} in ${{ env.TARGET_BRANCH }}'
+          commit-message: 'Update version in docs to ${{ env.TAG_NAME }} in ${{ env.TARGET_BRANCH }}'
           body: |
             This change updates SOCI docs to point to ${{ env.TAG_NAME }}.
 


### PR DESCRIPTION


**Issue #, if available:**

**Description of changes:**
We were overwriting our PRs to the release branch with the one to main branch. This shouldn't be happening to begin with, but will add a safeguard to guarantee this. Future PRs should add safeguards for disallowing pushes without having the requisite changes merged.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
