### PR TITLE
Ignore license check for go-metrics

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -19,9 +19,18 @@ allow-licenses:
   - 'X11'
   - 'Zlib'
 
-# Exception the following usages of MPL-2.0 dependencies
 allow_dependencies_licenses:
+  # Exception the following usages of MPL-2.0 dependencies
   - pkg:golang/github.com/hashicorp/go-retryablehttp
   - pkg:golang/github.com/hashicorp/errwrap
   - pkg:golang/github.com/hashicorp/go-cleanhttp
   - pkg:golang/github.com/hashicorp/go-multierror
+
+  # TODO: Remove this once this issue is resolved (NOT closed as not planned):
+  # https://github.com/actions/dependency-review-action/issues/1145
+  # We have to ignore this since dependency-review-action reports
+  # both Apache-2.0 AND Apache-2.0 AND CC-BY-SA-4.0,
+  # which is correct, however the code is entirely Apache-2.0
+  # and only the documentation is CC-BY-SA-4.0. Since we don't
+  # consume the documentation at all, we should ignore this for now.
+  - pkg:golang/github.com/docker/go-metrics


### PR DESCRIPTION
**Issue #, if available:**
Related to https://github.com/awslabs/soci-snapshotter/pull/2070

**Description of changes:**
https://github.com/awslabs/soci-snapshotter/pull/2070 is failing because of a license check that shouldn't be failing.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
