### PR TITLE
fix(workflows): properly write VERSION var to GITHUB_ENV

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -83,7 +83,7 @@ jobs:
           # This will fail if doesn't follow major.minor format
           printf "%s" "${major_minor}" | grep -qP '^[0-9]+\.[0-9]+$'
 
-          printf "v%s.0" "${major_minor}" >> $GITHUB_ENV
+          printf "VERSION=v%s.0" "${major_minor}" >> $GITHUB_ENV
       - name: Create release branch
         env:
           commit: ${{ github.event.inputs.base_commit }}


### PR DESCRIPTION
**Description of changes:** Add missing `VERSION=` prefix when writing to `$GITHUB_ENV` in the `create-release-branch` workflow's dispatch path. Without it, GitHub Actions rejects the bare value v0.15.0 as invalid format. See [this](https://github.com/awslabs/soci-snapshotter/actions/runs/30566605937/job/90952588956#:~:text=Unable%20to%20process%20file%20command%20%27env%27%20successfully) test failure.

**Testing performed:** This PR triggers the`test-create-branch` job. While this job doesn't reach the broken code directly, it uses the same `VERSION=` pattern.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
