### PR TITLE
Make soci.NewDB return a new database instance per call

### DIFF
--- a/cmd/soci/commands/convert.go
+++ b/cmd/soci/commands/convert.go
@@ -139,6 +139,7 @@ var ConvertCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer artifactsDb.Close()
 
 		builderOpts, err := parseBuilderOptions(cmd)
 		if err != nil {
@@ -150,6 +151,7 @@ var ConvertCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer builder.Close()
 
 		batchCtx, done, err := blobStore.BatchOpen(ctx)
 		if err != nil {
@@ -226,6 +228,7 @@ func runStandaloneConvert(ctx context.Context, cmd *cli.Command, inputPath strin
 	if err != nil {
 		return fmt.Errorf("failed to create artifacts database: %w", err)
 	}
+	defer artifactsDb.Close()
 
 	builderOpts, err := parseBuilderOptions(cmd)
 	if err != nil {
@@ -238,6 +241,7 @@ func runStandaloneConvert(ctx context.Context, cmd *cli.Command, inputPath strin
 	if err != nil {
 		return err
 	}
+	defer builder.Close()
 
 	requestedPlatforms, err := internal.GetPlatforms(ctx, cmd, imageInfo.Image, imageInfo.ContentStore)
 	if err != nil {

--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -123,6 +123,7 @@ var CreateCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer artifactsDb.Close()
 
 		builderOpts := []soci.BuilderOption{
 			soci.WithMinLayerSize(minLayerSize),
@@ -145,6 +146,7 @@ var CreateCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer builder.Close()
 
 		for _, plat := range ps {
 			batchCtx, done, err := blobStore.BatchOpen(ctx)

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -51,6 +51,7 @@ var infoCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer db.Close()
 
 		artifactType, err := db.GetArtifactType(digest.String())
 		if err != nil {

--- a/cmd/soci/commands/index/list.go
+++ b/cmd/soci/commands/index/list.go
@@ -153,6 +153,7 @@ var listCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer db.Close()
 		db.Walk(func(ae *soci.ArtifactEntry) error {
 			if f(ae) {
 				artifacts = append(artifacts, ae)

--- a/cmd/soci/commands/index/rm.go
+++ b/cmd/soci/commands/index/rm.go
@@ -56,6 +56,7 @@ var rmCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer db.Close()
 		if ref == "" {
 			ctx, cancel := internal.AppContext(ctx, cmd)
 			defer cancel()

--- a/cmd/soci/commands/prefetch/info.go
+++ b/cmd/soci/commands/prefetch/info.go
@@ -56,6 +56,7 @@ var infoCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer db.Close()
 
 		artifactType, err := db.GetArtifactType(digest.String())
 		if err != nil {

--- a/cmd/soci/commands/prefetch/list.go
+++ b/cmd/soci/commands/prefetch/list.go
@@ -53,6 +53,7 @@ var listCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer db.Close()
 
 		contentStore, err := store.NewContentStore(internal.ContentStoreOptions(ctx, cmd)...)
 		if err != nil {

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -115,6 +115,7 @@ if they are available in the snapshotter's local content store.
 		if err != nil {
 			return err
 		}
+		defer artifactsDb.Close()
 
 		refspec, err := reference.Parse(ref)
 		if err != nil {

--- a/cmd/soci/commands/rebuild_db.go
+++ b/cmd/soci/commands/rebuild_db.go
@@ -48,6 +48,7 @@ var RebuildDBCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer artifactsDb.Close()
 
 		blobStore, err := store.NewContentStore(internal.ContentStoreOptions(ctx, cmd)...)
 		if err != nil {

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -74,6 +74,7 @@ var getFileCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer artifactsDB.Close()
 
 		layerReader, err := getLayer(ctx, artifactsDB, ztocDigest, client.ContentStore())
 		if err != nil {

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -65,6 +65,7 @@ var infoCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer db.Close()
 		entry, err := db.GetArtifactEntry(digest.String())
 		if err != nil {
 			return err

--- a/cmd/soci/commands/ztoc/list.go
+++ b/cmd/soci/commands/ztoc/list.go
@@ -64,6 +64,7 @@ var listCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		defer db.Close()
 
 		ztocDgst := cmd.String(ztocDigestFlag)
 		imgRef := cmd.String(imageRefFlag)

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -25,7 +25,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/awslabs/soci-snapshotter/config"
@@ -34,7 +33,6 @@ import (
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
 	"github.com/containerd/platforms"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -83,9 +81,6 @@ var (
 	ArtifactEntryTypeLayer ArtifactEntryType = "soci_layer"
 	// ArtifactEntryTypePrefetch indicates that an ArtifactEntry is a SOCI prefetch artifact
 	ArtifactEntryTypePrefetch ArtifactEntryType = "soci_prefetch"
-
-	db   *ArtifactsDb
-	once sync.Once
 )
 
 var (
@@ -128,28 +123,21 @@ type ArtifactEntry struct {
 	SpanSize int64
 }
 
-// NewDB returns an instance of an ArtifactsDB
+// NewDB returns a new instance of an ArtifactsDb backed by the bolt database
+// at path, creating the file if it does not exist. Bolt holds an exclusive
+// file lock on the database, so the returned ArtifactsDb must be closed with
+// Close before the same file can be opened again.
 func NewDB(path string) (*ArtifactsDb, error) {
-	once.Do(func() {
-		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-		if err != nil {
-			log.L.WithError(err).WithField("path", path).Error("Cannot create or open file")
-			return
-		}
-		defer f.Close()
-		database, err := bolt.Open(f.Name(), 0600, nil)
-		if err != nil {
-			log.L.WithError(err).Error("Cannot open the db")
-			return
-		}
-		db = &ArtifactsDb{db: database}
-	})
-
-	if db == nil {
-		return nil, errors.New("artifacts.db is not available")
+	database, err := bolt.Open(path, 0600, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open artifacts db %s: %w", path, err)
 	}
+	return &ArtifactsDb{db: database}, nil
+}
 
-	return db, nil
+// Close closes the underlying bolt database, releasing its file lock.
+func (db *ArtifactsDb) Close() error {
+	return db.db.Close()
 }
 
 func (db *ArtifactsDb) getIndexArtifactEntries(indexDigest string) ([]ArtifactEntry, error) {

--- a/soci/artifacts_test.go
+++ b/soci/artifacts_test.go
@@ -18,7 +18,7 @@ package soci
 
 import (
 	"os"
-	"sync"
+	"path/filepath"
 	"testing"
 
 	bolt "go.etcd.io/bbolt"
@@ -125,16 +125,36 @@ func TestArtifactDbPath(t *testing.T) {
 	}
 }
 
-func TestArtifactDB_DoesNotExist(t *testing.T) {
-	resetArtifactDBInit()
-	t.Cleanup(resetArtifactDBInit)
-	once.Do(func() {
-		// Fail db initialization.
-		db = nil
-	})
-	_, err := NewDB(ArtifactsDbPath(t.TempDir()))
+func TestArtifactDB_CannotBeCreated(t *testing.T) {
+	_, err := NewDB(ArtifactsDbPath(filepath.Join(t.TempDir(), "nonexistent")))
 	if err == nil {
-		t.Fatalf("getArtifactEntry should fail since artifacts.db doesn't exist")
+		t.Fatalf("NewDB should fail since the parent directory doesn't exist")
+	}
+}
+
+func TestArtifactDB_IndependentInstances(t *testing.T) {
+	dbA, err := NewDB(ArtifactsDbPath(t.TempDir()))
+	if err != nil {
+		t.Fatalf("can't create first db: %v", err)
+	}
+	defer dbA.Close()
+	dbB, err := NewDB(ArtifactsDbPath(t.TempDir()))
+	if err != nil {
+		t.Fatalf("can't create second db: %v", err)
+	}
+	defer dbB.Close()
+
+	ae := &ArtifactEntry{
+		Size:           10,
+		Digest:         "sha256:80d6aec48c0a74635a5f3dc555528c1673afaa21ed6e1270a9a44de66e8ffa55",
+		OriginalDigest: "sha256:1236aec48c0a74635a5f3dc666628c1673afaa21ed6e1270a9a44de66e811111",
+		Type:           ArtifactEntryTypeIndex,
+	}
+	if err := dbA.WriteArtifactEntry(ae); err != nil {
+		t.Fatalf("can't write entry to first db: %v", err)
+	}
+	if _, err := dbB.GetArtifactEntry(ae.Digest); err == nil {
+		t.Fatalf("entry written to first db should not be visible in second db")
 	}
 }
 
@@ -228,11 +248,11 @@ func newTestableDb() (*ArtifactsDb, error) {
 	}
 	defer f.Close()
 	defer os.Remove(f.Name())
-	db, err := bolt.Open(f.Name(), 0600, nil)
+	db, err := NewDB(f.Name())
 	if err != nil {
 		return nil, err
 	}
-	err = db.Update(func(tx *bolt.Tx) error {
+	err = db.db.Update(func(tx *bolt.Tx) error {
 		_, err := tx.CreateBucketIfNotExists(bucketKeySociArtifacts)
 		if err != nil {
 			return err
@@ -242,10 +262,5 @@ func newTestableDb() (*ArtifactsDb, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ArtifactsDb{db: db}, nil
-}
-
-func resetArtifactDBInit() {
-	once = sync.Once{}
-	db = nil
+	return db, nil
 }

--- a/soci/soci_index.go
+++ b/soci/soci_index.go
@@ -445,6 +445,9 @@ type IndexBuilder struct {
 	blobStore    store.Store
 	config       *builderConfig
 	ztocBuilder  *ztoc.Builder
+	// ownsArtifactsDb is true when the builder opened the artifacts database
+	// itself rather than receiving one via WithArtifactsDb.
+	ownsArtifactsDb bool
 }
 
 // NewIndexBuilder returns an `IndexBuilder` that is used to create soci indices.
@@ -460,20 +463,33 @@ func NewIndexBuilder(contentStore content.Store, blobStore store.Store, opts ...
 			return nil, err
 		}
 	}
+	ownsArtifactsDb := false
 	if cfg.artifactsDb == nil {
 		var err error
 		cfg.artifactsDb, err = NewDB(ArtifactsDbPath(config.DefaultSociSnapshotterRootPath))
 		if err != nil {
 			return nil, err
 		}
+		ownsArtifactsDb = true
 	}
 
 	return &IndexBuilder{
-		contentStore: contentStore,
-		blobStore:    blobStore,
-		config:       cfg,
-		ztocBuilder:  ztoc.NewBuilder(cfg.buildToolIdentifier),
+		contentStore:    contentStore,
+		blobStore:       blobStore,
+		config:          cfg,
+		ztocBuilder:     ztoc.NewBuilder(cfg.buildToolIdentifier),
+		ownsArtifactsDb: ownsArtifactsDb,
 	}, nil
+}
+
+// Close releases resources held by the IndexBuilder. It closes the artifacts
+// database if the builder opened it itself; a database provided via
+// WithArtifactsDb is left open for its owner to close.
+func (b *IndexBuilder) Close() error {
+	if b.ownsArtifactsDb {
+		return b.config.artifactsDb.Close()
+	}
+	return nil
 }
 
 // Build builds a soci index for `img` and pushes it with its corresponding zTOCs to the blob store.


### PR DESCRIPTION
## Issue #, if available

n/a

## Description of changes

`soci.NewDB` guarded its initialization with a package-level `sync.Once`, which latched both the first path and the first failure: a second call with a different path silently returned the database opened at the first path, and a failed first open left every subsequent call failing regardless of path, with the real error swallowed into a log line.

Nothing in this repository needs the singleton — the daemon never touches `ArtifactsDb`, each CLI command calls `NewDB` once, and the package's own tests already bypass it (`newTestableDb`). But it bites library consumers that call `NewDB` with more than one path in a process.

This change:

- Makes `NewDB` return a fresh `*ArtifactsDb` on every call, propagating open errors to the caller.
- Adds `(*ArtifactsDb).Close()` to release bolt's file lock, deferred at every CLI call site.
- Adds `(*IndexBuilder).Close()`, which closes the artifacts database only if the builder opened it itself; a database injected via `WithArtifactsDb` is left for its owner to close.

Behavior note: `NewDB` calls are no longer deduplicated, so a process constructing multiple `IndexBuilder`s should share a database via `WithArtifactsDb` — bolt blocks when opening a file that is already locked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)