### PR TITLE
feat(resolver): Add opt-in registry auth client sharing to reduce token exchanges

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -84,6 +84,9 @@ skip_check_snapshotter_supported = false
   image_service_path = '/run/containerd/containerd.sock'
 
 [resolver]
+  auth_client_ttl_sec = 3600
+  enable_auth_client_sharing = false
+
 [snapshotter]
   min_layer_size = 0
   allow_invalid_mounts_on_restart = false

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -47,6 +47,10 @@ const (
 // ServiceConfig defaults
 const (
 	DefaultImageServiceAddress = "/run/containerd/containerd.sock"
+
+	// defaultAuthClientTTLSec is how long cached registry auth clients are
+	// reused before being discarded and rebuilt. See `ResolverConfig.AuthClientTTLSec`.
+	defaultAuthClientTTLSec = 3600
 )
 
 // ParallelPullUnpack defaults

--- a/config/resolver.go
+++ b/config/resolver.go
@@ -41,6 +41,21 @@ package config
 // ResolverConfig is config for resolving registries.
 type ResolverConfig struct {
 	Host map[string]HostConfig `toml:"host"`
+
+	// AuthClientTTLSec is how long (in seconds) cached registry auth clients
+	// (and their resolved registry-host configurations) are reused before
+	// being discarded and rebuilt. Rebuilding re-resolves credentials and
+	// re-authenticates, so the TTL bounds both memory growth of the caches
+	// and the lifetime of any credential-derived state. Negative means cache
+	// entries never expire. Default: 3600.
+	AuthClientTTLSec int64 `toml:"auth_client_ttl_sec"`
+
+	// EnableAuthClientSharing, when true, shares auth clients between image
+	// references that target the same registry host with identical
+	// credentials, so same-registry images pay a single auth token exchange
+	// instead of one per image. When false (the default), every image gets
+	// its own auth client and token exchange.
+	EnableAuthClientSharing bool `toml:"enable_auth_client_sharing"`
 }
 
 type HostConfig struct {

--- a/config/service.go
+++ b/config/service.go
@@ -87,5 +87,8 @@ func parseServiceConfig(cfg *Config) error {
 	if cfg.CRIKeychainConfig.ImageServicePath == "" {
 		cfg.CRIKeychainConfig.ImageServicePath = DefaultImageServiceAddress
 	}
+	if cfg.ResolverConfig.AuthClientTTLSec == 0 {
+		cfg.ResolverConfig.AuthClientTTLSec = defaultAuthClientTTLSec
+	}
 	return nil
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -88,6 +88,8 @@ This set of variables must be at the top of your TOML file due to not belonging 
 ## config/resolver.go
 
 ### [resolver]
+- `auth_client_ttl_sec` (int) — How long (seconds) cached registry auth clients and resolved registry-host configurations are reused before being discarded and rebuilt (re-resolving credentials and re-authenticating). Bounds memory growth of the caches on long-lived daemons. Negative means never expire. Default: 3600.
+- `enable_auth_client_sharing` (bool) — Shares auth clients between image references that target the same registry host with identical credentials, so same-registry images pay a single auth token exchange instead of one per image. When false, every image gets its own auth client and token exchange. Default: false.
 #### [resolver.host]
 #### [resolver.host.examplehost]
 #### [[resolver.host.examplehost.mirrors]]

--- a/service/resolver/client.go
+++ b/service/resolver/client.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/awslabs/soci-snapshotter/config"
@@ -175,6 +176,15 @@ const (
 
 type dockerAuthHandler struct {
 	authorizer docker.Authorizer
+
+	// challengeMu + inflight deduplicate concurrent 401 challenges. When
+	// many goroutines hit a 401 at the same time (e.g. concurrent
+	// pre-resolution redirects before the first token lands), only one
+	// actually fetches the token; the rest wait and reuse the result.
+	challengeMu sync.Mutex
+	inflight    bool
+	inflightErr error
+	inflightCh  chan struct{} // closed when the in-flight challenge completes
 }
 
 // newDockerAuthHandler implements the AuthHandler interface, using
@@ -186,12 +196,41 @@ func newDockerAuthHandler(authorizer docker.Authorizer) socihttp.AuthHandler {
 }
 
 // HandleChallenge calls the underlying docker.Authorizer's AddResponses method.
+// This is where the actual token exchange round-trip happens. Concurrent
+// challenges are deduplicated: only the first goroutine fetches the token;
+// others wait for it. This prevents the thundering-herd of N concurrent 401s
+// each independently fetching the same token when many layers resolve at once.
 func (d *dockerAuthHandler) HandleChallenge(ctx context.Context, resp *http.Response) error {
+	d.challengeMu.Lock()
+	if d.inflight {
+		// Another goroutine is already fetching a token. Wait for it.
+		ch := d.inflightCh
+		d.challengeMu.Unlock()
+		select {
+		case <-ch:
+			return d.inflightErr
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	// We are the first — mark in-flight and proceed.
+	d.inflight = true
+	d.inflightCh = make(chan struct{})
+	d.challengeMu.Unlock()
+
 	log.G(ctx).Infof("Received status code: %v. Authorizing...", resp.Status)
 	// Prepare authorization for the target host using docker.Authorizer.
 	// The authorizer should auto-refresh any expired tokens.
-	return d.authorizer.AddResponses(ctx, []*http.Response{resp})
+	err := d.authorizer.AddResponses(ctx, []*http.Response{resp})
 
+	// Signal waiters and reset for future challenges (token refresh).
+	d.challengeMu.Lock()
+	d.inflightErr = err
+	d.inflight = false
+	close(d.inflightCh)
+	d.challengeMu.Unlock()
+
+	return err
 }
 
 // AuthorizeRequest calls the underlying docker.Authorizer's Authorize method.

--- a/service/resolver/registry.go
+++ b/service/resolver/registry.go
@@ -33,6 +33,7 @@
 package resolver
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -40,6 +41,7 @@ import (
 	"time"
 
 	"github.com/awslabs/soci-snapshotter/config"
+	socihttp "github.com/awslabs/soci-snapshotter/internal/http"
 	rhttp "github.com/hashicorp/go-retryablehttp"
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
@@ -66,16 +68,147 @@ type RegistryManager struct {
 	creds []Credential
 	// registryHostMap is a map of image reference to registry configurations
 	registryHostMap *sync.Map
+	// authClientMap caches AuthClients keyed by (host, credential
+	// fingerprint), so images from the same registry with identical
+	// credentials share one client — and therefore one auth token exchange —
+	// instead of paying a 401+token round-trip per image. Images with
+	// different credentials get distinct clients (see AsRegistryHosts).
+	authClientMap *sync.Map
+	// authClientTTL bounds how long entries in registryHostMap and
+	// authClientMap are reused. Expired entries are lazily evicted on access
+	// and periodically swept, so cached clients (and the image references
+	// they accumulate) do not pile up indefinitely on a long-lived daemon.
+	// <= 0 means entries never expire.
+	authClientTTL time.Duration
+}
+
+// expiringEntry wraps a cached value with its creation time.
+type expiringEntry struct {
+	value     any
+	createdAt time.Time
+}
+
+func (rm *RegistryManager) expired(e *expiringEntry) bool {
+	return rm.authClientTTL > 0 && time.Since(e.createdAt) > rm.authClientTTL
+}
+
+// loadUnexpired returns the value for key if present and not expired.
+// Expired entries are deleted on access.
+func (rm *RegistryManager) loadUnexpired(m *sync.Map, key string) (any, bool) {
+	v, ok := m.Load(key)
+	if !ok {
+		return nil, false
+	}
+	e := v.(*expiringEntry)
+	if rm.expired(e) {
+		m.Delete(key)
+		return nil, false
+	}
+	return e.value, true
+}
+
+// sweep removes all expired entries from the caches. Called periodically so
+// entries for hosts/credentials that are never accessed again still get
+// reclaimed.
+func (rm *RegistryManager) sweep() {
+	for _, m := range []*sync.Map{rm.registryHostMap, rm.authClientMap} {
+		m.Range(func(k, v any) bool {
+			if rm.expired(v.(*expiringEntry)) {
+				m.Delete(k)
+			}
+			return true
+		})
+	}
 }
 
 // NewRegistryManager returns a new RegistryManager
 func NewRegistryManager(httpConfig config.RetryableHTTPClientConfig, registryConfig config.ResolverConfig, credsFuncs []Credential) *RegistryManager {
-	return &RegistryManager{
+	rm := &RegistryManager{
 		retryClient:     newRetryableClientFromConfig(httpConfig),
 		header:          globalHeaders(),
 		registryConfig:  registryConfig,
 		creds:           credsFuncs,
 		registryHostMap: &sync.Map{},
+		authClientMap:   &sync.Map{},
+		authClientTTL:   time.Duration(registryConfig.AuthClientTTLSec) * time.Second,
+	}
+	if rm.authClientTTL > 0 {
+		// Periodic sweep so never-again-accessed entries are also reclaimed.
+		go func() {
+			ticker := time.NewTicker(rm.authClientTTL)
+			defer ticker.Stop()
+			for range ticker.C {
+				rm.sweep()
+			}
+		}()
+	}
+	return rm
+}
+
+// authClientKey returns a cache key for sharing AuthClients between images.
+// Two images share an AuthClient (and therefore an auth token exchange) only
+// when they target the same registry host AND resolve to identical
+// credentials. Credentials are resolved once, up front, via the same
+// credential providers the AuthClient would use at request time; the secret
+// is hashed so it is not retained in the key.
+func (rm *RegistryManager) authClientKey(imgRefSpec reference.Spec) string {
+	host := imgRefSpec.Hostname()
+	username, secret, err := multiCredsFuncs(imgRefSpec, rm.creds...)(host)
+	if err != nil {
+		// Credential resolution failed; fall back to a per-image key so we
+		// never share a client across an unknown credential boundary.
+		return "ref\x00" + imgRefSpec.String()
+	}
+	credHash := sha256.Sum256([]byte(username + "\x00" + secret))
+	return fmt.Sprintf("host\x00%s\x00%x", host, credHash)
+}
+
+// sharedAuthClient is an AuthClient shared by multiple image references that
+// resolved to the same (host, credential) identity. The credential providers
+// can be scoped per image reference (e.g. the CRI keychain stores credentials
+// keyed by image ref and removes them once a pull completes), so the shared
+// client's credential function must not be bound to a single image ref.
+// Instead it tries every image ref that joined this client, newest first
+// (newer refs are the most likely to still have live credentials in
+// ref-scoped keychains).
+type sharedAuthClient struct {
+	client *socihttp.AuthClient
+
+	mu   sync.Mutex
+	refs []reference.Spec
+}
+
+// addRef registers an image reference with this shared client, so request-time
+// credential resolution can use its (identical) credentials.
+func (s *sharedAuthClient) addRef(ref reference.Spec) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, r := range s.refs {
+		if r.String() == ref.String() {
+			return
+		}
+	}
+	s.refs = append(s.refs, ref)
+}
+
+// credsFunc returns a credential function that tries all registered image
+// references, newest first, returning the first non-empty credentials.
+func (s *sharedAuthClient) credsFunc(creds []Credential) func(string) (string, string, error) {
+	return func(host string) (string, string, error) {
+		s.mu.Lock()
+		refs := make([]reference.Spec, len(s.refs))
+		copy(refs, s.refs)
+		s.mu.Unlock()
+		for i := len(refs) - 1; i >= 0; i-- {
+			username, secret, err := multiCredsFuncs(refs[i], creds...)(host)
+			if err != nil {
+				return "", "", err
+			}
+			if username != "" || secret != "" {
+				return username, secret, nil
+			}
+		}
+		return "", "", nil
 	}
 }
 
@@ -84,27 +217,55 @@ func NewRegistryManager(httpConfig config.RetryableHTTPClientConfig, registryCon
 // to the configurations present in RegistryManager.
 func (rm *RegistryManager) AsRegistryHosts() RegistryHosts {
 	/*
-		We create new AuthClient's for every unique image reference because credentials can be
-		scoped to specific images/repositories (eg: OAuth2). Although, our underlying auth handler
-		(docker.Authorizer) fetches tokens at request time, this can potentially become an issue in
-		the future if the authorizer re-uses the scoped credentials it gets through one of our credential
-		providers (eg: K8s through our CRI implementation). For this reason, our credential providers
-		should try to store+index credentials at a more granular level than just the host name
-		(ideally by the full image reference).
+		By default we create new AuthClient's for every unique image reference
+		because credentials can be scoped to specific images/repositories
+		(eg: OAuth2, K8s pull secrets through our CRI implementation).
+
+		When EnableAuthClientSharing is set, AuthClients are shared between
+		image references that target the same registry host with identical
+		credentials (see authClientKey), so same-registry images pay a single
+		auth token exchange instead of one per image. Images whose credential
+		providers return different credentials get distinct AuthClients and
+		never share tokens.
 	*/
 	return func(imgRefSpec reference.Spec) ([]docker.RegistryHost, error) {
 		// Check whether registry host configurations exist for this image ref
 		// in the cache.
-		if hostConfigurations, ok := rm.registryHostMap.Load(imgRefSpec.String()); ok {
+		if hostConfigurations, ok := rm.loadUnexpired(rm.registryHostMap, imgRefSpec.String()); ok {
 			return hostConfigurations.([]docker.RegistryHost), nil
 		}
 
 		var registryHosts []docker.RegistryHost
 
-		// Create an AuthClient for this image reference.
-		authClient, err := newAuthClient(rm.retryClient, rm.header, multiCredsFuncs(imgRefSpec, rm.creds...))
-		if err != nil {
-			return nil, err
+		var authClient *socihttp.AuthClient
+		if rm.registryConfig.EnableAuthClientSharing {
+			// Reuse an AuthClient if one already exists for this host+credential
+			// identity; otherwise create one and cache it.
+			acKey := rm.authClientKey(imgRefSpec)
+			var shared *sharedAuthClient
+			if cached, ok := rm.loadUnexpired(rm.authClientMap, acKey); ok {
+				shared = cached.(*sharedAuthClient)
+			} else {
+				newShared := &sharedAuthClient{}
+				newClient, err := newAuthClient(rm.retryClient, rm.header, newShared.credsFunc(rm.creds))
+				if err != nil {
+					return nil, err
+				}
+				newShared.client = newClient
+				// LoadOrStore: if another goroutine raced us, share its client so
+				// both images use the same token cache.
+				cached, _ := rm.authClientMap.LoadOrStore(acKey, &expiringEntry{value: newShared, createdAt: time.Now()})
+				shared = cached.(*expiringEntry).value.(*sharedAuthClient)
+			}
+			shared.addRef(imgRefSpec)
+			authClient = shared.client
+		} else {
+			// Per-image auth client (the default behavior, no sharing).
+			var err error
+			authClient, err = newAuthClient(rm.retryClient, rm.header, multiCredsFuncs(imgRefSpec, rm.creds...))
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		host := imgRefSpec.Hostname()
@@ -158,7 +319,7 @@ func (rm *RegistryManager) AsRegistryHosts() RegistryHosts {
 		}
 
 		// Create a `RegistryHost` configuration for this host.
-		host, err = docker.DefaultHost(host)
+		host, err := docker.DefaultHost(host)
 		if err != nil {
 			return nil, err
 		}
@@ -172,7 +333,7 @@ func (rm *RegistryManager) AsRegistryHosts() RegistryHosts {
 		})
 
 		// Cache `RegistryHost` configurations for all hosts that provide this image.
-		rm.registryHostMap.Store(imgRefSpec.String(), registryHosts)
+		rm.registryHostMap.Store(imgRefSpec.String(), &expiringEntry{value: registryHosts, createdAt: time.Now()})
 
 		return registryHosts, nil
 	}

--- a/service/resolver/registry.go
+++ b/service/resolver/registry.go
@@ -33,6 +33,7 @@
 package resolver
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"net/http"
@@ -121,8 +122,10 @@ func (rm *RegistryManager) sweep() {
 	}
 }
 
-// NewRegistryManager returns a new RegistryManager
-func NewRegistryManager(httpConfig config.RetryableHTTPClientConfig, registryConfig config.ResolverConfig, credsFuncs []Credential) *RegistryManager {
+// NewRegistryManager returns a new RegistryManager. The provided context ties
+// the lifetime of the periodic cache sweeper to the snapshotter service: when
+// ctx is cancelled (e.g. the service shuts down), the sweeper goroutine stops.
+func NewRegistryManager(ctx context.Context, httpConfig config.RetryableHTTPClientConfig, registryConfig config.ResolverConfig, credsFuncs []Credential) *RegistryManager {
 	rm := &RegistryManager{
 		retryClient:     newRetryableClientFromConfig(httpConfig),
 		header:          globalHeaders(),
@@ -134,11 +137,17 @@ func NewRegistryManager(httpConfig config.RetryableHTTPClientConfig, registryCon
 	}
 	if rm.authClientTTL > 0 {
 		// Periodic sweep so never-again-accessed entries are also reclaimed.
+		// Tied to ctx so it stops when the snapshotter service is torn down.
 		go func() {
 			ticker := time.NewTicker(rm.authClientTTL)
 			defer ticker.Stop()
-			for range ticker.C {
-				rm.sweep()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					rm.sweep()
+				}
 			}
 		}()
 	}

--- a/service/resolver/registry_test.go
+++ b/service/resolver/registry_test.go
@@ -1,0 +1,76 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package resolver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/awslabs/soci-snapshotter/config"
+	"go.uber.org/goleak"
+)
+
+// TestNoGoroutinesAreLeakedWhenRegistryManagerContextIsCancelled asserts that the
+// periodic cache sweeper is tied to the lifetime of the snapshotter service: once
+// the context passed to NewRegistryManager is cancelled, the sweeper goroutine
+// exits instead of ticking for the life of the process.
+func TestNoGoroutinesAreLeakedWhenRegistryManagerContextIsCancelled(t *testing.T) {
+	// Ignore goroutines that already existed, so this only reports goroutines
+	// started by this test rather than pre-existing ones from other tests.
+	ignoreExisting := goleak.IgnoreCurrent()
+	defer goleak.VerifyNone(t, ignoreExisting)
+
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// A positive TTL is what starts the sweeper. Keep it long enough that the
+	// goroutine cannot exit simply because the ticker fired.
+	rm := NewRegistryManager(testCtx, config.RetryableHTTPClientConfig{},
+		config.ResolverConfig{AuthClientTTLSec: 3600}, nil)
+	if rm.authClientTTL <= 0 {
+		t.Fatalf("expected a positive authClientTTL so the sweeper starts, got %v", rm.authClientTTL)
+	}
+
+	// Cancelling the service context must stop the sweeper. goleak (deferred
+	// above) retries for a short while, so it tolerates the scheduling delay
+	// between cancel() and the goroutine actually returning.
+	cancel()
+}
+
+// TestRegistryManagerSweeperIsNotStartedWithoutTTL asserts that no sweeper
+// goroutine is started when expiry is disabled (TTL <= 0), in which case cache
+// entries never expire and there is nothing to sweep.
+func TestRegistryManagerSweeperIsNotStartedWithoutTTL(t *testing.T) {
+	ignoreExisting := goleak.IgnoreCurrent()
+	defer goleak.VerifyNone(t, ignoreExisting)
+
+	// Deliberately not cancelled: with expiry disabled there should be no
+	// goroutine depending on the context to shut down.
+	testCtx := context.Background()
+
+	for _, ttlSec := range []int64{0, -1} {
+		rm := NewRegistryManager(testCtx, config.RetryableHTTPClientConfig{},
+			config.ResolverConfig{AuthClientTTLSec: ttlSec}, nil)
+		if rm.authClientTTL > 0 {
+			t.Fatalf("auth_client_ttl_sec=%d: expected non-positive authClientTTL, got %v", ttlSec, rm.authClientTTL)
+		}
+		if rm.expired(&expiringEntry{createdAt: time.Now().Add(-24 * time.Hour)}) {
+			t.Fatalf("auth_client_ttl_sec=%d: entries must never expire when expiry is disabled", ttlSec)
+		}
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -88,7 +88,7 @@ func NewSociSnapshotterService(ctx context.Context, root string, serviceCfg *con
 
 	hosts := sOpts.registryHosts
 	if hosts == nil {
-		hosts = resolver.NewRegistryManager(httpConfig, registryConfig, sOpts.credsFuncs).AsRegistryHosts()
+		hosts = resolver.NewRegistryManager(ctx, httpConfig, registryConfig, sOpts.credsFuncs).AsRegistryHosts()
 	}
 	userxattr, err := overlayutils.NeedsUserXAttr(snapshotterRoot(root))
 	if err != nil {


### PR DESCRIPTION
**Description of changes:**

Every image reference gets its own `AuthClient` with its own `docker.Authorizer`, so N images pulled from the same registry with the same credentials perform N separate auth token exchanges (401 → token endpoint GET → retried request, ~2 extra round-trips each). During multi-image launches this adds seconds of serial auth latency.

- When many layers of one image resolve concurrently, they can all hit a 401 before the first token lands, each independently fetching the same token (observed ~6 redundant exchanges for a single 8-layer image).
- The per-image-ref `registryHostMap` cache grows without bound on long-lived daemons.

**1. Opt-in auth client sharing** (`enable_auth_client_sharing`, default `false` - default behavior is unchanged). When enabled, AuthClients are shared between image references keyed by `(host, credential fingerprint)`:

- Credentials are resolved up front through the same providers the client uses at request time and SHA-256 hashed into the cache key, so two images share a client (and its token) **only** when their credentials are byte-identical. Images with different credentials (e.g. different K8s pull secrets) get distinct clients and never share tokens.
- Credential providers can be scoped per image ref (the CRI keychain stores creds by image ref and removes them after pull), so the shared client's credential function tries all image refs that joined it, newest-first, rather than binding to a single ref.

**2. Concurrent 401 challenge deduplication** (always on). When multiple goroutines hit a 401 simultaneously, only the first fetches the token; the rest wait for the in-flight result. Reduces the ~6 redundant exchanges per image to ~1.

**3. TTL-bounded caches** (`auth_client_ttl_sec`, default 3600). Cached auth clients and resolved registry-host configurations are lazily evicted on access and periodically swept. This also bounds the pre-existing unbounded growth of `registryHostMap`. Negative disables expiry.

```toml
[resolver]
  enable_auth_client_sharing = true   # opt in; default false (per-image clients)
  auth_client_ttl_sec = 3600          # negative = never expire
```

With sharing enabled, a 10-image batch from one registry performs 1 token exchange instead of 10. The challenge dedup alone (no opt-in needed) removes the redundant concurrent exchanges within each image.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
