### PR TITLE
fix(metrics): Record InitMetadataStoreLatency after initialization completes

### DIFF
--- a/metadata/reader.go
+++ b/metadata/reader.go
@@ -96,12 +96,11 @@ func NewReader(db *bolt.DB, sr *io.SectionReader, toc ztoc.TOC, opts ...Option) 
 
 	r := &reader{sr: sr, db: db, initG: new(errgroup.Group)}
 	start := time.Now()
-	if rOpts.Telemetry != nil && rOpts.Telemetry.InitMetadataStoreLatency != nil {
-		rOpts.Telemetry.InitMetadataStoreLatency(start)
-	}
-
 	if err := r.init(toc, rOpts); err != nil {
 		return nil, fmt.Errorf("failed to initialize metadata: %w", err)
+	}
+	if rOpts.Telemetry != nil && rOpts.Telemetry.InitMetadataStoreLatency != nil {
+		rOpts.Telemetry.InitMetadataStoreLatency(start)
 	}
 	return r, nil
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

The `InitMetadataStoreLatency` telemetry hook in `metadata.NewReader` was invoked immediately after capturing `start := time.Now()`, *before* calling `r.init(toc, rOpts)`. As a result, the `soci_fs_operation_duration_milliseconds{operation_type="init_metadata_store"}` metric always observed a near-zero latency instead of the actual time spent parsing the TOC and persisting filesystem metadata to bbolt.

This change moves the telemetry hook to after `r.init()` completes, so the metric reports the real initialization duration.

**Testing performed:**

- Existing unit test `TestMetadataReader` verifies the telemetry hook is still called (via `newCalledTelemetry`).
- Verified metric now reports non-zero values reflecting actual init time when mounting images with SOCI indexes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.