### PR TITLE
fix(backgroundfetcher): Background fetcher queue blocks layer mounts during silence period

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -84,7 +84,7 @@ func NewConfig() *Config {
 	cfg := &Config{}
 
 	// Set any defaults which do not align with Go zero values.
-	var initParsers = []configParser{defaultPullModes, defaultDirectoryCacheConfig}
+	var initParsers = []configParser{defaultPullModes, defaultDirectoryCacheConfig, defaultBackgroundFetchConfig}
 	if err := parseConfig(cfg, append(initParsers, parsers...)); err != nil {
 		return nil
 	}

--- a/config/config.toml
+++ b/config/config.toml
@@ -47,7 +47,8 @@ skip_check_snapshotter_supported = false
   disable = false
   silence_period_msec = 30000
   fetch_period_msec = 500
-  max_queue_size = 100
+  max_queue_size = 300
+  drop_policy = 'newest'
   emit_metric_period_sec = 10
 
 [content_store]

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -128,6 +128,11 @@ func TestConfigDefaults(t *testing.T) {
 			actual:   cfg.BackgroundFetchConfig.MaxQueueSize,
 		},
 		{
+			name:     "bg drop policy",
+			expected: defaultBgDropPolicy,
+			actual:   cfg.BackgroundFetchConfig.DropPolicy,
+		},
+		{
 			name:     "bg emit metrics period",
 			expected: int64(defaultBgMetricEmitPeriodSec),
 			actual:   cfg.BackgroundFetchConfig.EmitMetricPeriodSec,
@@ -289,6 +294,78 @@ concurrent_download_chunk_size = "badchunksize"
 			assert: func(t *testing.T, actual *Config, err error) {
 				if err == nil {
 					t.Error("Expected error, got none")
+				}
+			},
+		},
+		{
+			name: "BackgroundFetchMaxQueueSizeUnlimited",
+			config: []byte(`
+[background_fetch]
+max_queue_size = -1
+`),
+			assert: func(t *testing.T, actual *Config, err error) {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+				if actual.BackgroundFetchConfig.MaxQueueSize != -1 {
+					t.Errorf("Expected max_queue_size -1, got %d", actual.BackgroundFetchConfig.MaxQueueSize)
+				}
+			},
+		},
+		{
+			name: "BackgroundFetchMaxQueueSizeZeroDefaultsTo300",
+			config: []byte(`
+[background_fetch]
+max_queue_size = 0
+`),
+			assert: func(t *testing.T, actual *Config, err error) {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+				if actual.BackgroundFetchConfig.MaxQueueSize != 300 {
+					t.Errorf("Expected max_queue_size to default to 300, got %d", actual.BackgroundFetchConfig.MaxQueueSize)
+				}
+			},
+		},
+		{
+			name: "BackgroundFetchMaxQueueSizeExplicit",
+			config: []byte(`
+[background_fetch]
+max_queue_size = 50
+`),
+			assert: func(t *testing.T, actual *Config, err error) {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+				if actual.BackgroundFetchConfig.MaxQueueSize != 50 {
+					t.Errorf("Expected max_queue_size 50, got %d", actual.BackgroundFetchConfig.MaxQueueSize)
+				}
+			},
+		},
+		{
+			name: "BackgroundFetchDropPolicyNewest",
+			config: []byte(`
+[background_fetch]
+drop_policy = "newest"
+`),
+			assert: func(t *testing.T, actual *Config, err error) {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+				if actual.BackgroundFetchConfig.DropPolicy != "newest" {
+					t.Errorf("Expected drop_policy newest, got %q", actual.BackgroundFetchConfig.DropPolicy)
+				}
+			},
+		},
+		{
+			name: "BackgroundFetchDropPolicyInvalid",
+			config: []byte(`
+[background_fetch]
+drop_policy = "random"
+`),
+			assert: func(t *testing.T, actual *Config, err error) {
+				if err == nil {
+					t.Error("Expected error for invalid drop_policy, got none")
 				}
 			},
 		},

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -66,10 +66,14 @@ const (
 	// The background fetcher will fetch a single span every `defaultFetchPeriod`.
 	defaultBgFetchPeriodMsec = 500
 
-	// defaultBgMaxQueueSize specifies the maximum size of the bg-fetcher work queue i.e., the maximum number
-	// of span managers that can be queued. In case of overflow, the `Add` call
-	// will block until a span manager is removed from the workqueue.
-	defaultBgMaxQueueSize = 100
+	// defaultBgMaxQueueSize specifies the maximum size of the bg-fetcher work queue,
+	// i.e., the maximum number of span managers that can be queued. When full,
+	// the entry selected by drop_policy is evicted; Add never blocks.
+	defaultBgMaxQueueSize = 300
+
+	// defaultBgDropPolicy specifies which work-queue entry is evicted when
+	// max_queue_size is reached. Valid values: "oldest", "newest".
+	defaultBgDropPolicy = "newest"
 
 	// defaultBgMetricEmitPeriodSec is the default amount of interval at which the background fetcher emits metrics
 	defaultBgMetricEmitPeriodSec = 10

--- a/config/fs.go
+++ b/config/fs.go
@@ -39,6 +39,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/containerd/containerd/v2/defaults"
@@ -109,6 +110,12 @@ func defaultDirectoryCacheConfig(cfg *Config) error {
 	return nil
 }
 
+func defaultBackgroundFetchConfig(cfg *Config) error {
+	cfg.FSConfig.BackgroundFetchConfig.MaxQueueSize = defaultBgMaxQueueSize
+	cfg.FSConfig.BackgroundFetchConfig.DropPolicy = defaultBgDropPolicy
+	return nil
+}
+
 type FuseConfig struct {
 	// AttrTimeout defines overall timeout attribute for a file system in seconds.
 	AttrTimeout int64 `toml:"attr_timeout"`
@@ -136,10 +143,18 @@ type BackgroundFetchConfig struct {
 	// The background fetcher will fetch one span every FetchPeriodMsec.
 	FetchPeriodMsec int64 `toml:"fetch_period_msec"`
 
-	// MaxQueueSize specifies the maximum size of the work queue
-	// i.e., the maximum number of span managers that can be queued
-	// in the background fetcher.
+	// MaxQueueSize specifies the maximum size of the work queue, i.e., the
+	// maximum number of span managers that can be queued in the background
+	// fetcher. When the queue is full, the entry selected by DropPolicy is
+	// dropped and the layer stays lazy-loaded on demand. Adding never blocks.
+	// -1 means unlimited (never drop). 0 is invalid. Default: 100.
 	MaxQueueSize int `toml:"max_queue_size"`
+
+	// DropPolicy controls which entry is removed when MaxQueueSize is
+	// reached. "oldest" drops the head of the queue (longest-queued layer);
+	// "newest" drops the entry being added (the layer that just mounted).
+	// Default: "oldest".
+	DropPolicy string `toml:"drop_policy"`
 
 	// EmitMetricPeriodSec is the amount of interval (in second) at which the background
 	// fetcher emits metrics
@@ -250,11 +265,17 @@ func parseBackgroundFetchConfig(cfg *Config) error {
 	if cfg.BackgroundFetchConfig.SilencePeriodMsec == 0 {
 		cfg.BackgroundFetchConfig.SilencePeriodMsec = defaultBgSilencePeriodMsec
 	}
-
 	if cfg.BackgroundFetchConfig.MaxQueueSize == 0 {
 		cfg.BackgroundFetchConfig.MaxQueueSize = defaultBgMaxQueueSize
 	}
-
+	if cfg.BackgroundFetchConfig.DropPolicy == "" {
+		cfg.BackgroundFetchConfig.DropPolicy = defaultBgDropPolicy
+	}
+	switch cfg.BackgroundFetchConfig.DropPolicy {
+	case "oldest", "newest":
+	default:
+		return fmt.Errorf("background_fetch.drop_policy must be \"oldest\" or \"newest\", got %q", cfg.BackgroundFetchConfig.DropPolicy)
+	}
 	if cfg.BackgroundFetchConfig.EmitMetricPeriodSec == 0 {
 		cfg.BackgroundFetchConfig.EmitMetricPeriodSec = defaultBgMetricEmitPeriodSec
 	}

--- a/docs/config.md
+++ b/docs/config.md
@@ -74,7 +74,8 @@ This set of variables must be at the top of your TOML file due to not belonging 
 - `disable` (bool) — Disables the background fetcher. Default: false.
 - `silence_period_msec` (int) — Time that the background fetcher will be paused when a new image is mounted. Default: 30000.
 - `fetch_period_msec` (int) — How often spans will be fetched. Default: 500.
-- `max_queue_size` (int) — Max span managers that can be queued. Default: 100.
+- `max_queue_size` (int) — Max entries in the background fetch work queue. When full, the entry chosen by `drop_policy` is evicted and that layer stays lazy-loaded on demand; adding never blocks layer mounts. -1 for unlimited. Default: 300.
+- `drop_policy` (string) — Which entry to evict when `max_queue_size` is reached. "oldest" drops the head of the queue (longest-queued layer); "newest" drops the entry being added (the layer that just mounted). Default: "newest".
 - `emit_metric_period_sec` (int) — Interval of background fetcher metric emission. Default: 10.
 
 ### [content_store]

--- a/fs/backgroundfetcher/background_fetcher.go
+++ b/fs/backgroundfetcher/background_fetcher.go
@@ -19,6 +19,7 @@ package backgroundfetcher
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	commonmetrics "github.com/awslabs/soci-snapshotter/fs/metrics/common"
@@ -80,9 +81,19 @@ type BackgroundFetcher struct {
 
 	bfPauser pauser
 
-	// All span managers are added to the channel and picked up in Run().
-	// If a span manager is still able to fetch, it is reinserted into the chanel.
-	workQueue chan Resolver
+	// All span managers are appended to the work queue and picked up in Run().
+	// If a span manager is still able to fetch, it is re-appended.
+	//
+	// The queue is an unbounded, mutex-guarded slice rather than a fixed-size
+	// channel: Add is called on the layer resolve (Mount critical) path, so it
+	// must never block; and dropping entries would permanently skip background
+	// fetching for those layers. Queued entries are small (a Resolver pointer
+	// per layer), so unbounded growth is bounded in practice by the number of
+	// concurrently-mounted layers. maxQueueSize is kept as an observability
+	// threshold: exceeding it logs a warning but does not block or drop.
+	workQueueMu sync.Mutex
+	workQueue   []Resolver
+
 	closeChan chan struct{}
 	pauseChan chan struct{}
 }
@@ -98,9 +109,8 @@ func NewBackgroundFetcher(opts ...Option) (*BackgroundFetcher, error) {
 	// with a burst capacity of 1 (i.e., it will never invoke more than 1 bg-fetch
 	// within bf.fetchPeriod)
 	bf.rateLimiter = rate.NewLimiter(rate.Every(bf.fetchPeriod), 1)
-	bf.workQueue = make(chan Resolver, bf.maxQueueSize)
 	bf.closeChan = make(chan struct{})
-	bf.pauseChan = make(chan struct{}, bf.maxQueueSize)
+	bf.pauseChan = make(chan struct{}, 1)
 
 	if bf.bfPauser == nil {
 		bf.bfPauser = defaultPauser{}
@@ -110,9 +120,40 @@ func NewBackgroundFetcher(opts ...Option) (*BackgroundFetcher, error) {
 }
 
 // Add a new Resolver to be background fetched from.
-// Sends the resolver through the channel, which will be received in the Run() method.
+// Appends the resolver to the work queue, which is drained by Run().
+//
+// Add never blocks and never drops: it is called on the layer resolve
+// (Mount critical) path, where blocking on a full queue would stall layer
+// mounts (previously observed as pulls stalling for a full silence period),
+// and dropping would permanently skip background fetching for the layer.
 func (bf *BackgroundFetcher) Add(resolver Resolver) {
-	bf.workQueue <- resolver
+	bf.workQueueMu.Lock()
+	bf.workQueue = append(bf.workQueue, resolver)
+	n := len(bf.workQueue)
+	bf.workQueueMu.Unlock()
+	if bf.maxQueueSize > 0 && n > bf.maxQueueSize {
+		log.L.WithField("queueSize", n).WithField("maxQueueSize", bf.maxQueueSize).
+			Debug("background fetch work queue exceeded max_queue_size (non-fatal; queue is unbounded)")
+	}
+}
+
+// pop removes and returns the next Resolver from the work queue, or nil if
+// the queue is empty.
+func (bf *BackgroundFetcher) pop() Resolver {
+	bf.workQueueMu.Lock()
+	defer bf.workQueueMu.Unlock()
+	if len(bf.workQueue) == 0 {
+		return nil
+	}
+	lr := bf.workQueue[0]
+	bf.workQueue = bf.workQueue[1:]
+	return lr
+}
+
+func (bf *BackgroundFetcher) queueSize() int {
+	bf.workQueueMu.Lock()
+	defer bf.workQueueMu.Unlock()
+	return len(bf.workQueue)
 }
 
 func (bf *BackgroundFetcher) Close() error {
@@ -121,8 +162,14 @@ func (bf *BackgroundFetcher) Close() error {
 }
 
 // Pause sends a signal to pause the background fetcher for silencePeriod on the next iteration.
+// The signal is idempotent (pending signals are coalesced into a single pause),
+// so this never blocks even if a signal is already pending.
 func (bf *BackgroundFetcher) Pause() {
-	bf.pauseChan <- struct{}{}
+	select {
+	case bf.pauseChan <- struct{}{}:
+	default:
+		// A pause signal is already pending; coalesce.
+	}
 }
 
 func (bf *BackgroundFetcher) pause(ctx context.Context) {
@@ -161,20 +208,18 @@ func (bf *BackgroundFetcher) Run(ctx context.Context) error {
 		default:
 		}
 
-		select {
-		case lr := <-bf.workQueue:
+		if lr := bf.pop(); lr != nil {
 			if lr.Closed() {
 				continue
 			}
 			go func() {
 				more, err := lr.Resolve(ctx)
 				if more {
-					bf.workQueue <- lr
+					bf.Add(lr)
 				} else if err != nil {
 					log.G(ctx).WithError(err).Warn("error trying to resolve layer, removing it from the queue")
 				}
 			}()
-		default:
 		}
 
 		if err := bf.rateLimiter.Wait(ctx); err != nil {
@@ -192,7 +237,7 @@ func (bf *BackgroundFetcher) emitWorkQueueMetric(ctx context.Context, ticker *ti
 			return
 		case <-ticker.C:
 			// background fetcher is at the snapshotter's fs level, so no image digest as key
-			commonmetrics.AddImageOperationCount(commonmetrics.BackgroundFetchWorkQueueSize, "", int32(len(bf.workQueue)))
+			commonmetrics.AddImageOperationCount(commonmetrics.BackgroundFetchWorkQueueSize, "", int32(bf.queueSize()))
 		}
 	}
 }

--- a/fs/backgroundfetcher/background_fetcher.go
+++ b/fs/backgroundfetcher/background_fetcher.go
@@ -24,6 +24,7 @@ import (
 
 	commonmetrics "github.com/awslabs/soci-snapshotter/fs/metrics/common"
 	"github.com/containerd/log"
+	digest "github.com/opencontainers/go-digest"
 	"golang.org/x/time/rate"
 )
 
@@ -50,6 +51,18 @@ func WithMaxQueueSize(size int) Option {
 	}
 }
 
+func WithDropPolicy(policy string) Option {
+	return func(bf *BackgroundFetcher) error {
+		bf.dropPolicy = policy
+		return nil
+	}
+}
+
+const (
+	DropPolicyOldest = "oldest"
+	DropPolicyNewest = "newest"
+)
+
 func WithEmitMetricPeriod(period time.Duration) Option {
 	return func(bf *BackgroundFetcher) error {
 		bf.emitMetricPeriod = period
@@ -75,6 +88,7 @@ type BackgroundFetcher struct {
 	silencePeriod    time.Duration
 	fetchPeriod      time.Duration
 	maxQueueSize     int
+	dropPolicy       string
 	emitMetricPeriod time.Duration
 
 	rateLimiter *rate.Limiter
@@ -84,13 +98,11 @@ type BackgroundFetcher struct {
 	// All span managers are appended to the work queue and picked up in Run().
 	// If a span manager is still able to fetch, it is re-appended.
 	//
-	// The queue is an unbounded, mutex-guarded slice rather than a fixed-size
-	// channel: Add is called on the layer resolve (Mount critical) path, so it
-	// must never block; and dropping entries would permanently skip background
-	// fetching for those layers. Queued entries are small (a Resolver pointer
-	// per layer), so unbounded growth is bounded in practice by the number of
-	// concurrently-mounted layers. maxQueueSize is kept as an observability
-	// threshold: exceeding it logs a warning but does not block or drop.
+	// The queue is a mutex-guarded slice. Add is called on the layer resolve
+	// (Mount critical) path and never blocks. When maxQueueSize > 0 and the
+	// queue is full, the entry selected by dropPolicy is evicted (that layer
+	// loses background fetching but continues to serve lazily on demand).
+	// When maxQueueSize < 0 (unlimited), no eviction occurs.
 	workQueueMu sync.Mutex
 	workQueue   []Resolver
 
@@ -116,25 +128,37 @@ func NewBackgroundFetcher(opts ...Option) (*BackgroundFetcher, error) {
 		bf.bfPauser = defaultPauser{}
 	}
 
+	// Pre-create the eviction counter at 0 so it is always exposed by the
+	// metrics endpoint, even before the first eviction.
+	commonmetrics.InitOperationCount(commonmetrics.BackgroundFetchWorkQueueEvicted, digest.Digest(""))
+
 	return bf, nil
 }
 
 // Add a new Resolver to be background fetched from.
 // Appends the resolver to the work queue, which is drained by Run().
 //
-// Add never blocks and never drops: it is called on the layer resolve
-// (Mount critical) path, where blocking on a full queue would stall layer
-// mounts (previously observed as pulls stalling for a full silence period),
-// and dropping would permanently skip background fetching for the layer.
+// Add never blocks: it is called on the layer resolve (Mount critical) path,
+// where blocking would stall layer mounts. When the queue is bounded
+// (maxQueueSize > 0) and full, the entry selected by dropPolicy is evicted.
 func (bf *BackgroundFetcher) Add(resolver Resolver) {
 	bf.workQueueMu.Lock()
-	bf.workQueue = append(bf.workQueue, resolver)
-	n := len(bf.workQueue)
-	bf.workQueueMu.Unlock()
-	if bf.maxQueueSize > 0 && n > bf.maxQueueSize {
-		log.L.WithField("queueSize", n).WithField("maxQueueSize", bf.maxQueueSize).
-			Debug("background fetch work queue exceeded max_queue_size (non-fatal; queue is unbounded)")
+	if bf.maxQueueSize > 0 && len(bf.workQueue) >= bf.maxQueueSize {
+		if bf.dropPolicy == DropPolicyOldest {
+			bf.workQueue = bf.workQueue[1:]
+			commonmetrics.IncOperationCount(commonmetrics.BackgroundFetchWorkQueueEvicted, digest.Digest(""))
+			log.L.WithField("maxQueueSize", bf.maxQueueSize).
+				Debug("background fetch work queue full; evicting oldest entry")
+		} else {
+			bf.workQueueMu.Unlock()
+			commonmetrics.IncOperationCount(commonmetrics.BackgroundFetchWorkQueueEvicted, digest.Digest(""))
+			log.L.WithField("maxQueueSize", bf.maxQueueSize).
+				Debug("background fetch work queue full; dropping newly added entry")
+			return
+		}
 	}
+	bf.workQueue = append(bf.workQueue, resolver)
+	bf.workQueueMu.Unlock()
 }
 
 // pop removes and returns the next Resolver from the work queue, or nil if

--- a/fs/backgroundfetcher/background_fetcher_test.go
+++ b/fs/backgroundfetcher/background_fetcher_test.go
@@ -19,6 +19,7 @@ package backgroundfetcher
 import (
 	"compress/gzip"
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -152,6 +153,137 @@ func TestBackgroundFetcherRun(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// mockResolver is a simple resolver for testing Add eviction behavior.
+type mockResolver struct {
+	id     string
+	closed bool
+}
+
+func (m *mockResolver) Resolve(ctx context.Context) (bool, error) { return false, nil }
+func (m *mockResolver) Close() error                              { return nil }
+func (m *mockResolver) Closed() bool                              { return m.closed }
+
+func TestAddEvictsOldestWhenFull(t *testing.T) {
+	bf, err := NewBackgroundFetcher(
+		WithFetchPeriod(time.Second),
+		WithMaxQueueSize(3),
+		WithDropPolicy(DropPolicyOldest),
+		WithEmitMetricPeriod(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r1 := &mockResolver{id: "r1"}
+	r2 := &mockResolver{id: "r2"}
+	r3 := &mockResolver{id: "r3"}
+	r4 := &mockResolver{id: "r4"}
+
+	bf.Add(r1)
+	bf.Add(r2)
+	bf.Add(r3)
+	if bf.queueSize() != 3 {
+		t.Fatalf("expected queue size 3, got %d", bf.queueSize())
+	}
+
+	bf.Add(r4)
+	if bf.queueSize() != 3 {
+		t.Fatalf("expected queue size 3 after eviction, got %d", bf.queueSize())
+	}
+
+	// oldest (r1) should have been evicted; head should be r2
+	head := bf.pop()
+	if head.(*mockResolver).id != "r2" {
+		t.Fatalf("expected head to be r2, got %s", head.(*mockResolver).id)
+	}
+}
+
+func TestAddDropsNewestWhenFull(t *testing.T) {
+	bf, err := NewBackgroundFetcher(
+		WithFetchPeriod(time.Second),
+		WithMaxQueueSize(3),
+		WithDropPolicy(DropPolicyNewest),
+		WithEmitMetricPeriod(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r1 := &mockResolver{id: "r1"}
+	r2 := &mockResolver{id: "r2"}
+	r3 := &mockResolver{id: "r3"}
+	r4 := &mockResolver{id: "r4"}
+
+	bf.Add(r1)
+	bf.Add(r2)
+	bf.Add(r3)
+	bf.Add(r4) // should be dropped
+
+	if bf.queueSize() != 3 {
+		t.Fatalf("expected queue size 3, got %d", bf.queueSize())
+	}
+
+	// queue should be [r1, r2, r3] — r4 was dropped
+	head := bf.pop()
+	if head.(*mockResolver).id != "r1" {
+		t.Fatalf("expected head to be r1, got %s", head.(*mockResolver).id)
+	}
+	second := bf.pop()
+	if second.(*mockResolver).id != "r2" {
+		t.Fatalf("expected second to be r2, got %s", second.(*mockResolver).id)
+	}
+	third := bf.pop()
+	if third.(*mockResolver).id != "r3" {
+		t.Fatalf("expected third to be r3, got %s", third.(*mockResolver).id)
+	}
+}
+
+func TestAddUnlimitedQueueNeverEvicts(t *testing.T) {
+	bf, err := NewBackgroundFetcher(
+		WithFetchPeriod(time.Second),
+		WithMaxQueueSize(-1),
+		WithDropPolicy(DropPolicyOldest),
+		WithEmitMetricPeriod(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 200; i++ {
+		bf.Add(&mockResolver{id: fmt.Sprintf("r%d", i)})
+	}
+	if bf.queueSize() != 200 {
+		t.Fatalf("expected queue size 200 for unlimited, got %d", bf.queueSize())
+	}
+}
+
+func TestAddDefaultDropPolicyIsNewest(t *testing.T) {
+	bf, err := NewBackgroundFetcher(
+		WithFetchPeriod(time.Second),
+		WithMaxQueueSize(2),
+		WithEmitMetricPeriod(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r1 := &mockResolver{id: "r1"}
+	r2 := &mockResolver{id: "r2"}
+	r3 := &mockResolver{id: "r3"}
+
+	bf.Add(r1)
+	bf.Add(r2)
+	bf.Add(r3) // should be dropped (newest)
+
+	if bf.queueSize() != 2 {
+		t.Fatalf("expected queue size 2, got %d", bf.queueSize())
+	}
+	head := bf.pop()
+	if head.(*mockResolver).id != "r1" {
+		t.Fatalf("expected head to be r1 (newest dropped, queue unchanged), got %s", head.(*mockResolver).id)
 	}
 }
 

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -233,6 +233,7 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 		bgSilencePeriod             = time.Duration(cfg.BackgroundFetchConfig.SilencePeriodMsec) * time.Millisecond
 		bgEmitMetricPeriod          = time.Duration(cfg.BackgroundFetchConfig.EmitMetricPeriodSec) * time.Second
 		bgMaxQueueSize              = cfg.BackgroundFetchConfig.MaxQueueSize
+		bgDropPolicy                = cfg.BackgroundFetchConfig.DropPolicy
 	)
 
 	metadataStore := fsOpts.metadataStore
@@ -275,12 +276,14 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 			"fetchPeriod":      bgFetchPeriod,
 			"silencePeriod":    bgSilencePeriod,
 			"maxQueueSize":     bgMaxQueueSize,
+			"dropPolicy":       bgDropPolicy,
 			"emitMetricPeriod": bgEmitMetricPeriod,
 		}).Info("constructing background fetcher")
 
 		bgFetcher, err = bf.NewBackgroundFetcher(bf.WithFetchPeriod(bgFetchPeriod),
 			bf.WithSilencePeriod(bgSilencePeriod),
 			bf.WithMaxQueueSize(bgMaxQueueSize),
+			bf.WithDropPolicy(bgDropPolicy),
 			bf.WithEmitMetricPeriod(bgEmitMetricPeriod))
 
 		if err != nil {

--- a/fs/metrics/common/metrics.go
+++ b/fs/metrics/common/metrics.go
@@ -138,6 +138,9 @@ const (
 	// Number of items in the work queue of background fetcher
 	BackgroundFetchWorkQueueSize = "background_fetch_work_queue_size"
 
+	// Number of entries evicted from the background fetcher work queue because it was full
+	BackgroundFetchWorkQueueEvicted = "background_fetch_work_queue_evicted"
+
 	// ResolveCacheHit counts layer resolves served from the resolver LRU cache
 	// (e.g. a layer that was pre-resolved and is still cached when containerd
 	// mounts it). A high hit ratio means pre-resolution is landing.
@@ -277,6 +280,14 @@ func MeasureLatencyInMicroseconds(operation string, layer digest.Digest, start t
 // IncOperationCount wraps the labels attachment as well as calling Inc into a single method.
 func IncOperationCount(operation string, layer digest.Digest) {
 	operationCount.WithLabelValues(operation, layer.String()).Inc()
+}
+
+// InitOperationCount pre-creates the labeled series for an operation count
+// metric at 0 so it is exposed by the metrics endpoint before the first
+// increment (queries against a never-incremented counter otherwise return
+// no data).
+func InitOperationCount(operation string, layer digest.Digest) {
+	operationCount.WithLabelValues(operation, layer.String()).Add(0)
 }
 
 // GetOperationCount returns the current value of an operation count metric for a given layer.


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

`BackgroundFetcher.Add` does a blocking channel send, and it's called from `Resolve` on the mount critical path. When more layers mount than the queue can hold (`max_queue_size`, default 100), mounts block waiting for space.
But the fetcher sleeps for `silence_period_msec` (default 30s) on each new image mount before draining anything, so during a multi-image launch, mounts stall for the full silence period.

When launching 10 images (~160 layers) at once: pull time was ~30s with the default config, dropping to ~3s when we set `silence_period_msec=100`.
The correlation made the root cause obvious.

 Switching the work queue from a fixed-capacity channel to a mutex-guarded slice.
`Add` now appends instantly, never blocks, never drops. Every layer still gets background-fetched once the silence period ends.

Also made `Pause()` non-blocking (capacity-1 channel with select/default) so it can't pile up or stall the mount path either.

`max_queue_size` stays in the config as a logging threshold, exceeding it emits a debug log but doesn't cap the queue. Existing configs keep working unchanged.

Why not just increase max_queue_size? A bigger number just moves the cliff. Any workload that exceeds it silently re-triggers the stall with no error or log to point at. Making `Add` structurally non-blocking removes the failure mode entirely.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
