### PR TITLE
Parallelize more unit tests and reduce redundant spans

### DIFF
--- a/fs/span-manager/span_manager_test.go
+++ b/fs/span-manager/span_manager_test.go
@@ -48,8 +48,8 @@ func TestSpanManager(t *testing.T) {
 			maxSpans: 1,
 		},
 		{
-			name:     "a file from 100 spans",
-			maxSpans: 100,
+			name:     "a file from 20 spans",
+			maxSpans: 20,
 		},
 		{
 			name:          "bad MaxSpanID",
@@ -63,7 +63,7 @@ func TestSpanManager(t *testing.T) {
 		},
 		{
 			name:     "header verification fails",
-			maxSpans: 100,
+			maxSpans: 5,
 			sectionReader: io.NewSectionReader(readerFn(func(b []byte, _ int64) (int, error) {
 				sz := compression.Offset(len(b))
 				r := testutil.NewTestRand(t)
@@ -74,7 +74,7 @@ func TestSpanManager(t *testing.T) {
 		},
 		{
 			name:     "span digest verification fails",
-			maxSpans: 100,
+			maxSpans: 5,
 			sectionReader: io.NewSectionReader(readerFn(func(b []byte, _ int64) (int, error) {
 				var r bytes.Buffer
 				w := gzip.NewWriter(&r)
@@ -95,6 +95,7 @@ func TestSpanManager(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			var err error
 			defer func() {
 				if err != nil && !errors.Is(err, tc.expectedError) {

--- a/ztoc/ztoc_test.go
+++ b/ztoc/ztoc_test.go
@@ -86,8 +86,12 @@ var testZtocs = []struct {
 }
 
 func TestDecompress(t *testing.T) {
+	t.Parallel()
 	for _, tc := range testZtocs {
-		testDecompress(t, tc.compressionAlgo, tc.tarGenerator)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			testDecompress(t, tc.compressionAlgo, tc.tarGenerator)
+		})
 	}
 }
 
@@ -230,6 +234,7 @@ func TestDecompressWithGzipHeaders(t *testing.T) {
 }
 
 func TestDecompressWithPigz(t *testing.T) {
+	t.Parallel()
 	pigzPath, err := exec.LookPath("pigz")
 	if err != nil {
 		t.Skip("pigz not installed, skipping test")
@@ -263,6 +268,7 @@ func TestDecompressWithPigz(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			// Build an uncompressed tar
 			tarReader := testutil.BuildTar(tarEntries)
 			tarFilePath, _, err := testutil.WriteTarToTempFile("pigz-test-*.tar", tarReader)
@@ -360,6 +366,7 @@ func TestDecompressWithPigz(t *testing.T) {
 }
 
 func TestZtocGenerationConsistency(t *testing.T) {
+	t.Parallel()
 	for _, tc := range testZtocs {
 		testZtocGenerationConsistency(t, tc.compressionAlgo, tc.tarGenerator)
 	}
@@ -453,6 +460,7 @@ func testZtocGenerationConsistency(t *testing.T, compressionAlgo string, generat
 }
 
 func TestZtocGeneration(t *testing.T) {
+	t.Parallel()
 	for _, tc := range testZtocs {
 		testZtocGeneration(t, tc.compressionAlgo, tc.tarGenerator)
 	}
@@ -649,6 +657,7 @@ func benchmarkZtocGeneration(b *testing.B, algo string, generator tarGenerator) 
 }
 
 func TestZtocSerialization(t *testing.T) {
+	t.Parallel()
 	for _, tc := range testZtocs {
 		testZtocSerialization(t, tc.compressionAlgo, tc.tarGenerator)
 	}


### PR DESCRIPTION
**Issue #, if available:**

Final optimization in the unit tests optimization chain with https://github.com/awslabs/soci-snapshotter/pull/2066 , https://github.com/awslabs/soci-snapshotter/pull/2061 , and https://github.com/awslabs/soci-snapshotter/pull/2059

**Description of changes:**

```
  ztoc              13.541 → 4.27s
  fs/span-manager    11.996s → 2.65s
```

Before - 

```
ok  	github.com/awslabs/soci-snapshotter/fs/span-manager	11.996s
ok  	github.com/awslabs/soci-snapshotter/ztoc	13.541
```

After - 
```
ok  	github.com/awslabs/soci-snapshotter/fs/span-manager	2.65s
ok  	github.com/awslabs/soci-snapshotter/ztoc	4.27s
```

**Testing performed:**

```
-race -count=3 -shuffle=on -parallel 32
-parallel 1

also checked temp files were removed
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
