### PR TITLE
Parallelize unit tests and reduce redundant sizes

### DIFF
--- a/fs/layer/util_test.go
+++ b/fs/layer/util_test.go
@@ -105,6 +105,7 @@ func testNodeRead(t *testing.T, factory metadata.Store) {
 			for bo, baseo := range baseOffsetCond {
 				for fn, filesize := range fileSizeCond {
 					t.Run(fmt.Sprintf("reading_%s_%s_%s_%s", sn, in, bo, fn), func(t *testing.T) {
+						t.Parallel()
 						ctx, cancel := context.WithCancel(context.Background())
 						defer cancel()
 						if filesize > int64(len(sampleData1)) {
@@ -325,6 +326,7 @@ func testExistenceWithOpaque(t *testing.T, factory metadata.Store, opaque Overla
 	for _, tt := range tests {
 		for _, spanSize := range spanSizeCond {
 			t.Run(fmt.Sprintf("testExistence_%s_spansize_%d", tt.name, spanSize), func(t *testing.T) {
+				t.Parallel()
 				ztoc, sr, err := ztoc.BuildZtocReader(t, tt.in, gzip.DefaultCompression, spanSize)
 				if err != nil {
 					t.Fatalf("failed to build sample ztoc: %v", err)

--- a/fs/reader/reader_test.go
+++ b/fs/reader/reader_test.go
@@ -99,6 +99,7 @@ func testFileReadAt(t *testing.T, factory metadata.Store) {
 					for _, spanSize := range spanSizeCond {
 						for _, prefix := range filePrefixes {
 							t.Run(fmt.Sprintf("reading_%s_%s_%s_%s_spansize_%d", sn, in, bo, fn, spanSize), func(t *testing.T) {
+								t.Parallel()
 								if filesize > int64(len(sampleData1)) {
 									t.Fatal("sample file size is larger than sample data")
 								}
@@ -195,6 +196,7 @@ func testFailReader(t *testing.T, factory metadata.Store) {
 	}
 	for _, spanSize := range spanSizeCond {
 		t.Run(fmt.Sprintf("reading_spansize_%d", spanSize), func(t *testing.T) {
+			t.Parallel()
 			ztoc, sr, err := ztoc.BuildZtocReader(t, tarEntry, gzip.DefaultCompression, spanSize)
 			if err != nil {
 				t.Fatalf("failed to build sample ztoc: %v", err)

--- a/fs/remote/resolver_test.go
+++ b/fs/remote/resolver_test.go
@@ -49,6 +49,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	socihttp "github.com/awslabs/soci-snapshotter/internal/http"
 	"github.com/awslabs/soci-snapshotter/version"
@@ -291,6 +292,8 @@ func TestRetry(t *testing.T) {
 	rclient := rhttp.NewClient()
 	rclient.HTTPClient.Transport = tr
 	rclient.Backoff = rhttp.DefaultBackoff
+	rclient.RetryWaitMin = time.Millisecond
+	rclient.RetryWaitMax = 10 * time.Millisecond
 	f := &httpFetcher{
 		realURL:      "test",
 		roundTripper: &rhttp.RoundTripper{Client: rclient},

--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -392,17 +392,18 @@ func TestSpanManagerRetries(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := testutil.NewTestRand(t)
-			randStr := string(r.RandomByteData(10000000))
+			randStr := string(r.RandomByteData(2000000))
 
 			entries := []testutil.TarEntry{
 				testutil.File("test", randStr),
 			}
-			ztoc, sr, err := ztoc.BuildZtocReader(t, entries, gzip.DefaultCompression, 100000)
+			ztoc, sr, err := ztoc.BuildZtocReader(t, entries, gzip.BestSpeed, 100000)
 			if err != nil {
 				t.Fatal(err)
 			}
+			size := sr.Size()
 			rdr := newRetryableReaderAt(sr, tc.readerErrors)
-			sr = io.NewSectionReader(rdr, 0, 10000000)
+			sr = io.NewSectionReader(rdr, 0, size)
 			sm, err := New(ztoc, sr, cache.NewMemoryCache(), tc.spanManagerRetries, digest.FromString(""))
 			assert.Nil(t, err)
 

--- a/metadata/util_test.go
+++ b/metadata/util_test.go
@@ -177,6 +177,7 @@ func testReader(t *testing.T, factory readerFactory) {
 		for _, prefix := range allowedPrefix {
 			for srcCompresionName, srcCompression := range srcCompressions {
 				t.Run(tt.name+"-"+srcCompresionName, func(t *testing.T) {
+					t.Parallel()
 					opts := []testutil.BuildTarOption{
 						testutil.WithPrefix(prefix),
 					}


### PR DESCRIPTION
**Issue #, if available:**

Continuing optimizations from https://github.com/awslabs/soci-snapshotter/pull/2061 and https://github.com/awslabs/soci-snapshotter/pull/2059

All of these tests are safe to parallelize.

Prev - 

```
ok      github.com/awslabs/soci-snapshotter/fs/layer    9.042s
ok      github.com/awslabs/soci-snapshotter/fs/reader   7.354s
ok      github.com/awslabs/soci-snapshotter/fs/remote   8.140s
ok  	github.com/awslabs/soci-snapshotter/metadata	8.851s
ok      github.com/awslabs/soci-snapshotter/fs/span-manager     19.149s
```

Now - 

```
ok      github.com/awslabs/soci-snapshotter/fs/layer    2.758s
ok      github.com/awslabs/soci-snapshotter/fs/reader   1.663s
ok      github.com/awslabs/soci-snapshotter/fs/remote   1.144s
ok  	github.com/awslabs/soci-snapshotter/metadata	1.863s
ok      github.com/awslabs/soci-snapshotter/fs/span-manager     8.754s
```


**Description of changes:**

```
  ┌─────────────────┬─────────┬────────┬───────────────────────────┐
  │     package     │ before  │ after  │           lever           │
  ├─────────────────┼─────────┼────────┼───────────────────────────┤
  │ fs/layer        │  8.859s │ 2.706s │ t.Parallel()              │
  ├─────────────────┼─────────┼────────┼───────────────────────────┤
  │ fs/reader       │  7.143s │ 1.663s │ t.Parallel()              │
  ├─────────────────┼─────────┼────────┼───────────────────────────┤
  │ fs/remote       │  8.139s │ 1.139s │ retry backoff bounds      │
  ├─────────────────┼─────────┼────────┼───────────────────────────┤
  │ fs/span-manager │ 17.883s │ 8.356s │ shrink retries fixture    │
  ├─────────────────┼─────────┼────────┼───────────────────────────┤
  │ metadata        │  8.759s │ 1.836s │ t.Parallel()              │
  ├─────────────────┼─────────┼────────┼───────────────────────────┤
```

**Testing performed:**

```
  -race -count=5 -shuffle=on -parallel 32   → all three pass
  -race -count=1 -parallel 1                → all three pass (9.85s / 8.04s / 10.77s)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
