### PR TITLE
feat(metadata): Add "db-multi" per-layer metadata store to avoid the shared bbolt writer lock

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -324,7 +324,8 @@ func serve(ctx context.Context, rpc *grpc.Server, addr string, rs snapshots.Snap
 }
 
 const (
-	dbMetadataType = "db"
+	dbMetadataType      = "db"
+	dbMultiMetadataType = "db-multi"
 )
 
 func getMetadataStore(ctx context.Context, rootDir string, config config.Config) (metadata.Store, error) {
@@ -351,9 +352,26 @@ func getMetadataStore(ctx context.Context, rootDir string, config config.Config)
 			}
 			return metadata.NewReader(db, sr, toc, opts...)
 		}, nil
+	case dbMultiMetadataType:
+		log.G(ctx).WithFields(logrus.Fields{
+			"root":       rootDir,
+			"store_type": config.MetadataStore,
+		}).Debug("initializing per-layer (db-multi) metadata store")
+
+		// Same bbolt tuning as the shared "db" store, but each layer gets its
+		// own database file, so concurrent layer initializations don't contend
+		// on a single bbolt writer lock. Databases are removed when their
+		// reader is closed.
+		bOpts := bolt.Options{
+			NoFreelistSync:  true,
+			InitialMmapSize: 64 * 1024 * 1024,
+			FreelistType:    bolt.FreelistMapType,
+		}
+		dbDir := filepath.Join(rootDir, "metadata")
+		return metadata.NewMultiReader(dbDir, metadata.DBMultiOptions{BoltOptions: &bOpts}), nil
 	default:
