### PR TITLE
fix(metadata): remove stale metadata DB on startup

### DIFF
--- a/cmd/soci-snapshotter-grpc/main.go
+++ b/cmd/soci-snapshotter-grpc/main.go
@@ -335,13 +335,20 @@ func getMetadataStore(ctx context.Context, rootDir string, config config.Config)
 			"store_type": config.MetadataStore,
 		}).Debug("initializing metadata store")
 
+		// The metadata DB is ephemeral and is always rebuilt from zTOCs on mount.
+		// Remove stale data that may persist after an unclean shutdown.
+		dbPath := filepath.Join(rootDir, "metadata.db")
+		if err := os.Remove(dbPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("failed to remove stale metadata db: %w", err)
+		}
+
 		bOpts := bolt.Options{
 			NoFreelistSync:  true,
 			InitialMmapSize: 64 * 1024 * 1024,
 			FreelistType:    bolt.FreelistMapType,
 			NoSync:          config.MetadataDBNoSync,
 		}
-		db, err := bolt.Open(filepath.Join(rootDir, "metadata.db"), 0600, &bOpts)
+		db, err := bolt.Open(dbPath, 0600, &bOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/soci-snapshotter-grpc/main_test.go
+++ b/cmd/soci-snapshotter-grpc/main_test.go
@@ -112,3 +112,39 @@ func writeTestConfig(t *testing.T, dir, content string) string {
 	}
 	return path
 }
+
+func TestGetMetadataStoreRemovesExistingDB(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "metadata.db")
+
+	// Create a fake stale DB file to simulate crash leftovers.
+	if err := os.WriteFile(dbPath, []byte("stale data"), 0600); err != nil {
+		t.Fatalf("failed to create stale db: %v", err)
+	}
+
+	ctx := context.Background()
+	cfg := config.Config{MetadataStore: "db"}
+
+	store, err := getMetadataStore(ctx, tempDir, cfg)
+	if err != nil {
+		t.Fatalf("getMetadataStore failed: %v", err)
+	}
+	if store == nil {
+		t.Fatal("expected non-nil store")
+	}
+}
+
+func TestGetMetadataStoreWorksWithNoExistingDB(t *testing.T) {
+	tempDir := t.TempDir()
+
+	ctx := context.Background()
+	cfg := config.Config{MetadataStore: "db"}
+
+	store, err := getMetadataStore(ctx, tempDir, cfg)
+	if err != nil {
+		t.Fatalf("getMetadataStore failed: %v", err)
+	}
+	if store == nil {
+		t.Fatal("expected non-nil store")
+	}
+}


### PR DESCRIPTION
**Description of changes:** The metadata DB is ephemeral and always rebuilt from zTOCs on layer mount. After an unclean shutdown, orphaned buckets from the previous run persist in the file and are never reused. Remove the file on startup to prevent unbounded growth from repeated crashes.

**Testing performed:** Added unit tests. More testing via CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.