### PR TITLE
feat(metadata): Add metadata_db_no_sync and metadata_insertion_chunk_size config

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -339,12 +339,16 @@ func getMetadataStore(ctx context.Context, rootDir string, config config.Config)
 			NoFreelistSync:  true,
 			InitialMmapSize: 64 * 1024 * 1024,
 			FreelistType:    bolt.FreelistMapType,
+			NoSync:          config.MetadataDBNoSync,
 		}
 		db, err := bolt.Open(filepath.Join(rootDir, "metadata.db"), 0600, &bOpts)
 		if err != nil {
 			return nil, err
 		}
 		return func(sr *io.SectionReader, toc ztoc.TOC, opts ...metadata.Option) (metadata.Reader, error) {
+			if config.MetadataInsertionChunkSize > 0 {
+				opts = append(opts, metadata.WithInsertionChunkSize(config.MetadataInsertionChunkSize))
+			}
 			return metadata.NewReader(db, sr, toc, opts...)
 		}, nil
 	default:

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,18 @@ type Config struct {
 	// MetadataStore is the type of the metadata store to use.
 	MetadataStore string `toml:"metadata_store"`
 
+	// MetadataDBNoSync disables bbolt's per-transaction fsync for the metadata
+	// store. The metadata DB is derived data rebuilt from zTOCs on every daemon
+	// restart, so fsync durability is unnecessary. Skipping it removes
+	// synchronous disk flushes from layer metadata initialization.
+	MetadataDBNoSync bool `toml:"metadata_db_no_sync"`
+
+	// MetadataInsertionChunkSize is the maximum number of node insertions per
+	// bbolt transaction during metadata store initialization. Larger chunks
+	// amortize per-commit overhead over more insertions. 0 means use the
+	// default (5000).
+	MetadataInsertionChunkSize int `toml:"metadata_insertion_chunk_size"`
+
 	// SkipCheckSnapshotterSupported is a flag to skip check for overlayfs support needed to confirm if SOCI can work
 	SkipCheckSnapshotterSupported bool `toml:"skip_check_snapshotter_supported"`
 }

--- a/config/config.toml
+++ b/config/config.toml
@@ -11,6 +11,8 @@ metrics_network = 'tcp'
 no_prometheus = false
 debug_address = ''
 metadata_store = 'db'
+metadata_db_no_sync = false
+metadata_insertion_chunk_size = 0
 skip_check_snapshotter_supported = false
 
 [http]

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,6 +34,8 @@ This set of variables must be at the top of your TOML file due to not belonging 
 - `no_prometheus` — Defined [above](#configfsgofsconfig), cannot be redeclared.
 - `debug_address` (string) — Address where [go pprof](https://pkg.go.dev/net/http/pprof) server will listen. If empty, no logs will be emitted. Default: "".
 - `metadata_store` (string) — Metadata storage type. Only "db" is valid. Default: "db".
+- `metadata_db_no_sync` (bool) — Disables bbolt's per-transaction fsync for the metadata store. The metadata DB is derived data rebuilt from zTOCs on each daemon restart, so fsync durability is unnecessary. Removes synchronous disk flushes from layer metadata initialization. Default: false.
+- `metadata_insertion_chunk_size` (int) — Max node insertions per bbolt transaction during metadata init. Larger chunks amortize per-commit overhead. 0 means use the default. Default: 5000.
 - `skip_check_snapshotter_supported` (bool) - skip check for snapshotter is supported which can give performance benefits for SOCI daemon startup time. This config should only be done if you are sure overlayfs is supported. Default: false
 
 #

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -99,7 +99,8 @@ type File interface {
 }
 
 type Options struct {
-	Telemetry *Telemetry
+	Telemetry          *Telemetry
+	InsertionChunkSize int // max insertions per bbolt transaction; <= 0 means default
 }
 
 // Option is an option to configure the behaviour of reader.
@@ -109,6 +110,15 @@ type Option func(o *Options) error
 func WithTelemetry(telemetry *Telemetry) Option {
 	return func(o *Options) error {
 		o.Telemetry = telemetry
+		return nil
+	}
+}
+
+// WithInsertionChunkSize sets the maximum number of node insertions per bbolt
+// transaction during metadata store initialization.
+func WithInsertionChunkSize(chunkSize int) Option {
+	return func(o *Options) error {
+		o.InsertionChunkSize = chunkSize
 		return nil
 	}
 }

--- a/metadata/reader.go
+++ b/metadata/reader.go
@@ -55,11 +55,9 @@ import (
 )
 
 const (
-	// bboltInsertionChunkSize roughly determines the maximum number of insertions to
-	// bbolt per transaction. We chose 5K to be the chunk size as it yielded the best
-	// balance between performance and memory usage compared to other chunk sizes (1k and 10k)
-	// that were benchmarked.
-	bboltInsertionChunkSize = 5000
+	// defaultInsertionChunkSize roughly determines the maximum number of
+	// insertions to bbolt per transaction. Override with WithInsertionChunkSize.
+	defaultInsertionChunkSize = 5000
 )
 
 // reader stores filesystem metadata parsed from a TOC to metadata DB
@@ -124,7 +122,11 @@ func (r *reader) init(toc ztoc.TOC, rOpts Options) (retErr error) {
 		return fmt.Errorf("failed to get a unique id for metadata reader")
 	}
 
-	return r.initNodes(toc)
+	chunkSize := rOpts.InsertionChunkSize
+	if chunkSize <= 0 {
+		chunkSize = defaultInsertionChunkSize
+	}
+	return r.initNodes(toc, chunkSize)
 }
 
 func (r *reader) initRootNode(fsID string) error {
@@ -164,8 +166,8 @@ func (r *reader) initRootNode(fsID string) error {
 	})
 }
 
-func (r *reader) initNodes(toc ztoc.TOC) error {
-	fileMetadataChunks := partition(toc.FileMetadata, bboltInsertionChunkSize)
+func (r *reader) initNodes(toc ztoc.TOC, insertionChunkSize int) error {
+	fileMetadataChunks := partition(toc.FileMetadata, insertionChunkSize)
 
 	md := make(map[uint32]*metadataEntry)
 	for _, fileMetadataChunk := range fileMetadataChunks {
@@ -278,7 +280,7 @@ func (r *reader) initNodes(toc ztoc.TOC) error {
 		return bytes.Compare(addendum[i].id, addendum[j].id) < 0
 	})
 
-	metadataChunks := partition(addendum, bboltInsertionChunkSize)
+	metadataChunks := partition(addendum, insertionChunkSize)
 	for _, metadataChunk := range metadataChunks {
 		if err := r.db.Batch(func(tx *bolt.Tx) (err error) {
 			meta, err := getMetadataBucket(tx, r.fsID)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Two new configuration values for tuning the bbolt metadata store initialization:

- **`metadata_db_no_sync`** (bool, default false): disables bbolt's per-transaction fsync. The metadata DB is derived data rebuilt from zTOCs on every daemon restart, so fsync durability is unnecessary. Skipping it removes synchronous disk flushes from layer metadata initialization.
- **`metadata_insertion_chunk_size`** (int, default 5000): max node insertions per bbolt transaction during metadata init. Larger chunks amortize per-commit overhead (B-tree rebalance, page COW, and fsync when enabled) over more insertions.

Under parallel image mounts, the metadata store's synchronous fsyncs and frequent small commits add measurable I/O latency per layer. These configuration values trade durabilit the snapshotter never needs (the DB is ephemeral) for faster initialization.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