-		return nil, fmt.Errorf("unknown metadata store type: %v; must be %v",
-			config.MetadataStore, dbMetadataType)
+		return nil, fmt.Errorf("unknown metadata store type: %v; must be %v or %v",
+			config.MetadataStore, dbMetadataType, dbMultiMetadataType)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -69,7 +69,10 @@ type Config struct {
 	// DebugAddress is a Unix domain socket address where the snapshotter exposes /debug/ endpoints.
 	DebugAddress string `toml:"debug_address"`
 
-	// MetadataStore is the type of the metadata store to use.
+	// MetadataStore is the type of the metadata store to use. Valid values are
+	// "db" (a single shared on-disk bbolt database, the default) and
+	// "db-multi" (one bbolt database per layer, to avoid the shared writer
+	// lock).
 	MetadataStore string `toml:"metadata_store"`
 
 	// MetadataDBNoSync disables bbolt's per-transaction fsync for the metadata

--- a/docs/config.md
+++ b/docs/config.md
@@ -33,7 +33,9 @@ This set of variables must be at the top of your TOML file due to not belonging 
 - `metrics_network` (string) — Chooses protocol to send metrics over (e.g. tcp, unix, etc). Default: "tcp".
 - `no_prometheus` — Defined [above](#configfsgofsconfig), cannot be redeclared.
 - `debug_address` (string) — Address where [go pprof](https://pkg.go.dev/net/http/pprof) server will listen. If empty, no logs will be emitted. Default: "".
-- `metadata_store` (string) — Metadata storage type. Only "db" is valid. Default: "db".
+- `metadata_store` (string) — Metadata storage type. One of "db" or "db-multi". Default: "db".
+  - `"db"` — Persists layer metadata to a single on-disk [bbolt](https://github.com/etcd-io/bbolt) database (`metadata.db`) shared by all layers, under the snapshotter root. All layers share one bbolt writer lock, so concurrent layer initializations serialize on it.
+  - `"db-multi"` — Same on-disk bbolt format and code path as "db", but each layer gets its own database file (under the `metadata/` subdirectory), so concurrent layer initializations do not contend on a single writer lock. Each database is removed when its layer's reader is closed. Trades more open file descriptors for reduced write-lock contention when many layers initialize at once.
 - `metadata_db_no_sync` (bool) — Disables bbolt's per-transaction fsync for the metadata store. The metadata DB is derived data rebuilt from zTOCs on each daemon restart, so fsync durability is unnecessary. Removes synchronous disk flushes from layer metadata initialization. Default: false.
 - `metadata_insertion_chunk_size` (int) — Max node insertions per bbolt transaction during metadata init. Larger chunks amortize per-commit overhead. 0 means use the default. Default: 5000.
 - `skip_check_snapshotter_supported` (bool) - skip check for snapshotter is supported which can give performance benefits for SOCI daemon startup time. This config should only be done if you are sure overlayfs is supported. Default: false

--- a/metadata/dbmulti.go
+++ b/metadata/dbmulti.go
@@ -1,0 +1,116 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package metadata
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/awslabs/soci-snapshotter/ztoc"
+	"github.com/rs/xid"
+	bolt "go.etcd.io/bbolt"
+)
+
+// DBMultiOptions configures the per-layer bbolt databases created by the
+// "db-multi" metadata store. The zero value is valid and applies bbolt's own
+// defaults.
+type DBMultiOptions struct {
+	// BoltOptions are passed to bolt.Open for each per-layer database. If nil,
+	// bbolt defaults are used.
+	BoltOptions *bolt.Options
+}
+
+// multiReader wraps the standard bbolt-backed reader but owns the bolt.DB it
+// runs against. Unlike the shared "db" store, "db-multi" opens a separate
+// database file per layer, so concurrent layer initializations do not contend
+// on a single bbolt writer lock. Because the database is per-layer (not shared
+// across the daemon), multiReader is responsible for closing the handle and
+// removing the file when the reader is closed.
+type multiReader struct {
+	Reader          // the underlying *reader
+	db     *bolt.DB // owned by this multiReader (nil for clones)
+	dbPath string   // path of the database file to remove on close (empty for clones)
+}
+
+var _ Reader = (*multiReader)(nil)
+
+// NewMultiReader parses a TOC and persists filesystem metadata to a freshly
+// created, per-layer bbolt database under dir. The database file is removed
+// when Close is called. It uses the same on-disk format and code path as the
+// shared "db" store; the only difference is that each layer gets its own
+// database, avoiding the single-writer-lock contention of the shared store.
+func NewMultiReader(dir string, opts DBMultiOptions) func(*io.SectionReader, ztoc.TOC, ...Option) (Reader, error) {
+	return func(sr *io.SectionReader, toc ztoc.TOC, rOpts ...Option) (Reader, error) {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return nil, fmt.Errorf("failed to create metadata dir %q: %w", dir, err)
+		}
+		// A unique, collision-free filename per layer database.
+		dbPath := filepath.Join(dir, "metadata-"+xid.New().String()+".db")
+		db, err := bolt.Open(dbPath, 0600, opts.BoltOptions)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open per-layer metadata db %q: %w", dbPath, err)
+		}
+		r, err := NewReader(db, sr, toc, rOpts...)
+		if err != nil {
+			// Clean up the freshly created db on failure.
+			db.Close()
+			os.Remove(dbPath)
+			return nil, err
+		}
+		return &multiReader{Reader: r, db: db, dbPath: dbPath}, nil
+	}
+}
+
+// Clone returns a reader that shares the same underlying per-layer database but
+// does not own it: closing a clone must not close the shared handle or remove
+// the file (only the owning multiReader does that on Close).
+func (r *multiReader) Clone(sr *io.SectionReader) (Reader, error) {
+	inner, err := r.Reader.Clone(sr)
+	if err != nil {
+		return nil, err
+	}
+	return &multiReader{Reader: inner}, nil
+}
+
+// NumOfNodes reports the number of nodes in the underlying reader, if it
+// supports it. It exists so db-multi can be exercised by the same reader
+// correctness suite as the shared "db" store.
+func (r *multiReader) NumOfNodes() (int, error) {
+	if n, ok := r.Reader.(interface{ NumOfNodes() (int, error) }); ok {
+		return n.NumOfNodes()
+	}
+	return 0, fmt.Errorf("underlying reader does not support NumOfNodes")
+}
+
+// Close closes the underlying reader and, if this reader owns the database
+// (i.e. it is not a clone), closes the bolt handle and removes the file.
+func (r *multiReader) Close() error {
+	rErr := r.Reader.Close()
+	if r.db != nil {
+		if cErr := r.db.Close(); cErr != nil && rErr == nil {
+			rErr = cErr
+		}
+		if r.dbPath != "" {
+			if rmErr := os.Remove(r.dbPath); rmErr != nil && !os.IsNotExist(rmErr) && rErr == nil {
+				rErr = rmErr
+			}
+		}
+	}
+	return rErr
+}

--- a/metadata/reader_test.go
+++ b/metadata/reader_test.go
@@ -79,6 +79,29 @@ func (r *testableReadCloser) Close() error {
 	return r.testableReader.Close()
 }
 
+func TestMultiMetadataReader(t *testing.T) {
+	testReader(t, newTestableMultiReader)
+}
+
+func newTestableMultiReader(sr *io.SectionReader, toc ztoc.TOC, opts ...Option) (testableReader, error) {
+	dir, err := os.MkdirTemp("", "readertestdbmulti")
+	if err != nil {
+		return nil, err
+	}
+	r, err := NewMultiReader(dir, DBMultiOptions{})(sr, toc, opts...)
+	if err != nil {
+		os.RemoveAll(dir)
+		return nil, err
+	}
+	return &testableReadCloser{
+		testableReader: r.(*multiReader),
+		closeFn: func() error {
+			// multiReader.Close removes the per-layer db file; also drop the dir.
+			return os.RemoveAll(dir)
+		},
+	}, nil
+}
+
 func TestPartition(t *testing.T) {
 	testCases := []struct {
 		name      string


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds a new metadata store, `metadata_store = "db-multi"`, that gives each layer its own bbolt database instead of the single shared database used by the default `"db"` store.

The default `"db"` store writes all layers' metadata to one `metadata.db`. bbolt is single-writer, so concurrent layer initializations (multi-layer images, or many images pulled at once) serialize on that one writer lock. `"db-multi"` removes the contention by writing each layer to an independent database.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
