### PR TITLE
Remove Go 1.25, add Go 1.27 in CI

### DIFF
--- a/.github/workflows/benchmark-visualization.yml
+++ b/.github/workflows/benchmark-visualization.yml
@@ -19,7 +19,7 @@ permissions:
   deployments: write
 
 env:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.7'
 
 jobs:
   benchmark:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
-        go-version: ['1.25.12', '1.26.4']
+        go-version: ['1.26.7', '1.27.1']
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ['1.25.12', '1.26.4']
+        go-version: ['1.26.7', '1.27.1']
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.setup.outputs.available-runners) }}
-        go-version: ['1.25.12', '1.26.4']
+        go-version: ['1.26.7', '1.27.1']
         containerd: ["1.7.32", "2.0.9", "2.2.4", "2.3.1"]
     env:
       DOCKER_BUILD_ARGS: "CONTAINERD_VERSION=${{ matrix.containerd }}"

--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.7'
 
 permissions:
   contents: write

--- a/.github/workflows/comparision-test.yml
+++ b/.github/workflows/comparision-test.yml
@@ -11,7 +11,7 @@ on:
       - 'Makefile'
 
 env:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.7'
 
 jobs:
   check:

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -23,7 +23,7 @@ on:
       - 'scripts/update-version-in-docs.sh'
 
 env:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.7'
 
 jobs:
   test-create-branch:

--- a/.github/workflows/create-third-party-licenses.yml
+++ b/.github/workflows/create-third-party-licenses.yml
@@ -22,7 +22,7 @@ on:
     branches: ['release/**']
 
 env:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.7'
 
 jobs:
   test-build:

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -7,7 +7,7 @@ on:
     branches: ['main', 'release/**']
 
 env:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.7'
   GOLANGCI_LINT_VERSION: '2.5.0'
 
 jobs:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -12,7 +12,7 @@ on:
       - 'Makefile'
 
 env:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.7'
 
 permissions:
   contents: write


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Go 1.25 is EOL, so using Go 1.26 instead and building with Go 1.27 in our CI

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
