### PR TITLE
Upgrade to go 1.25.12

### DIFF
--- a/.github/workflows/benchmark-visualization.yml
+++ b/.github/workflows/benchmark-visualization.yml
@@ -19,7 +19,7 @@ permissions:
   deployments: write
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   benchmark:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
-        go-version: ['1.25.11', '1.26.4']
+        go-version: ['1.25.12', '1.26.4']
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ['1.25.11', '1.26.4']
+        go-version: ['1.25.12', '1.26.4']
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
-        go-version: ['1.25.11', '1.26.4']
+        go-version: ['1.25.12', '1.26.4']
         containerd: ["1.7.32", "2.0.9", "2.2.4", "2.3.1"]
     env:
       DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"

--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 permissions:
   contents: write

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -11,7 +11,7 @@ on:
       - 'Makefile'
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   check:

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -23,7 +23,7 @@ on:
       - 'scripts/update-version-in-docs.sh'
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   test-create-branch:

--- a/.github/workflows/create-third-party-licenses.yml
+++ b/.github/workflows/create-third-party-licenses.yml
@@ -22,7 +22,7 @@ on:
     branches: ['release/**']
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 jobs:
   test-build:

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -7,7 +7,7 @@ on:
     branches: ['main', 'release/**']
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
   GOLANGCI_LINT_VERSION: '2.5.0'
 
 jobs:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,7 +12,7 @@ on:
       - 'Makefile'
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.25.12'
 
 permissions:
   contents: write


### PR DESCRIPTION
**Issue #, if available:**

Similar to https://github.com/awslabs/soci-snapshotter/pull/1953
- The current version upgrade fixes - https://nvd.nist.gov/vuln/detail/CVE-2026-39822

- go1.25.12 (released 2026-07-07) includes security fixes to the crypto/tls and os packages, as well as bug fixes to the compiler, the go command, and the net and os packages. See the [Go 1.25.12 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.12+label%3ACherryPickApproved) on our issue tracker for details.
  - https://go.dev/doc/devel/release#go1.25.minor

**Description of changes:**

**Testing performed:**

```
prafulg@lima-default:/Volumes/git/prafulg/soci-snapshotter$ sudo make build
cd cmd/ ; GO111MODULE=auto go build -o /Volumes/git/prafulg/soci-snapshotter/out/soci-snapshotter-grpc  -ldflags '-X github.com/awslabs/soci-snapshotter/version.Version=eaac9210.m -X github.com/awslabs/soci-snapshotter/version.Revision=eaac92101e86be6d4f59bb19651fd863e39a0e33.m  -s -w '  ./soci-snapshotter-grpc
cd cmd/ ; GO111MODULE=auto go build -o /Volumes/git/prafulg/soci-snapshotter/out/soci  -ldflags '-X github.com/awslabs/soci-snapshotter/version.Version=eaac9210.m -X github.com/awslabs/soci-snapshotter/version.Revision=eaac92101e86be6d4f59bb19651fd863e39a0e33.m  -s -w '  ./soci
prafulg@lima-default:/Volumes/git/prafulg/soci-snapshotter$ sudo make test
test-lib
go: downloading github.com/montanaflynn/stats v0.12.2
go: downloading golang.org/x/crypto v0.54.0
ok  	github.com/awslabs/soci-snapshotter/cache	1.011s
ok  	github.com/awslabs/soci-snapshotter/config	1.016s
ok  	github.com/awslabs/soci-snapshotter/fs	2.786s
ok  	github.com/awslabs/soci-snapshotter/fs/backgroundfetcher	22.379s
ok  	github.com/awslabs/soci-snapshotter/fs/layer	8.884s
?   	github.com/awslabs/soci-snapshotter/fs/metrics/common	[no test files]
?   	github.com/awslabs/soci-snapshotter/fs/metrics/layer	[no test files]
ok  	github.com/awslabs/soci-snapshotter/fs/reader	7.254s
ok  	github.com/awslabs/soci-snapshotter/fs/remote	8.142s
ok  	github.com/awslabs/soci-snapshotter/fs/source	1.009s
ok  	github.com/awslabs/soci-snapshotter/fs/span-manager	18.736s
ok  	github.com/awslabs/soci-snapshotter/idtools	1.008s
ok  	github.com/awslabs/soci-snapshotter/integration	1.027s
ok  	github.com/awslabs/soci-snapshotter/internal/archive/compression	1.012s
ok  	github.com/awslabs/soci-snapshotter/internal/http	1.010s
ok  	github.com/awslabs/soci-snapshotter/internal/os	1.010s
ok  	github.com/awslabs/soci-snapshotter/metadata	8.851s
?   	github.com/awslabs/soci-snapshotter/service	[no test files]
?   	github.com/awslabs/soci-snapshotter/service/keychain/cri/v1	[no test files]
?   	github.com/awslabs/soci-snapshotter/service/keychain/dockerconfig	[no test files]
?   	github.com/awslabs/soci-snapshotter/service/keychain/kubeconfig	[no test files]
?   	github.com/awslabs/soci-snapshotter/service/plugin	[no test files]
ok  	github.com/awslabs/soci-snapshotter/service/resolver	1.010s
ok  	github.com/awslabs/soci-snapshotter/snapshot	1.023s
ok  	github.com/awslabs/soci-snapshotter/soci	1.030s
ok  	github.com/awslabs/soci-snapshotter/soci/store	1.017s
?   	github.com/awslabs/soci-snapshotter/util/dbutil	[no test files]
?   	github.com/awslabs/soci-snapshotter/util/dockershell	[no test files]
?   	github.com/awslabs/soci-snapshotter/util/dockershell/compose	[no test files]
?   	github.com/awslabs/soci-snapshotter/util/dockershell/exec	[no test files]
ok  	github.com/awslabs/soci-snapshotter/util/ioutils	1.007s
ok  	github.com/awslabs/soci-snapshotter/util/lrucache	1.008s
?   	github.com/awslabs/soci-snapshotter/util/namedmutex	[no test files]
ok  	github.com/awslabs/soci-snapshotter/util/ociutil	1.007s
?   	github.com/awslabs/soci-snapshotter/util/testutil	[no test files]
ok  	github.com/awslabs/soci-snapshotter/version	1.005s
ok  	github.com/awslabs/soci-snapshotter/ztoc	47.297s
ok  	github.com/awslabs/soci-snapshotter/ztoc/compression	1.007s
?   	github.com/awslabs/soci-snapshotter/ztoc/compression/fbs/zinfo	[no test files]
?   	github.com/awslabs/soci-snapshotter/ztoc/fbs/ztoc	[no test files]
test-cmd
?   	github.com/awslabs/soci-snapshotter/cmd/soci	[no test files]
?   	github.com/awslabs/soci-snapshotter/cmd/soci/commands	[no test files]
?   	github.com/awslabs/soci-snapshotter/cmd/soci/commands/global	[no test files]
?   	github.com/awslabs/soci-snapshotter/cmd/soci/commands/index	[no test files]
?   	github.com/awslabs/soci-snapshotter/cmd/soci/commands/internal	[no test files]
?   	github.com/awslabs/soci-snapshotter/cmd/soci/commands/prefetch	[no test files]
?   	github.com/awslabs/soci-snapshotter/cmd/soci/commands/ztoc	[no test files]
ok  	github.com/awslabs/soci-snapshotter/cmd/soci-snapshotter-grpc	1.150s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
