### PR TITLE
feat(metrics): Add pull/mount critical-path observability metrics

### DIFF
--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -26,7 +26,9 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
+	commonmetrics "github.com/awslabs/soci-snapshotter/fs/metrics/common"
 	sociremote "github.com/awslabs/soci-snapshotter/fs/remote"
 	socihttp "github.com/awslabs/soci-snapshotter/internal/http"
 	"github.com/awslabs/soci-snapshotter/soci"
@@ -35,6 +37,7 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/pkg/reference"
 	"github.com/containerd/log"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2/content"
@@ -317,6 +320,11 @@ func (f *artifactFetcher) Store(ctx context.Context, desc ocispec.Descriptor, re
 }
 
 func FetchSociArtifacts(ctx context.Context, refspec reference.Spec, indexDesc ocispec.Descriptor, localStore store.Store, remoteStore resolverStorage) (*soci.Index, error) {
+	// Measure the total index+zTOC fetch. This blocks the first Mount for the
+	// image, so it is on the pull critical path.
+	indexFetchStart := time.Now()
+	defer commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.SociIndexFetch, indexDesc.Digest, indexFetchStart)
+
 	fetcher, err := newArtifactFetcher(refspec, localStore, remoteStore)
 	if err != nil {
 		return nil, fmt.Errorf("could not create an artifact fetcher: %w", err)
@@ -370,6 +378,14 @@ func FetchSociArtifacts(ctx context.Context, refspec reference.Spec, indexDesc o
 	eg, ctx := errgroup.WithContext(ctx)
 	for i, blob := range index.Blobs {
 		eg.Go(func() error {
+			// Key the metric by the image layer digest the zTOC belongs to so
+			// it aligns with the other per-layer metrics; fall back to the zTOC
+			// blob digest if the annotation is absent.
+			layerDigest := digest.Digest(blob.Annotations[soci.IndexAnnotationImageLayerDigest])
+			if layerDigest == "" {
+				layerDigest = blob.Digest
+			}
+			ztocFetchStart := time.Now()
 			rc, local, err := fetcher.Fetch(ctx, blob)
 			if err != nil {
 				return fmt.Errorf("cannot fetch artifact: %w", err)
@@ -381,6 +397,7 @@ func FetchSociArtifacts(ctx context.Context, refspec reference.Spec, indexDesc o
 			if err := fetcher.Store(ctx, blob, rc); err != nil && !store.IsErrAlreadyExists(err) {
 				return fmt.Errorf("unable to store ztoc in local store: %w", err)
 			}
+			commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.ZtocFetch, layerDigest, ztocFetchStart)
 			return store.LabelGCRefContent(ctx, localStore, desc, "ztoc."+strconv.Itoa(i), blob.Digest.String())
 		})
 	}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -1160,6 +1160,7 @@ func (fs *filesystem) setupFuseServer(ctx context.Context, mountpoint string, no
 		log.G(ctx).WithField("binary", fusermountBin).WithError(err).Info("fusermount binary not installed; trying direct mount")
 		mountOpts.DirectMountStrict = true
 	}
+	fuseMountStart := time.Now()
 	server, err := fuse.NewServer(rawFS, mountpoint, mountOpts)
 	if err != nil {
 		log.G(ctx).WithError(err).Error("failed to make filesystem server")
@@ -1178,7 +1179,9 @@ func (fs *filesystem) setupFuseServer(ctx context.Context, mountpoint string, no
 		})
 	}
 
-	return server.WaitMount()
+	err = server.WaitMount()
+	commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.FuseMount, l.Info().Digest, fuseMountStart)
+	return err
 }
 
 func (fs *filesystem) Check(ctx context.Context, mountpoint string, labels map[string]string) error {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -154,6 +154,13 @@ func (pr *preresolver) Enqueue(imgNameAndDigest string, fn func(context.Context)
 		case pr.queue <- fn:
 			pr.cache.Store(imgNameAndDigest, struct{}{})
 		default:
+			// The work queue is full: drop this pre-resolve. The layer will
+			// still be resolved on its own Mount, just serially rather than
+			// ahead of time. Count drops so this bound is observable (e.g.
+			// when many images are mounted at once and the shared queue
+			// saturates). Keyed with an empty layer digest since this is a
+			// daemon-wide queue.
+			commonmetrics.IncOperationCount(commonmetrics.PreresolveQueueDrop, digest.Digest(""))
 			return
 		}
 	}

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -306,7 +306,9 @@ func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, ref
 	// If it exists, we decide if we want to lazily load layer, or
 	// download/decompress the entire layer
 	// If we decide to download/decompress the entire layer, getZtoc will not return the ztoc
