### PR TITLE
fs/reader: fix spancache fd leak in file Verify

### DIFF
--- a/fs/reader/reader.go
+++ b/fs/reader/reader.go
@@ -220,6 +220,7 @@ func (sf *file) Verify() (retErr error) {
 	if err != nil {
 		return err
 	}
+	defer tarHeaderReader.Close()
 	counterReader := ioutils.NewPositionTrackerReader(tarHeaderReader)
 	tarReader := tar.NewReader(counterReader)
 	tarHeader, err := tarReader.Next()


### PR DESCRIPTION
`file.Verify` never closes the reader returned by `spanManager.GetContents`, leaking one spancache file descriptor per verified file. The sibling call site in `ReadAt` (~45 lines up) closes its reader with `defer r.Close()` — `Verify` is the only `GetContents` caller that doesn't.

`Verify` runs on first access of every file in a lazily mounted layer, so pod-startup waves that touch many files across several images leak FDs in bursts. In production we drove the snapshotter past its `LimitNOFILE` (65535) during concurrent pod starts — hundreds to thousands of `too many open files` errors on spancache blob opens per storm (worst node: 15k in one day) — and the resulting stuck state escalated into the containers-stuck-in-creating symptom class reported in #1826 / #2037 (in our case a containerd-side GC hang; we've submitted a resilience fix there as containerd/containerd#13799). Steady-state FD counts look deceptively healthy afterwards because Go's `os.File` finalizers eventually reclaim leaked descriptors once the readers are GC'd.

One-line fix: `defer tarHeaderReader.Close()`.

Happy to share (lightly redacted) goroutine dumps and journal evidence from the production incident if useful.
