### PR TITLE
Upgrade golangci-lint to 2.12.2

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GO_VERSION: '1.26.7'
-  GOLANGCI_LINT_VERSION: '2.5.0'
+  GOLANGCI_LINT_VERSION: '2.12.2'
 
 jobs:
   check:


### PR DESCRIPTION


**Issue #, if available:**

**Description of changes:**
The last version of golangci-lint didn't support Go 1.26, so upgrading it.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
