### PR TITLE
Dockerfile: skip unnecessary builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN mkdir -p /opt/rapidgzip/usr/local/bin
 RUN git clone https://github.com/mxmlnkn/rapidgzip.git && \
     cd rapidgzip && \
     git checkout "rapidgzip-v${RAPIDGZIP_VERSION}" && \
+    git -c submodule."external/bzip2-tests".update=none submodule update --init --recursive && \
     if [ "$TARGETARCH" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then \
         # Disable ISA-L on ARM due to linking errors.
         export ISAL_FLAGS="-DWITH_ISAL=OFF"; \
@@ -91,7 +92,7 @@ RUN git clone https://github.com/mxmlnkn/rapidgzip.git && \
           -DCMAKE_C_FLAGS="-O2 -fPIC" \
           ${ISAL_FLAGS} \
           -DCMAKE_BUILD_TYPE=Release .. && \
-    make -j$(nproc) && \
+    cmake --build . --target rapidgzip --parallel "$(nproc)" && \
     cp src/tools/rapidgzip /opt/rapidgzip/usr/local/bin/ && \
     chmod +x /opt/rapidgzip/usr/local/bin/rapidgzip && \
     cd ../.. && \


### PR DESCRIPTION
**Description of changes:** Fix CI failures in the rapidgzip Docker build stage:
1. Initialize git submodules after checkout, as rapidgzip's submodule build dependencies weren't being fetched. Exclude bzip2-tests (hosted on sourceware.org, unreachable from CI, only test data).
2. Build only the rapidgzip binary target instead of the full project.

**Testing performed:** CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
