### PR TITLE
Fix resolveSpan passing an absolute offset as a span-relative one

### DIFF
--- a/fs/span-manager/span_manager.go
+++ b/fs/span-manager/span_manager.go
@@ -210,8 +210,11 @@ func (m *SpanManager) resolveSpan(spanID compression.SpanID) error {
 		return ErrExceedMaxSpan
 	}
 
-	// this func itself doesn't use the returned span data
-	_, err := m.getSpanContent(spanID, 0, m.spans[spanID].endUncompOffset)
+	// this func itself doesn't use the returned span data.
+	// `getSpanContent` takes offsets relative to the start of the span, so the
+	// whole span is [0, uncompressed span size).
+	s := m.spans[spanID]
+	_, err := m.getSpanContent(spanID, 0, s.endUncompOffset-s.startUncompOffset)
 	return err
 }
 


### PR DESCRIPTION
**Issue #, if available:**

Checks failing on main after the PR https://github.com/awslabs/soci-snapshotter/pull/2072 was merged to upgrade go version - https://github.com/awslabs/soci-snapshotter/actions/runs/33809525300/job/100837517543

```
--- FAIL: TestSpanManager (1.49s)
    --- FAIL: TestSpanManager/a_file_from_20_spans (1.49s)
panic: runtime error: slice bounds out of range [:1312256] with capacity 0 [recovered, repanicked]

```

All the other places in this test file uses relative offset like this - `m.getSpanContent(0, 0, s.endUncompOffset-s.startUncompOffset)` apart from this specific call inside `resolveSpan` helper function.

The current issue we caught is also mentioned here - https://github.com/golang/go/commit/2747d887eb683f4fca0ed1350b3cc1aec860cf70

**Description of changes:**

Disclaimer I used AI to figure out this issue and fix it -


`TestSpanManager/a_file_from_20_spans` panics on Go 1.27 with `slice bounds out of range [:1312256] with capacity 0`.

The test-only `resolveSpan` helper passed the span's *absolute* `endUncompOffset` to `getSpanContent`, which expects offsets *relative* to the start of the span. Every other caller correctly passes `endUncompOffset - startUncompOffset`.

The bug has been there since e193fe82 but was invisible: by the time the test calls `resolveSpan`, every span the file touches is already cached and uncompressed, so `getSpanContent` takes the cache path and builds a lazy `io.SectionReader` -  an oversized size there just EOFs early and is never read.

Go 1.27 didn't break anything; it just produced the first span layout that exercises the bug. Its `compress/flate` emits a different block layout, so the ztoc's checkpoints land differently:

| | spans | last span |
|---|---|---|
| Go 1.25 | MaxSpanID=16, 81920 B/span | `uncomp=[1294793, 1312256)`, size 17463 |
| Go 1.27.1 | MaxSpanID=14, 98304 B/span | `uncomp=[1312256, 1312256)`, **size 0** |

Under 1.27 the final checkpoint lands exactly at the end of the uncompressed stream, creating an empty trailing span (legal - `buildAllSpans` skips the monotonicity check for `i == MaxSpanID`). It sits past the file's content range, so `GetContents` never touches it and it is still `unrequested` when `resolveSpan` reaches it. That takes the fetch path, `uncompressSpan` returns an empty buffer for a zero-size span, and slicing it to the archive size panics.

Production code is unaffected: the exported `ResolveSpan` calls `fetchAndCacheSpan` directly, and `GetContents` derives relative offsets via `getSpanInfo`.


**Testing performed:**

```
`./fs/span-manager/...` passes under both Go 1.25 and Go 1.27.1 (it panics
under 1.27.1 without this change). Full `make test` passes under 1.27.1.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