+	ztocUnmarshalStart := time.Now()
 	ztoc, err := ztoc.Unmarshal(ztocReader)
+	commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.ZtocUnmarshal, desc.Digest, ztocUnmarshalStart)
 
 	if err != nil {
 		// for now error out and let container runtime handle the layer download

--- a/fs/layer/layer.go
+++ b/fs/layer/layer.go
@@ -265,6 +265,12 @@ func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, ref
 	if ok {
 		if l := c.(*layer); l.Check() == nil {
 			log.G(ctx).Debugf("hit layer cache %q", name)
+			// A cache hit means this layer was resolved earlier (typically by
+			// pre-resolution) and is still cached. Tracking the hit/miss ratio
+			// shows whether pre-resolution is landing or whether resolved
+			// layers are being evicted before use (resolve_result_entry too
+			// small for the concurrent working set).
+			commonmetrics.IncOperationCount(commonmetrics.ResolveCacheHit, desc.Digest)
 			return &layerRef{l, done}, nil
 		}
 		// Cached layer is invalid
@@ -274,6 +280,7 @@ func (r *Resolver) Resolve(ctx context.Context, hosts []docker.RegistryHost, ref
 		r.layerCacheMu.Unlock()
 	}
 
+	commonmetrics.IncOperationCount(commonmetrics.ResolveCacheMiss, desc.Digest)
 	log.G(ctx).Debugf("resolving")
 
 	// Resolve the blob.

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -85,6 +85,12 @@ const (
 	InitMetadataStore = "init_metadata_store"
 	SynchronousRead   = "synchronous_read"
 	BackgroundFetch   = "background_fetch"
+	// ZtocUnmarshal measures time to read and deserialize a layer's zTOC
+	// flatbuffer (io.ReadAll + flatbufToZtoc) during layer resolve.
+	ZtocUnmarshal = "ztoc_unmarshal"
+	// FuseMount measures time to create and mount the go-fuse server for a
+	// layer (fuse.NewServer + server.WaitMount) during layer resolve.
+	FuseMount = "fuse_mount"
 
 	SynchronousReadCount              = "synchronous_read_count"
 	SynchronousReadRegistryFetchCount = "synchronous_read_remote_registry_fetch_count"

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -151,6 +151,18 @@ const (
 	// preresolver work queue was full. Dropped layers are not pre-resolved and
 	// pay their full resolve cost serially on their own Mount.
 	PreresolveQueueDrop = "preresolve_queue_drop"
+	// SociIndexFetch measures the total time to fetch and store a SOCI index
+	// and all of its zTOC blobs (FetchSociArtifacts). This runs once per image
+	// (guarded by fetchOnce) and blocks the first Mount for that image, so it
+	// contributes directly to pull latency, especially when many images are
+	// pulled at once and their zTOC fetches contend on the registry.
+	SociIndexFetch = "soci_index_fetch"
+	// ZtocFetch measures the time to fetch and store a single zTOC blob from
+	// the registry into the local content store, keyed by the image layer
+	// digest the zTOC belongs to. These fetches are issued concurrently (one
+	// per zTOC-indexed layer) with no cross-image bound, so a high value here
+	// under parallel pulls indicates registry/connection contention.
+	ZtocFetch = "ztoc_fetch"
 )
 
 var (

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -91,6 +91,14 @@ const (
 	// FuseMount measures time to create and mount the go-fuse server for a
 	// layer (fuse.NewServer + server.WaitMount) during layer resolve.
 	FuseMount = "fuse_mount"
+	// BlobRedirect measures time for the synchronous registry round-trip that
+	// resolves a layer's blob URL (registry -> storage redirect) when creating
+	// the HTTP fetcher during layer resolve.
+	BlobRedirect = "blob_redirect"
+	// GetLayerSize measures time for the synchronous registry round-trip that
+	// fetches a layer's blob size when it is not present in the descriptor,
+	// during layer resolve.
+	GetLayerSize = "get_layer_size"
 
 	SynchronousReadCount              = "synchronous_read_count"
 	SynchronousReadRegistryFetchCount = "synchronous_read_remote_registry_fetch_count"

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -137,6 +137,20 @@ const (
 
 	// Number of items in the work queue of background fetcher
 	BackgroundFetchWorkQueueSize = "background_fetch_work_queue_size"
+
+	// ResolveCacheHit counts layer resolves served from the resolver LRU cache
+	// (e.g. a layer that was pre-resolved and is still cached when containerd
+	// mounts it). A high hit ratio means pre-resolution is landing.
+	ResolveCacheHit = "resolve_cache_hit"
+	// ResolveCacheMiss counts layer resolves that were not in the resolver LRU
+	// cache and had to be resolved on the critical path. A high miss ratio
+	// during a burst usually means resolve_result_entry is too small to hold
+	// the pre-resolved layers before they are used (they get evicted first).
+	ResolveCacheMiss = "resolve_cache_miss"
+	// PreresolveQueueDrop counts pre-resolve requests dropped because the
+	// preresolver work queue was full. Dropped layers are not pre-resolved and
+	// pay their full resolve cost serially on their own Mount.
+	PreresolveQueueDrop = "preresolve_queue_drop"
 )
 
 var (

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -156,7 +156,9 @@ func (r *Resolver) resolveFetcher(ctx context.Context, fc *fetcherConfig) (f fet
 		logger.WithField("ref", fc.refspec.String()).WithField("digest", fc.desc.Digest).
 			Debugf("layer size not found in labels; making a request to remote to get size")
 
+		getLayerSizeStart := time.Now()
 		fc.desc.Size, err = getLayerSize(ctx, hf)
+		commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.GetLayerSize, fc.desc.Digest, getLayerSizeStart)
 		if err != nil {
 			return nil, 0, fmt.Errorf("%w from %s: %w", ErrFailedToRetrieveLayerSize, socihttp.RedactHTTPQueryValuesFromString(hf.realURL), err)
 		}
@@ -246,7 +248,9 @@ func newHTTPFetcher(ctx context.Context, fc *fetcherConfig) (*httpFetcher, error
 
 		// Get the real blob URL
 		ctx = docker.WithScope(ctx, pullScope)
+		redirectStart := time.Now()
 		realURL, err := redirect(ctx, registryURL, tr)
+		commonmetrics.MeasureLatencyInMilliseconds(commonmetrics.BlobRedirect, digest, redirectStart)
 		if err != nil {
 			createFetcherErr = errors.Join(
 				fmt.Errorf("%w: %w (host %q, ref:%q, digest:%q)",


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds nine new operation types to the existing `soci_fs_operation_duration_milliseconds` histogram and `soci_fs_operation_count` counter, instrumenting the parts of the image-pull / layer-mount critical path that were previously unmeasured.

The existing metrics attribute overall `mount` latency but do not break it down into its sub-operations, and several synchronous steps on the resolve/mount critical path (registry round-trips, zTOC fetch/parse, FUSE mount) had no metric at all. When diagnosing per-layer and parallel-pull latency, this made it impossible to tell *where* time was going, the `mount` total was a black box, and the pre-existing `remote_registry_get` metric only covers span-content reads (the FUSE read path), not resolve-time round-trips.

These metrics make the full mount critical path attributable: `mount ≈ soci_index_fetch (amortized, once per image) + blob_redirect + get_layer_size + ztoc_unmarshal + init_metadata_store + fuse_mount + overhead` and expose pre-resolution effectiveness and fetch-fan-out contention.

## New metrics

Mount critical-path sub-operations (histogram, labeled by `operation_type`, `layer`):

| Metric | Measures |
|--------|----------|
| `ztoc_unmarshal` | Reading + deserializing a layer's zTOC flatbuffer during resolve |
| `fuse_mount` | `fuse.NewServer` + `WaitMount` (the kernel FUSE mount) |
| `blob_redirect` | The registry → storage (e.g. ECR → S3) blob-URL redirect resolution |
| `get_layer_size` | The extra registry round-trip to discover a layer's size when absent from the descriptor |
| `soci_index_fetch` | Total time of `FetchSociArtifacts` (index + all zTOC blobs), once per image |
| `ztoc_fetch` | Fetching + storing a single zTOC blob, keyed by the image layer digest |

Pre-resolution / cache effectiveness (counter, labeled by `operation_type`):

| Metric | Measures |
|--------|----------|
| `resolve_cache_hit` | Layer resolves served from the resolver LRU (pre-resolution landed) |
| `resolve_cache_miss` | Layer resolves that hit the critical path (not cached / evicted before use) |
| `preresolve_queue_drop` | Pre-resolve requests dropped because the preresolver work queue was full |

The hit/miss ratio directly shows whether pre-resolution is landing or whether
resolved layers are being evicted before use (i.e. `resolve_result_entry` too
small for the concurrent working set). `preresolve_queue_drop > 0` indicates the
shared preresolver queue saturated under heavy concurrent-mount load.

**Testing performed:**

- `go build ./fs/...` and `go vet ./fs/... ./fs/metrics/...` pass.
- `go test ./fs/` passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
