### PR TITLE
fix: Honor [resolver] insecure flag for SOCI index and blob fetch paths

### DIFF
--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -75,8 +75,8 @@ type orasBlobStore struct {
 	*remote.Repository
 }
 
-func newRemoteBlobStore(refspec reference.Spec, client *http.Client) (*orasBlobStore, error) {
-	repo, err := newRemoteStore(refspec, client)
+func newRemoteBlobStore(refspec reference.Spec, client *http.Client, plainHTTP bool) (*orasBlobStore, error) {
+	repo, err := newRemoteStore(refspec, client, plainHTTP)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create remote store: %w", err)
 	}
@@ -96,7 +96,7 @@ func (r *orasBlobStore) Resolve(ctx context.Context, reference string) (ocispec.
 	}
 
 	tr := &clientWrapper{r.Client}
-	url := sociremote.CraftBlobURL(reference, ref)
+	url := sociremote.CraftBlobURL(reference, ref, r.PlainHTTP)
 	resp, err := sociremote.GetHeader(ctx, url, tr)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -164,7 +164,7 @@ func (r *orasBlobStore) FetchRange(ctx context.Context, reference string, lower,
 	}
 
 	tr := &clientWrapper{r.Client}
-	realURL := sociremote.CraftBlobURL(reference, ref)
+	realURL := sociremote.CraftBlobURL(reference, ref, r.PlainHTTP)
 	resp, err := GetContentWithRange(ctx, realURL, tr, lower, upper)
 	if err != nil {
 		return nil, cleanFetchErrors(err)
@@ -207,7 +207,7 @@ func (r *orasBlobStore) doInitialFetch(ctx context.Context, reference string) (b
 	}
 
 	tr := &clientWrapper{r.Client}
-	url := sociremote.CraftBlobURL(reference, ref)
+	url := sociremote.CraftBlobURL(reference, ref, r.PlainHTTP)
 	resp, err := sociremote.GetHeaderWithGet(ctx, url, tr)
 	if err != nil {
 		return false, fmt.Errorf("error getting header info: %w", err)
@@ -232,15 +232,19 @@ func (c *clientWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return c.Client.Do(req)
 }
 
-func newRemoteStore(refspec reference.Spec, client *http.Client) (*remote.Repository, error) {
+func newRemoteStore(refspec reference.Spec, client *http.Client, plainHTTP bool) (*remote.Repository, error) {
 	repo, err := remote.NewRepository(refspec.Locator)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create repository %s: %w", refspec.Locator, err)
 	}
 	repo.Client = client
-	repo.PlainHTTP, err = docker.MatchLocalhost(refspec.Hostname())
-	if err != nil {
-		return nil, fmt.Errorf("cannot create repository %s: %w", refspec.Locator, err)
+	if plainHTTP {
+		repo.PlainHTTP = true
+	} else {
+		repo.PlainHTTP, err = docker.MatchLocalhost(refspec.Hostname())
+		if err != nil {
+			return nil, fmt.Errorf("cannot create repository %s: %w", refspec.Locator, err)
+		}
 	}
 
 	return repo, nil

--- a/fs/artifact_fetcher_test.go
+++ b/fs/artifact_fetcher_test.go
@@ -291,7 +291,7 @@ func TestNewRemoteStore(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected failure parsing reference: %v", err)
 			}
-			r, err := newRemoteStore(refspec, &client)
+			r, err := newRemoteStore(refspec, &client, false)
 			if err != nil {
 				t.Fatalf("unexpected error, got %v", err)
 			}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -169,6 +169,7 @@ type options struct {
 	overlayOpaqueType layer.OverlayOpaqueType
 	maxConcurrency    int64
 	pullModes         config.PullModes
+	resolverConfig    config.ResolverConfig
 }
 
 func WithGetSources(s source.GetSources) Option {
@@ -207,6 +208,15 @@ func WithMaxConcurrency(maxConcurrency int64) Option {
 func WithPullModes(pullModes config.PullModes) Option {
 	return func(opts *options) {
 		opts.pullModes = pullModes
+	}
+}
+
+// WithResolverConfig passes the registry resolver config to the filesystem so
+// the SOCI index/zTOC fetch path can honor per-host settings (e.g. insecure
+// mirrors for plain HTTP registries).
+func WithResolverConfig(resolverConfig config.ResolverConfig) Option {
+	return func(opts *options) {
+		opts.resolverConfig = resolverConfig
 	}
 }
 
@@ -338,6 +348,7 @@ func NewFilesystem(ctx context.Context, root string, cfg config.FSConfig, opts .
 		fuseMetricsEmitWaitDuration: fuseMetricsEmitWaitDuration,
 		pr:                          pr,
 		pullModes:                   pullModes,
+		resolverConfig:              fsOpts.resolverConfig,
 		containerd:                  client,
 		inProgressImageUnpacks:      unpackJobs,
 	}, nil
@@ -430,8 +441,24 @@ type filesystem struct {
 	fuseMetricsEmitWaitDuration time.Duration
 	pr                          *preresolver
 	pullModes                   config.PullModes
+	resolverConfig              config.ResolverConfig
 	containerd                  *store.ContainerdClient
 	inProgressImageUnpacks      *unpackJobs
+}
+
+// isInsecureHost reports whether the given registry host is configured as an
+// insecure (plain HTTP) mirror in the resolver config.
+func (fs *filesystem) isInsecureHost(host string) bool {
+	hostConfig, ok := fs.resolverConfig.Host[host]
+	if !ok {
+		return false
+	}
+	for _, mirror := range hostConfig.Mirrors {
+		if mirror.Insecure {
+			return true
+		}
+	}
+	return false
 }
 
 func (fs *filesystem) MountParallel(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
@@ -508,7 +535,7 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 			Transport: newAuthClient,
 		}
 	}
-	remoteStore, err := newRemoteBlobStore(refspec, client)
+	remoteStore, err := newRemoteBlobStore(refspec, client, fs.isInsecureHost(refspec.Hostname()))
 	if err != nil {
 		return fmt.Errorf("cannot create remote store: %w", err)
 	}
@@ -762,7 +789,7 @@ func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels 
 	if err != nil {
 		return fmt.Errorf("cannot parse image ref (%s): %w", imageRef, err)
 	}
-	remoteStore, err := newRemoteBlobStore(refspec, client)
+	remoteStore, err := newRemoteBlobStore(refspec, client, fs.isInsecureHost(refspec.Hostname()))
 	if err != nil {
 		return fmt.Errorf("cannot create remote store: %w", err)
 	}
@@ -832,7 +859,7 @@ func (fs *filesystem) fetchSociIndex(ctx context.Context, imageRef, indexDigest,
 		return nil, err
 	}
 
-	remoteStore, err := newRemoteStore(refspec, client)
+	remoteStore, err := newRemoteStore(refspec, client, fs.isInsecureHost(refspec.Hostname()))
 	if err != nil {
 		return nil, err
 	}

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -458,8 +458,14 @@ func redirect(ctx context.Context, blobURL string, tr http.RoundTripper) (string
 	return "", fmt.Errorf("%w on redirect %v", ErrUnexpectedStatusCode, res.StatusCode)
 }
 
-func CraftBlobURL(reference string, ref registry.Reference) string {
-	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s", resolver.DefaultScheme(reference), ref.Host(), ref.Repository, ref.Reference)
+func CraftBlobURL(reference string, ref registry.Reference, plainHTTP bool) string {
+	scheme := resolver.DefaultScheme(reference)
+	// plainHTTP forces HTTP for hosts explicitly configured as insecure, which
+	// DefaultScheme (localhost-only) would otherwise not cover.
+	if plainHTTP {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s", scheme, ref.Host(), ref.Repository, ref.Reference)
 }
 
 func GetHeader(ctx context.Context, realURL string, rt http.RoundTripper) (*http.Response, error) {

--- a/service/service.go
+++ b/service/service.go
@@ -103,6 +103,7 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 	fsOpts := append(sOpts.fsOpts, socifs.WithGetSources(getSources),
 		socifs.WithOverlayOpaqueType(opq),
 		socifs.WithPullModes(serviceCfg.PullModes),
+		socifs.WithResolverConfig(registryConfig),
 	)
 	if serviceCfg.FSConfig.MaxConcurrency != 0 {
 		fsOpts = append(fsOpts, socifs.WithMaxConcurrency(serviceCfg.FSConfig.MaxConcurrency))


### PR DESCRIPTION
**Issue #, if available:** 
#1965 

**Description of changes:**

The `[resolver.host.<host>.mirrors] insecure = true` config only controlled the layer-blob resolver in `service/resolver`.
The SOCI index fetch, zTOC blob fetches, and parallel-pull blob operations each derived their URL scheme independently via `docker.MatchLocalhost` (which only treats literal localhost as plain HTTP). 
Registries configured as insecure mirrors (e.g. an internal registry on a non-localhost IP over plain HTTP), got HTTPS requests that failed.

**Config example:**
```toml
[resolver]
  [resolver.host."100.65.30.95:32624"]
    [[resolver.host."100.65.30.95:32624".mirrors]]
      host = "http://100.65.30.95:32624"
      insecure = true
```

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
