### PR TITLE
Don't preserve tar ownership in standalone extraction

### DIFF
--- a/cmd/soci/commands/internal/standalone.go
+++ b/cmd/soci/commands/internal/standalone.go
@@ -61,7 +61,10 @@ func LoadImage(ctx context.Context, inputPath string, tmpDir string) (*Standalon
 			return nil, fmt.Errorf("failed to open tar %s: %w", inputPath, err)
 		}
 		defer tarFile.Close()
-		if _, err := ctdarchive.Apply(ctx, tmpDir, tarFile); err != nil {
+		// Extract as the current user instead of reproducing the tar's UID/GID.
+		// OCI layout tars record root ownership (0/0), which is irrelevant for a
+		// content-addressed layout and makes Lchown fail for non-root users.
+		if _, err := ctdarchive.Apply(ctx, tmpDir, tarFile, ctdarchive.WithNoSameOwner()); err != nil {
 			return nil, fmt.Errorf("failed to extract OCI tar %s: %w", inputPath, err)
 		}
 	}


### PR DESCRIPTION
**Issue #, if available:**

Fixes https://github.com/awslabs/soci-snapshotter/issues/2022

**Description of changes:**

We extracts the OCI layout tar via containerd's archive.Apply which saves the record as root ownership (UID/GID 0).

Previously this leads to failures as such - 
```
$ soci convert --standalone /tmp/al2023.tar /tmp/al2024.tar
soci: failed to extract OCI tar /tmp/al2023.tar: failed to Lchown "/tmp/soci-oci-2689145274/blobs" for UID 0, GID 0: lchown /tmp/soci-oci-2689145274/blobs: operation not permitted
```

Fixed by passing `WithNoSameOwner()` which extracts the layout as the current user instead.

**Testing performed:**

- Verified by converting a nerdctl save tar as a non-root user (fails before, passes after)
- Ran Standalone Integration Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
