### PR TITLE
Use CodeBuild runners for tests running as root

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,25 +46,9 @@ jobs:
         run: dnf install zlib-static.aarch64 -y
       - run: make
       - run: make test-with-coverage
+      - run: sudo -E env PATH=$PATH make test-root-with-coverage
       - name: Show test coverage
         run: make show-test-coverage
-
-  # This is a temporary workaround to ensure we are testing our packages
-  # that require root (currently only the snapshot package).
-  # ref: https://github.com/awslabs/soci-snapshotter/issues/1878
-  test-root:
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        go-version: ['1.25.11', '1.26.4']
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
-        with:
-          go-version: ${{ matrix.go-version }}
-      # Only snapshot package has tests that require root
-      - run: sudo -E env PATH=$PATH go test ./snapshot -test.root
 
   integration:
     needs: setup

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ CMD_BINARIES=$(addprefix $(OUTDIR)/,$(CMD))
 PACKAGE_LIST_CMD=go list -f '{{.ImportPath}}' ./... | grep -v "benchmark" | paste -sd ","
 
 SOCI_LIBRARY_PACKAGE_LIST=$(shell $(PACKAGE_LIST_CMD))
+SOCI_LIBRARY_PACKAGE_LIST_ROOT=github.com/awslabs/soci-snapshotter/snapshot
 SOCI_CLI_PACKAGE_LIST=$(shell echo $(SOCI_LIBRARY_PACKAGE_LIST),$(shell cd $(SOCI_SNAPSHOTTER_PROJECT_ROOT)/cmd/soci && $(PACKAGE_LIST_CMD)))
 SOCI_GRPC_PACKAGE_LIST=$(shell echo $(SOCI_LIBRARY_PACKAGE_LIST),$(shell cd $(SOCI_SNAPSHOTTER_PROJECT_ROOT)/cmd/soci-snapshotter-grpc && $(PACKAGE_LIST_CMD)))
 
@@ -142,6 +143,14 @@ vendor:
 gen-config: build
 	@$(OUTDIR)/soci-snapshotter-grpc config default > $(SOCI_SNAPSHOTTER_PROJECT_ROOT)/config/config.toml
 
+test-root:
+	@if ! [ "$(shell id -u)" = 0 ]; then\
+		echo "You must run this command as root";\
+		exit 1;\
+	fi
+	@echo "$@"
+	GO111MODULE=$(GO111MODULE_VALUE) go test $(GO_TEST_FLAGS) $(GO_LD_FLAGS) -race $(SOCI_LIBRARY_PACKAGE_LIST_ROOT) -test.root -args $(GO_TEST_ARGS)
+
 test: test-lib test-cmd
 
 test-lib:
@@ -165,6 +174,13 @@ test-with-coverage: $(COVDIR)/unit
 	GO_TEST_ARGS="-test.gocoverdir=$(COVDIR)/unit" \
 	GO_BUILD_FLAGS="$(GO_BUILD_FLAGS) -coverpkg=$(SOCI_LIBRARY_PACKAGE_LIST)"\
 		$(MAKE) test
+
+test-root-with-coverage: $(COVDIR)/unit
+	@echo "$@"
+	GO_TEST_FLAGS="$(GO_TEST_FLAGS) -cover" \
+	GO_TEST_ARGS="-test.gocoverdir=$(COVDIR)/unit" \
+	GO_BUILD_FLAGS="$(GO_BUILD_FLAGS) -coverpkg=$(SOCI_LIBRARY_PACKAGE_LIST_ROOT)"\
+		$(MAKE) test-root
 
 $(COVDIR):
 	@mkdir -p $@


### PR DESCRIPTION
**Issue #, if available:**
Closes #1878 

**Description of changes:**
CodeBuild updated its kernel so our workaround in #1875 shouldn't be needed anymore. Added some targets to make testing easier.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
