### PR TITLE
Update rapidgzip to v0.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG RUNC_VERSION=1.3.3
 ARG NERDCTL_VERSION=2.1.6
 ARG CRICTL_VERSION=1.36.0
 ARG IGZIP_VERSION=2.31.1
-ARG RAPIDGZIP_VERSION=0.14.3
+ARG RAPIDGZIP_VERSION=0.16.0
 
 FROM public.ecr.aws/docker/library/registry:3.1.1 AS registry
 
@@ -75,13 +75,12 @@ RUN mkdir -p /opt/rapidgzip/usr/local/bin
 RUN git clone https://github.com/mxmlnkn/rapidgzip.git && \
     cd rapidgzip && \
     git checkout "rapidgzip-v${RAPIDGZIP_VERSION}" && \
-    git -c submodule."external/bzip2-tests".update=none submodule update --init --recursive && \
+    git submodule update --init --recursive && \
     if [ "$TARGETARCH" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then \
         # Disable ISA-L on ARM due to linking errors.
         export ISAL_FLAGS="-DWITH_ISAL=OFF"; \
-
         # Disable fcf-protection which is not supported on ARM.
-        sed -i 's/-fcf-protection=full/-fcf-protection=none/g' CMakeLists.txt; \
+        sed -i 's/-fcf-protection=full/-fcf-protection=none/g' librapidarchive/CMakeLists.txt; \
     else \
         export ISAL_FLAGS=""; \
     fi && \
@@ -91,7 +90,7 @@ RUN git clone https://github.com/mxmlnkn/rapidgzip.git && \
           -DCMAKE_CXX_FLAGS="-O2 -fPIC" \
           -DCMAKE_C_FLAGS="-O2 -fPIC" \
           ${ISAL_FLAGS} \
-          -DCMAKE_BUILD_TYPE=Release .. && \
+          -DCMAKE_BUILD_TYPE=Release ../librapidarchive && \
     cmake --build . --target rapidgzip --parallel "$(nproc)" && \
     cp src/tools/rapidgzip /opt/rapidgzip/usr/local/bin/ && \
     chmod +x /opt/rapidgzip/usr/local/bin/rapidgzip && \

--- a/util/dockershell/compose/compose.go
+++ b/util/dockershell/compose/compose.go
@@ -128,7 +128,7 @@ func Build(dockerComposeYaml string, opts ...Option) ([]func() error, error) {
 	for _, arg := range cOpts.buildArgs {
 		buildArgs = append(buildArgs, "--build-arg", arg)
 	}
-	cmd := exec.Command("docker", append([]string{"compose", "-f", confFile, "build", "-q"}, buildArgs...)...)
+	cmd := exec.Command("docker", append([]string{"compose", "-f", confFile, "build", "--progress=plain"}, buildArgs...)...)
 	if cOpts.addStdio != nil {
 		cOpts.addStdio(cmd)
 	}


### PR DESCRIPTION
**Issue #, if available:**
Fast follow to #2050

**Description of changes:**
This updates the rapidgzip repo to v0.16.0, which removes the submodule that was giving us 403s in the CI.

Given how difficult #2050 was to debug, I also opted to sneak in a `--progress=plain` in lieu of `-q` in `docker build`, as the happy path will remain the same while the sad path is much more verbose (which is nicer to debug). Previously we'd only get `exit status 1` which is incredibly unhelpful.

**Testing performed:**
Attempted some happy/sad path testing in previous checks
Sad path: https://github.com/awslabs/soci-snapshotter/actions/runs/30493657067/job/90717363945#step:6:4376 (highlighted is the error that helped me do the rapidgzip upgrade)
Happy path: Check the CI for this PR 🙂 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
