### PR TITLE
fix(fs): prevent SIGSEGV crash and ImagePullBackOff hang on cancelled parallel pulls (#2036)

### DIFF
--- a/fs/adaptive_fetch_image_layers.go
+++ b/fs/adaptive_fetch_image_layers.go
@@ -179,7 +179,7 @@ func checkParallelPullUnpack(cfg *config.Parallel) error {
 }
 
 // GetOrAddImageJob adds the requisite image job to unpackJobs.
-// If the job already exists, return nil.
+// If the job already exists, return it.
 // Else, return the newly created imageUnpackJob.
 func (jobs *unpackJobs) GetOrAddImageJob(imageDigest string, cancel context.CancelCauseFunc) *imageUnpackJob {
 	jobs.mu.Lock()
@@ -205,13 +205,21 @@ func (jobs *unpackJobs) AddLayerJob(imageJob *imageUnpackJob, layerDigest string
 	jobs.mu.Lock()
 	defer jobs.mu.Unlock()
 
+	// The image job may have been removed by a concurrent cancelled/failed pull
+	// of the same image between GetOrAddImageJob and here. Look it up under the
+	// lock and fail gracefully instead of dereferencing a nil map entry, which
+	// previously crashed the daemon with a SIGSEGV (see awslabs/soci-snapshotter#2036).
+	image, ok := jobs.images[imageJob.imageDigest]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrImageUnpackJobNotFound, imageJob.imageDigest)
+	}
+
 	layerJob, err := newLayerUnpackJob(layerDigest, jobs.storage, withImageUnpackJob(imageJob))
 	if err != nil {
 		return nil, err
 	}
 
-	jobs.images[imageJob.imageDigest].layers[layerDigest] =
-		append(jobs.images[imageJob.imageDigest].layers[layerDigest], layerJob)
+	image.layers[layerDigest] = append(image.layers[layerDigest], layerJob)
 
 	return layerJob, nil
 }
@@ -453,6 +461,10 @@ func (jobs *unpackJobs) RemoveImageWithError(imageDigest string, cause error) er
 	}
 
 	// Cancelling an image will cancel all layer unpack jobs.
+	// The job is then fully evicted from the map so a subsequent pull of the same
+	// image rebuilds a fresh job rather than joining this cancelled one (whose
+	// premount context is dead) and failing forever with "context canceled" —
+	// the permanent (node, image) poisoning reported in this defect.
 	imageJob.Cancel(cause)
 	delete(jobs.images, imageDigest)
 	return nil
@@ -700,6 +712,17 @@ func (job *layerUnpackJob) AcquireUnpackLease(ctx context.Context) (func(), erro
 
 func (job *layerUnpackJob) Cancel(cause error) {
 	job.cancel(cause)
+	job.status.Store(LayerUnpackJobCancelled)
+}
+
+// markCancelled marks this layer job cancelled WITHOUT invoking the shared image
+// cancel function. In the current design every layer job's cancel is the image
+// job's cancel (see withImageUnpackJob), so calling Cancel() on one layer tears
+// down the shared premount context and every sibling layer with it. When a single
+// layer/pull fails but a concurrent duplicate pull of the same image is still in
+// flight, we mark just this job cancelled (so Remove can reclaim it) and leave the
+// shared context intact for the siblings.
+func (job *layerUnpackJob) markCancelled() {
 	job.status.Store(LayerUnpackJobCancelled)
 }
 

--- a/fs/adaptive_fetch_image_layers_test.go
+++ b/fs/adaptive_fetch_image_layers_test.go
@@ -18,6 +18,7 @@ package fs
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -216,6 +217,92 @@ type LayerUnpackVirtualStorage struct {
 
 func newVirtualDisk() *LayerUnpackVirtualStorage {
 	return &LayerUnpackVirtualStorage{}
+}
+
+// TestRemovingOneLayerJobKeepsSharedImageJob verifies that removing a single
+// cancelled/failed layer job does NOT tear down the shared image job while other
+// layer jobs of the same image are still in flight. This is what lets a cancelled
+// sibling pull avoid poisoning a concurrent duplicate pull of the same image
+// (the field ImagePullBackOff hang). The image job is evicted only when its last
+// layer job is removed.
+func TestRemovingOneLayerJobKeepsSharedImageJob(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	inProgressJobs, err := newUnpackJobs(testCtx, newEnableParallelPullConfig(), newVirtualDisk())
+	if err != nil {
+		t.Fatalf("failed to create unpack jobs: %v", err)
+	}
+
+	cancelled := false
+	imageJob := inProgressJobs.GetOrAddImageJob(helloWorldImageDigest, func(error) { cancelled = true })
+	layerA, err := inProgressJobs.AddLayerJob(imageJob, helloWorldLayerDigest)
+	if err != nil {
+		t.Fatalf("AddLayerJob A: %v", err)
+	}
+	otherLayerDigest := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	layerB, err := inProgressJobs.AddLayerJob(imageJob, otherLayerDigest)
+	if err != nil {
+		t.Fatalf("AddLayerJob B: %v", err)
+	}
+
+	layerA.markCancelled()
+	if err := inProgressJobs.Remove(layerA, context.Canceled); err != nil {
+		t.Fatalf("Remove(layerA): %v", err)
+	}
+	if !inProgressJobs.ImageExists(helloWorldImageDigest) {
+		t.Fatal("shared image job was evicted while another layer job was still in flight")
+	}
+	if cancelled {
+		t.Fatal("shared image job context was cancelled while another layer job was still in flight")
+	}
+
+	layerB.markCancelled()
+	if err := inProgressJobs.Remove(layerB, context.Canceled); err != nil {
+		t.Fatalf("Remove(layerB): %v", err)
+	}
+	if inProgressJobs.ImageExists(helloWorldImageDigest) {
+		t.Fatal("image job was not evicted after its last layer job was removed")
+	}
+}
+
+// TestAddLayerJobAfterImageRemovedDoesNotPanic is a regression test for
+// awslabs/soci-snapshotter#2036. A concurrent cancelled/failed pull of the same
+// image can remove the shared image job between GetOrAddImageJob and AddLayerJob.
+// AddLayerJob must fail gracefully with ErrImageUnpackJobNotFound instead of
+// dereferencing the now-nil image entry and crashing the daemon with a SIGSEGV.
+func TestAddLayerJobAfterImageRemovedDoesNotPanic(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	disk := newVirtualDisk()
+	inProgressJobs, err := newUnpackJobs(testCtx, newEnableParallelPullConfig(), disk)
+	if err != nil {
+		t.Fatalf("failed to create unpack jobs: %v", err)
+	}
+
+	// Obtain a handle to an image job, then simulate a concurrent pull removing
+	// it out from under us (exactly what RemoveImageWithError does on cancel).
+	imageJob := inProgressJobs.GetOrAddImageJob(helloWorldImageDigest, func(error) {})
+	if err := inProgressJobs.RemoveImageWithError(helloWorldImageDigest, context.Canceled); err != nil {
+		t.Fatalf("failed to remove image job: %v", err)
+	}
+
+	// This previously panicked (nil map dereference). It must now return an error.
+	layerJob, err := inProgressJobs.AddLayerJob(imageJob, helloWorldLayerDigest)
+	if err == nil {
+		t.Fatalf("expected error adding layer job to a removed image, got nil")
+	}
+	if !errors.Is(err, ErrImageUnpackJobNotFound) {
+		t.Fatalf("expected ErrImageUnpackJobNotFound, got: %v", err)
+	}
+	if layerJob != nil {
+		t.Fatalf("expected nil layer job on failure, got: %v", layerJob)
+	}
 }
 
 func (virtual *LayerUnpackVirtualStorage) Create() (string, error) {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -601,7 +601,14 @@ func (fs *filesystem) premount(ctx context.Context, desc ocispec.Descriptor, ref
 			err = cErr
 		}
 		if err != nil {
-			fs.inProgressImageUnpacks.RemoveImageWithError(layerJob.imageDigest, err)
+			// Remove ONLY this layer's job, marking it cancelled WITHOUT invoking
+			// the shared image cancel; otherwise a single layer/pull failure tears
+			// down the shared premount context and every concurrent duplicate pull
+			// of the same image with it (the #2036 SIGSEGV and the field
+			// ImagePullBackOff hang). The image job is evicted once its last layer
+			// job is removed.
+			layerJob.markCancelled()
+			fs.inProgressImageUnpacks.Remove(layerJob, err)
 		}
 		layerJob.errCh <- err
 		close(layerJob.errCh)
@@ -648,8 +655,13 @@ func (fs *filesystem) rebase(ctx context.Context, dgst digest.Digest, imageDiges
 	}
 	defer func() {
 		if err != nil {
-			layerJob.Cancel(err)
-			fs.inProgressImageUnpacks.RemoveImageWithError(layerJob.imageDigest, err)
+			// Remove ONLY this layer's job on failure and mark it cancelled without
+			// invoking the shared image cancel, so a cancelled/failed pull cannot
+			// tear down the shared image job (and its premount context) that a
+			// concurrent duplicate pull of the same image still needs (see
+			// awslabs/soci-snapshotter#2036 and the field ImagePullBackOff hang).
+			layerJob.markCancelled()
+			fs.inProgressImageUnpacks.Remove(layerJob, err)
 		} else {
 			fs.inProgressImageUnpacks.Remove(layerJob, err)
 		}


### PR DESCRIPTION
## Summary

Fixes failure modes of `parallel-pull-unpack` mode reported in #2036:

- **Daemon crash (SIGSEGV):** `panic: nil pointer dereference [signal SIGSEGV addr=0x50]` at `unpackJobs.AddLayerJob` (the `.layers` field offset), taking every container on the node down.
- **Silent node poisoning / ImagePullBackOff hang:** a `(node, image)` pair wedges — every pull retry fails with `failed to rebase layer …: context canceled`, the node stays `Ready=True`, and it never recovers.

## Root cause

`fs.MountParallel` runs once per layer. The first layer's `preloadAllLayers` creates a single shared `imageUnpackJob` and spawns premount goroutines for every layer on a shared premount context. Crucially, each layer job's cancel func **is** the shared image cancel (`withImageUnpackJob`: `luj.cancel = image.cancel`), and the premount/rebase failure paths called `RemoveImageWithError` (whole-image cancel + delete) and `layerJob.Cancel()`.

So when a pull is cancelled or a layer fails, the shared image job is torn down. If a **concurrent duplicate pull of the same image** is in flight (e.g. several pods of the same image scheduled in the same second):
- `RemoveImageWithError` deletes the map entry between another Prepare's `GetOrAddImageJob` and `AddLayerJob` → `AddLayerJob` dereferences a nil entry → **SIGSEGV**; or
- the shared premount context is cancelled mid-fetch → every sibling layer dies together (`context canceled` / `compressed digests did not match`), the pull can't finish, the 5-minute CRI `image_pull_progress_timeout` cancels it, kubelet retries ~5 min later, and the cycle repeats indefinitely → **the field hang**.

Both are the same root cause: a cancelled/failed pull tears down a shared image job that other in-flight pulls of the same image still depend on.

## Fix

- `AddLayerJob` looks the image job up under the lock and returns `ErrImageUnpackJobNotFound` instead of dereferencing a nil entry (kills the crash).
- New `layerUnpackJob.markCancelled()` sets only that layer's status to cancelled **without** invoking the shared image cancel.
- The premount and rebase failure paths now remove **only the failing layer job** (`markCancelled()` + `Remove(layerJob)`) instead of the whole image. The image job is evicted normally once its last layer job is removed, so a cancelled sibling no longer poisons a concurrent duplicate pull.

Two regression tests added: `TestAddLayerJobAfterImageRemovedDoesNotPanic` (crash) and `TestRemovingOneLayerJobKeepsSharedImageJob` (shared-job survival).

## Verification

Reproduced and verified on a single host running containerd 2.2.5 + soci-snapshotter (built from source) + CRI.

Same host/harness, this change vs stock:

| | stock v0.15.0 | this change |
|---|---|---|
| SIGSEGV panics | 8–12 | **0** |
| daemon crashes | 6+ | **0** |
| burst rounds that self-heal on retry | — | **5/5** |
| hang-style duplicate+cancel rounds that converge | — | **5/5** |
| steady-state pulls | — | **8/8** |

`go test ./fs/` (full package, including GC tests) passes. There are some flaky tests that fail, being adderessed by this PR #2075 

Fixes #2036

---
AI Assisted PR