### PR TITLE
[Feat]: Add support for custom HTTP request headers via snapshot labels

### DIFF
--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -143,7 +143,7 @@ func GetContentWithRange(ctx context.Context, realURL string, rt http.RoundTripp
 		return nil, err
 	}
 	r := fmt.Sprintf("bytes=%d-%d", lower, upper)
-	req.Header.Set("Range", r)
+	req.Header.Set(socihttp.HeaderRange, r)
 
 	resp, err := rt.RoundTrip(req)
 	if err != nil {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -476,6 +476,8 @@ func (fs *filesystem) MountParallel(ctx context.Context, mountpoint string, labe
 		return ErrParallelPullIsDisabled
 	}
 
+	ctx = socihttp.WithCustomHeaders(ctx, source.HeadersFromLabels(ctx, labels))
+
 	imageRef, ok := labels[ctdsnapshotters.TargetRefLabel]
 	if !ok {
 		return fmt.Errorf("unable to get image ref from labels")
@@ -552,6 +554,7 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 
 	premountCtx, cancel := context.WithCancelCause(context.Background())
 	premountCtx = namespaces.WithNamespace(premountCtx, ns)
+	premountCtx = socihttp.WithCustomHeaders(premountCtx, socihttp.CustomHeaders(ctx))
 	imageJob := fs.inProgressImageUnpacks.GetOrAddImageJob(imageDigest, cancel)
 
 	// If we fail anywhere after making the image job, we must remove the associated image job
@@ -781,6 +784,8 @@ func (fs *filesystem) CleanImage(ctx context.Context, imgDigest string) error {
 }
 
 func (fs *filesystem) MountLocal(ctx context.Context, mountpoint string, labels map[string]string, mounts []mount.Mount) error {
+	ctx = socihttp.WithCustomHeaders(ctx, source.HeadersFromLabels(ctx, labels))
+
 	imageRef, ok := labels[ctdsnapshotters.TargetRefLabel]
 	if !ok {
 		return fmt.Errorf("unable to get image ref from labels")
@@ -1039,6 +1044,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	// Setting the start time to measure the Mount operation duration.
 	start := time.Now()
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("mountpoint", mountpoint))
+	ctx = socihttp.WithCustomHeaders(ctx, source.HeadersFromLabels(ctx, labels))
 
 	// If this is empty or the label doesn't exist, then we will use the referrers API later
 	// to get find an index digest.
@@ -1129,6 +1135,7 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 		fs.pr.Enqueue(imgNameAndDigest, func(ctx context.Context) string {
 			// Use context from the preresolver, but append namespace from current ctx
 			ctx = namespaces.WithNamespace(ctx, ns)
+			ctx = socihttp.WithCustomHeaders(ctx, source.HeadersFromLabels(ctx, labels))
 
 			prefetchDesc := c.findPrefetchArtifact(desc.Digest.String())
 

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -181,6 +181,15 @@ type httpFetcher struct {
 	digest        digest.Digest
 	singleRange   bool
 	singleRangeMu sync.Mutex
+	// customHeaders is added to every request this fetcher makes, including
+	// background, liveness, and post-redirect fetches (e.g. to a CDN or object
+	// store). Reserved headers are never forwarded (see socihttp.ReservedHeaders).
+	//
+	// It is captured once, at fetcher creation. The layer cache key is ref+digest
+	// with no header, so a cached fetcher reuses the first caller's headers. A
+	// per-request header like a request id cannot be attributed once a layer is
+	// shared.
+	customHeaders http.Header
 }
 
 func newHTTPFetcher(ctx context.Context, fc *fetcherConfig) (*httpFetcher, error) {
@@ -263,11 +272,12 @@ func newHTTPFetcher(ctx context.Context, fc *fetcherConfig) (*httpFetcher, error
 
 		// Hit one destination
 		return &httpFetcher{
-			roundTripper: tr,
-			scope:        pullScope,
-			registryURL:  registryURL,
-			realURL:      realURL,
-			digest:       digest,
+			roundTripper:  tr,
+			scope:         pullScope,
+			registryURL:   registryURL,
+			realURL:       realURL,
+			digest:        digest,
+			customHeaders: socihttp.CustomHeaders(ctx),
 		}, nil
 	}
 
@@ -276,6 +286,7 @@ func newHTTPFetcher(ctx context.Context, fc *fetcherConfig) (*httpFetcher, error
 
 func (f *httpFetcher) fetch(ctx context.Context, rs []region, retry bool) (multipartReadCloser, error) {
 	ctx = docker.WithScope(ctx, f.scope)
+	ctx = socihttp.WithCustomHeaders(ctx, f.customHeaders)
 	if len(rs) == 0 {
 		return nil, ErrNoRegion
 	}
@@ -373,6 +384,7 @@ func (f *httpFetcher) fetch(ctx context.Context, rs []region, retry bool) (multi
 func (f *httpFetcher) check() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	ctx = socihttp.WithCustomHeaders(ctx, f.customHeaders)
 	f.urlMu.Lock()
 	url := f.realURL
 	f.urlMu.Unlock()
@@ -403,6 +415,7 @@ func (f *httpFetcher) check() error {
 }
 
 func (f *httpFetcher) refreshURL(ctx context.Context) error {
+	ctx = socihttp.WithCustomHeaders(ctx, f.customHeaders)
 	newRealURL, err := redirect(ctx, f.registryURL, f.roundTripper)
 	if err != nil {
 		return err

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -308,8 +308,8 @@ func (f *httpFetcher) fetch(ctx context.Context, rs []region, retry bool) (multi
 	for _, reg := range requests {
 		ranges += fmt.Sprintf("%d-%d,", reg.b, reg.e)
 	}
-	req.Header.Add("Range", fmt.Sprintf("bytes=%s", ranges[:len(ranges)-1]))
-	req.Header.Add("Accept-Encoding", "identity")
+	req.Header.Add(socihttp.HeaderRange, fmt.Sprintf("bytes=%s", ranges[:len(ranges)-1]))
+	req.Header.Add(socihttp.HeaderAcceptEncoding, "identity")
 
 	// Recording the roundtrip latency for remote registry GET operation.
 	start := time.Now()
@@ -380,7 +380,7 @@ func (f *httpFetcher) check() error {
 	if err != nil {
 		return fmt.Errorf("check failed: %w", err)
 	}
-	req.Header.Set("Range", "bytes=0-1")
+	req.Header.Set(socihttp.HeaderRange, "bytes=0-1")
 	res, err := f.roundTripper.RoundTrip(req)
 	if err != nil {
 		return fmt.Errorf("check failed: %w: %w", ErrRequestFailed, err)
@@ -441,7 +441,7 @@ func redirect(ctx context.Context, blobURL string, tr http.RoundTripper) (string
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Range", "bytes=0-1")
+	req.Header.Set(socihttp.HeaderRange, "bytes=0-1")
 
 	// The underlying http.Client will follow up to 10 redirects.
 	// See: https://pkg.go.dev/net/http#Get
@@ -496,7 +496,7 @@ func GetHeader(ctx context.Context, realURL string, rt http.RoundTripper) (*http
 			return nil, err
 		}
 		if i == 1 {
-			req.Header.Set("Range", "bytes=0-1")
+			req.Header.Set(socihttp.HeaderRange, "bytes=0-1")
 		}
 
 		resp, err := rt.RoundTrip(req)
@@ -526,7 +526,7 @@ func GetHeaderWithGet(ctx context.Context, realURL string, rt http.RoundTripper)
 			return nil, err
 		}
 		if i == 0 {
-			req.Header.Set("Range", "bytes=0-1")
+			req.Header.Set(socihttp.HeaderRange, "bytes=0-1")
 		}
 
 		resp, err := rt.RoundTrip(req)

--- a/fs/remote/resolver_test.go
+++ b/fs/remote/resolver_test.go
@@ -44,10 +44,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -400,6 +402,223 @@ func (u *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 		Header:     header,
 		Body:       io.NopCloser(bytes.NewReader([]byte("test"))),
 	}, nil
+}
+
+// headerCaptureRoundTripper records the headers of the request it sees.
+type headerCaptureRoundTripper struct{ got http.Header }
+
+func (h *headerCaptureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	h.got = req.Header.Clone()
+	header := make(http.Header)
+	header.Add("Content-Length", "4")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Request:    req,
+		Header:     header,
+		Body:       io.NopCloser(bytes.NewReader([]byte("test"))),
+	}, nil
+}
+
+// newTestAuthClient wraps rt in an AuthClient
+func newTestAuthClient(rt http.RoundTripper) *socihttp.AuthClient {
+	retryClient := rhttp.NewClient()
+	retryClient.HTTPClient.Transport = rt
+	ac, _ := socihttp.NewAuthClient(&emptyAuthHandler{}, socihttp.WithRetryableClient(retryClient), socihttp.WithHeader(http.Header{}))
+	return ac
+}
+
+// TestCustomHeaderReachesWireOnFetch proves a custom header stored on the fetcher
+// reaches the outgoing request, and that a reserved custom header does not
+// override the byte-range the fetcher sets itself.
+func TestCustomHeaderReachesWireOnFetch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	custom := http.Header{}
+	custom.Set("x-request-id", "caller-123")
+	custom.Set(socihttp.HeaderRange, "bytes=999-999") // reserved: must be ignored
+
+	rt := &headerCaptureRoundTripper{}
+	f := &httpFetcher{
+		realURL:       "dummyregistry",
+		roundTripper:  newTestAuthClient(rt),
+		customHeaders: custom,
+	}
+	if _, err := f.fetch(ctx, []region{{b: 0, e: 1}}, true); err != nil {
+		t.Fatalf("unexpected error = %v", err)
+	}
+	if got := rt.got.Get("x-request-id"); got != "caller-123" {
+		t.Fatalf("custom header not on the wire: got %q", got)
+	}
+	if got := rt.got.Get(socihttp.HeaderRange); got != "bytes=0-1" {
+		t.Fatalf("reserved custom Range overrode the fetcher's own range: got %q", got)
+	}
+}
+
+// TestMultipleCustomHeadersReachWireOnFetch proves the fetcher carries several
+// distinct custom headers at once (customHeaders is an http.Header map), and that
+// a reserved name mixed in is dropped while the rest pass through.
+func TestMultipleCustomHeadersReachWireOnFetch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	custom := http.Header{}
+	custom.Set("x-request-id", "caller-123")
+	custom.Set("x-tenant-id", "tenant-7")
+	custom.Set("x-trace", "trace-abc")
+	custom.Set(socihttp.HeaderAuthorization, "Basic zzz") // reserved: must be dropped
+
+	rt := &headerCaptureRoundTripper{}
+	f := &httpFetcher{
+		realURL:       "dummyregistry",
+		roundTripper:  newTestAuthClient(rt),
+		customHeaders: custom,
+	}
+	if _, err := f.fetch(ctx, []region{{b: 0, e: 1}}, true); err != nil {
+		t.Fatalf("unexpected error = %v", err)
+	}
+	want := map[string]string{
+		"x-request-id": "caller-123",
+		"x-tenant-id":  "tenant-7",
+		"x-trace":      "trace-abc",
+	}
+	for name, val := range want {
+		if got := rt.got.Get(name); got != val {
+			t.Fatalf("custom header %q not on the wire: got %q, want %q", name, got, val)
+		}
+	}
+	if got := rt.got.Get(socihttp.HeaderAuthorization); got != "" {
+		t.Fatalf("reserved Authorization must be dropped: got %q", got)
+	}
+}
+
+// TestCustomHeaderSurvivesCheck proves the header survives check(), which runs on
+// its own detached context.Background().
+func TestCustomHeaderSurvivesCheck(t *testing.T) {
+	custom := http.Header{}
+	custom.Set("x-request-id", "caller-123")
+
+	rt := &headerCaptureRoundTripper{}
+	f := &httpFetcher{
+		realURL:       "dummyregistry",
+		roundTripper:  newTestAuthClient(rt),
+		customHeaders: custom,
+	}
+	if err := f.check(); err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+	if got := rt.got.Get("x-request-id"); got != "caller-123" {
+		t.Fatalf("custom header lost on check(): got %q", got)
+	}
+}
+
+// TestCustomHeaderCapturedFromContext proves the full chain: a header on the
+// context passed to newHTTPFetcher is captured onto the fetcher and reaches the
+// wire on a later fetch. It fails if resolver.go stops reading the header off the
+// context at fetcher creation.
+func TestCustomHeaderCapturedFromContext(t *testing.T) {
+	refspec, err := reference.Parse("dummyexample.com/library/test")
+	if err != nil {
+		t.Fatalf("failed to parse reference: %v", err)
+	}
+	blobDigest := digest.FromString("dummy")
+
+	custom := http.Header{}
+	custom.Set("x-request-id", "caller-123")
+	ctx := socihttp.WithCustomHeaders(context.Background(), custom)
+
+	rt := &headerCaptureRoundTripper{}
+	hosts := []docker.RegistryHost{{
+		Client:       &http.Client{Transport: newTestAuthClient(rt)},
+		Host:         refspec.Hostname(),
+		Scheme:       "https",
+		Path:         "/v2",
+		Capabilities: docker.HostCapabilityPull,
+	}}
+
+	f, err := newHTTPFetcher(ctx, &fetcherConfig{
+		hosts:   hosts,
+		refspec: refspec,
+		desc:    ocispec.Descriptor{Digest: blobDigest, Size: 1},
+	})
+	if err != nil {
+		t.Fatalf("newHTTPFetcher: %v", err)
+	}
+	if _, err := f.fetch(context.Background(), []region{{b: 0, e: 1}}, true); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got := rt.got.Get("x-request-id"); got != "caller-123" {
+		t.Fatalf("header not captured from context and sent on the wire: got %q", got)
+	}
+}
+
+// TestCustomHeaderOverRealServer drives the real fetch path against a real HTTP
+// server (a TCP round-trip, not a mock RoundTripper) and asserts the server
+// receives x-amzn-requestid on the snapshotter's byte-range requests. This is
+// the closest local stand-in for the worker's sigv4 proxy seeing the header.
+func TestCustomHeaderOverRealServer(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("x-amzn-requestid"))
+		mu.Unlock()
+		w.Header().Set("Content-Length", "4")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("test"))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	refspec, err := reference.Parse(u.Host + "/repo:tag")
+	if err != nil {
+		t.Fatalf("parse ref: %v", err)
+	}
+
+	// Seed the header exactly as source.HeadersFromLabels would from the
+	// soci.header.x-amzn-requestid label.
+	custom := http.Header{}
+	custom.Set("x-amzn-requestid", "caller-xyz")
+	ctx := socihttp.WithCustomHeaders(context.Background(), custom)
+
+	// A real AuthClient over the real default transport — no mock anywhere.
+	retryClient := rhttp.NewClient()
+	retryClient.Logger = nil
+	ac, _ := socihttp.NewAuthClient(&emptyAuthHandler{}, socihttp.WithRetryableClient(retryClient), socihttp.WithHeader(http.Header{}))
+	host := docker.RegistryHost{
+		Client:       &http.Client{Transport: ac},
+		Host:         u.Host,
+		Scheme:       "http",
+		Path:         "/v2",
+		Capabilities: docker.HostCapabilityPull,
+	}
+
+	f, err := newHTTPFetcher(ctx, &fetcherConfig{
+		hosts:   []docker.RegistryHost{host},
+		refspec: refspec,
+		desc:    ocispec.Descriptor{Digest: digest.FromString("dummy"), Size: 1},
+	})
+	if err != nil {
+		t.Fatalf("newHTTPFetcher: %v", err)
+	}
+	if _, err := f.fetch(ctx, []region{{b: 0, e: 1}}, true); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) == 0 {
+		t.Fatal("server received no requests")
+	}
+	for i, id := range seen {
+		if id != "caller-xyz" {
+			t.Fatalf("request %d reached the server WITHOUT x-amzn-requestid: got %q", i, id)
+		}
+	}
+	t.Logf("real server saw x-amzn-requestid=%q on all %d byte-range requests", "caller-xyz", len(seen))
 }
 
 func TestParseSize(t *testing.T) {

--- a/fs/source/source.go
+++ b/fs/source/source.go
@@ -35,16 +35,20 @@ package source
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
+	socihttp "github.com/awslabs/soci-snapshotter/internal/http"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	"github.com/containerd/containerd/v2/pkg/reference"
 	ctdsnapshotters "github.com/containerd/containerd/v2/pkg/snapshotters"
+	"github.com/containerd/log"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/net/http/httpguts"
 )
 
 // GetSources is a function for converting snapshot labels into typed blob sources
@@ -90,7 +94,49 @@ const (
 
 	// HasSociIndexDigest is a label that tells if the layer was pulled with a SOCI index.
 	HasSociIndexDigest = "containerd.io/snapshot/remote/has.soci.index.digest"
+
+	// CustomHeaderLabelPrefix marks a snapshot label that carries a custom HTTP
+	// header for the snapshotter's registry requests. The header name is the label
+	// key after the prefix. The header value is the label value. For example:
+	//	containerd.io/snapshot/remote/soci.header.x-request-id = "<value>"
+	CustomHeaderLabelPrefix = "containerd.io/snapshot/remote/soci.header."
 )
+
+// HeadersFromLabels returns the custom headers from the CustomHeaderLabelPrefix
+// labels. It uses each label's suffix as the header name.
+//
+// HeadersFromLabels skips a label and logs a warning when:
+//   - the header name is reserved (see [socihttp.ReservedHeaders]), or
+//   - the name or value is not a valid HTTP header field.
+//
+// A skipped label never fails the mount. The value check rejects CR and LF, so a
+// label cannot inject a second header or split the request.
+func HeadersFromLabels(ctx context.Context, labels map[string]string) http.Header {
+	h := http.Header{}
+	for k, v := range labels {
+		if v == "" {
+			continue
+		}
+		name := strings.TrimPrefix(k, CustomHeaderLabelPrefix)
+		if name == k || name == "" {
+			continue
+		}
+		if _, ok := socihttp.ReservedHeaders[http.CanonicalHeaderKey(name)]; ok {
+			log.G(ctx).WithField("header", name).Warn("ignoring reserved custom header from snapshot label")
+			continue
+		}
+		if !httpguts.ValidHeaderFieldName(name) {
+			log.G(ctx).WithField("header", name).Warn("ignoring custom header with an invalid name from snapshot label")
+			continue
+		}
+		if !httpguts.ValidHeaderFieldValue(v) {
+			log.G(ctx).WithField("header", name).Warn("ignoring custom header with an invalid value from snapshot label")
+			continue
+		}
+		h.Set(name, v)
+	}
+	return h
+}
 
 // RegistryHosts is copied from [github.com/awslabs/soci-snapshotter/service/resolver.RegistryHosts]
 // to reduce package dependency

--- a/fs/source/source_test.go
+++ b/fs/source/source_test.go
@@ -17,11 +17,15 @@
 package source
 
 import (
+	"context"
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/pkg/reference"
 	ctdsnapshotters "github.com/containerd/containerd/v2/pkg/snapshotters"
+	"github.com/containerd/log"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 )
 
 const (
@@ -111,4 +115,139 @@ func TestNeighboringLayersSizeLengthMismatch(t *testing.T) {
 	if _, err := FromDefaultLabels(noopHosts)(labels); err == nil {
 		t.Fatal("expected error on digest/size length mismatch, got nil")
 	}
+}
+
+// TestHeadersFromLabels verifies the generic prefix convention: any label keyed
+// soci.header.<name> becomes header <name>, the snapshotter forwards it verbatim,
+// and non-matching, empty, or reserved labels are ignored.
+func TestHeadersFromLabels(t *testing.T) {
+	labels := map[string]string{
+		CustomHeaderLabelPrefix + "x-request-id":   "caller-123",
+		CustomHeaderLabelPrefix + "x-custom-trace": "trace-abc",
+		CustomHeaderLabelPrefix + "x-empty":        "",          // dropped: empty value
+		CustomHeaderLabelPrefix:                    "no-name",   // dropped: no header name
+		CustomHeaderLabelPrefix + "Authorization":  "Basic abc", // dropped: reserved
+		CustomHeaderLabelPrefix + "range":          "bytes=0-1", // dropped: reserved (any case)
+		"containerd.io/snapshot/remote/soci.size":  "4096",      // dropped: not a header label
+		"unrelated": "nope",
+	}
+
+	h := HeadersFromLabels(context.Background(), labels)
+
+	if got := h.Get("x-request-id"); got != "caller-123" {
+		t.Fatalf("x-request-id = %q, want %q", got, "caller-123")
+	}
+	if got := h.Get("x-custom-trace"); got != "trace-abc" {
+		t.Fatalf("x-custom-trace = %q, want %q", got, "trace-abc")
+	}
+	if _, ok := h["X-Empty"]; ok {
+		t.Fatalf("empty-valued header label should be dropped, got %v", h["X-Empty"])
+	}
+	if got := h.Get("Authorization"); got != "" {
+		t.Fatalf("reserved header Authorization should be dropped, got %q", got)
+	}
+	if got := h.Get("Range"); got != "" {
+		t.Fatalf("reserved header Range should be dropped, got %q", got)
+	}
+	// Only the two valid headers should be present.
+	if len(h) != 2 {
+		t.Fatalf("expected exactly 2 headers, got %d: %v", len(h), h)
+	}
+}
+
+func TestHeadersFromLabels_None(t *testing.T) {
+	if h := HeadersFromLabels(context.Background(), map[string]string{"foo": "bar"}); len(h) != 0 {
+		t.Fatalf("expected no headers, got %v", h)
+	}
+}
+
+// TestHeadersFromLabels_InvalidDropped verifies a label with an invalid header
+// name or a CR/LF in the value is dropped, so a label cannot inject a header.
+func TestHeadersFromLabels_InvalidDropped(t *testing.T) {
+	ctx, hook := ctxWithLogHook()
+
+	invalid := []string{"x with space", "x@bad", "x-inject", "x-null"}
+	labels := map[string]string{
+		CustomHeaderLabelPrefix + "x with space": "v",              // invalid name: space
+		CustomHeaderLabelPrefix + "x@bad":        "v",              // invalid name: non-token
+		CustomHeaderLabelPrefix + "x-inject":     "v\r\nX-Evil: 1", // invalid value: CRLF
+		CustomHeaderLabelPrefix + "x-null":       "a\x00b",         // invalid value: NUL
+		CustomHeaderLabelPrefix + "x-request-id": "caller-123",     // valid: kept
+	}
+
+	h := HeadersFromLabels(ctx, labels)
+
+	if got := h.Get("x-request-id"); got != "caller-123" {
+		t.Fatalf("valid header dropped: got %q", got)
+	}
+	if len(h) != 1 {
+		t.Fatalf("expected only the valid header, got %d: %v", len(h), h)
+	}
+	if got := h.Get("X-Evil"); got != "" {
+		t.Fatalf("CRLF injection produced a second header: %q", got)
+	}
+
+	warned := warnedHeaders(hook)
+	for _, name := range invalid {
+		if !warned[name] {
+			t.Fatalf("expected a WARN for dropped invalid header %q", name)
+		}
+	}
+}
+
+// TestHeadersFromLabels_ReservedDropped verifies every reserved header name is
+// dropped (case-insensitively) and a WARN is logged for each.
+func TestHeadersFromLabels_ReservedDropped(t *testing.T) {
+	// The canonical reserved names, plus mixed-case spellings to prove the match
+	// is case-insensitive.
+	names := []string{
+		"Range", "Accept-Encoding", "Accept", "Content-Type", "Content-Length",
+		"Authorization", "User-Agent", "Referer",
+		"AuThOrIzAtIoN", "USER-AGENT", "range",
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			ctx, hook := ctxWithLogHook()
+			labels := map[string]string{
+				CustomHeaderLabelPrefix + name:           "should-be-dropped",
+				CustomHeaderLabelPrefix + "x-request-id": "kept",
+			}
+
+			h := HeadersFromLabels(ctx, labels)
+
+			if got := h.Get(name); got != "" {
+				t.Fatalf("reserved header %q reached the map: %q", name, got)
+			}
+			if got := h.Get("x-request-id"); got != "kept" {
+				t.Fatalf("non-reserved header dropped: %q", got)
+			}
+			if !warnedHeaders(hook)[name] {
+				t.Fatalf("expected a WARN for dropped reserved header %q", name)
+			}
+		})
+	}
+}
+
+// ctxWithLogHook returns a context carrying a private WARN-level logger and a
+// hook that captures its entries. It does not touch the process-global logger,
+// so tests stay isolated.
+func ctxWithLogHook() (context.Context, *logrustest.Hook) {
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.WarnLevel)
+	return log.WithLogger(context.Background(), logrus.NewEntry(logger)), hook
+}
+
+// warnedHeaders returns the set of header names that were logged at WARN level.
+func warnedHeaders(hook *logrustest.Hook) map[string]bool {
+	warned := map[string]bool{}
+	for _, e := range hook.AllEntries() {
+		if e.Level != logrus.WarnLevel {
+			continue
+		}
+		if h, ok := e.Data["header"].(string); ok {
+			warned[h] = true
+		}
+	}
+	return warned
 }

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	go.etcd.io/bbolt v1.5.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.54.0
+	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0
@@ -97,7 +98,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -145,6 +145,16 @@ func (ac *AuthClient) Do(req *http.Request) (*http.Response, error) {
 		for k := range ac.header {
 			req.Header.Set(k, ac.header.Get(k))
 		}
+		// Add the custom headers from the context. Read from the captured ctx so they
+		// survive the request clone on a 401 retry. Skip a reserved name so a caller
+		// can never override a header the snapshotter or a shared library manages.
+		for k, vals := range CustomHeaders(ctx) {
+			name := http.CanonicalHeaderKey(k)
+			if _, reserved := ReservedHeaders[name]; reserved {
+				continue
+			}
+			req.Header[name] = append([]string(nil), vals...)
+		}
 		authReq, err := ac.handler.AuthorizeRequest(ctx, req)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", ErrFailedToAuthorizeRequest, err)

--- a/internal/http/auth.go
+++ b/internal/http/auth.go
@@ -257,7 +257,7 @@ func (ac *AuthClient) redirected(req *http.Request) *http.Request {
 		return nil
 	}
 	r := req.Clone(ac.getAuthCtx(req.Context()))
-	r.Header.Set("Referer", req.URL.String())
+	r.Header.Set(HeaderReferer, req.URL.String())
 	r.URL = newURL
 	r.Host = newURL.Host
 	return r

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -1,0 +1,31 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package http
+
+// These constants name the HTTP headers that the snapshotter or a shared library
+// sets on its own requests. A caller must not override them through a custom
+// header. ReservedHeaders lists them.
+const (
+	HeaderRange          = "Range"
+	HeaderAcceptEncoding = "Accept-Encoding"
+	HeaderAccept         = "Accept"
+	HeaderContentType    = "Content-Type"
+	HeaderContentLength  = "Content-Length"
+	HeaderAuthorization  = "Authorization"
+	HeaderUserAgent      = "User-Agent"
+	HeaderReferer        = "Referer"
+)

--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -16,6 +16,11 @@
 
 package http
 
+import (
+	"context"
+	"net/http"
+)
+
 // These constants name the HTTP headers that the snapshotter or a shared library
 // sets on its own requests. A caller must not override them through a custom
 // header. ReservedHeaders lists them.
@@ -29,3 +34,38 @@ const (
 	HeaderUserAgent      = "User-Agent"
 	HeaderReferer        = "Referer"
 )
+
+// ReservedHeaders holds the reserved header names in canonical form for lookup.
+// A reserved name is set by the snapshotter itself, or by a library it shares the
+// client with. oras-go and the containerd docker fetcher set Accept and
+// Content-Type for content negotiation, so a custom header must not replace them.
+// HeadersFromLabels drops a custom header whose name is in this set, and
+// AuthClient.Do never lets one override it.
+var ReservedHeaders = map[string]struct{}{
+	http.CanonicalHeaderKey(HeaderRange):          {},
+	http.CanonicalHeaderKey(HeaderAcceptEncoding): {},
+	http.CanonicalHeaderKey(HeaderAccept):         {},
+	http.CanonicalHeaderKey(HeaderContentType):    {},
+	http.CanonicalHeaderKey(HeaderContentLength):  {},
+	http.CanonicalHeaderKey(HeaderAuthorization):  {},
+	http.CanonicalHeaderKey(HeaderUserAgent):      {},
+	http.CanonicalHeaderKey(HeaderReferer):        {},
+}
+
+// customHeadersKey is the context key for the custom request headers.
+type customHeadersKey struct{}
+
+// WithCustomHeaders returns a context that adds h to every request the AuthClient
+// sends under it.
+func WithCustomHeaders(ctx context.Context, h http.Header) context.Context {
+	if len(h) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, customHeadersKey{}, h)
+}
+
+// CustomHeaders returns the headers set by WithCustomHeaders, or nil.
+func CustomHeaders(ctx context.Context) http.Header {
+	h, _ := ctx.Value(customHeadersKey{}).(http.Header)
+	return h
+}

--- a/internal/http/headers_test.go
+++ b/internal/http/headers_test.go
@@ -1,0 +1,165 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+type captureRoundTripper struct{ got http.Header }
+
+func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.got = req.Header.Clone()
+	return &http.Response{StatusCode: http.StatusOK}, nil
+}
+
+// echoRoundTripper returns the x-request-id it saw in a response header. It is
+// safe to share across goroutines because it keeps no state.
+type echoRoundTripper struct{}
+
+func (echoRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	h := make(http.Header)
+	h.Set("x-seen-id", req.Header.Get("x-request-id"))
+	return &http.Response{StatusCode: http.StatusOK, Header: h}, nil
+}
+
+// Guarantee: headers placed on the request context by WithCustomHeaders are attached
+// to the outgoing request by AuthClient.Do, alongside the global headers — proving a
+// shared, daemon-global AuthClient can still carry per-request (per-caller) values
+// like a request id.
+func TestCustomHeadersAttachedPerRequest(t *testing.T) {
+	global := http.Header{}
+	global.Set("User-Agent", "soci-test")
+	rt := &captureRoundTripper{}
+	ac := SimpleMockAuthClient(rt, global)
+
+	custom := http.Header{}
+	custom.Set("x-request-id", "caller-123")
+	custom.Set("x-custom-trace", "trace-1")
+	ctx := WithCustomHeaders(context.Background(), custom)
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example/blob", nil)
+	if _, err := ac.Do(req); err != nil {
+		t.Fatal(err)
+	}
+	if got := rt.got.Get("x-request-id"); got != "caller-123" {
+		t.Fatalf("x-request-id not attached: got %q", got)
+	}
+	if got := rt.got.Get("x-custom-trace"); got != "trace-1" {
+		t.Fatalf("x-custom-trace not attached: got %q", got)
+	}
+	if got := rt.got.Get("User-Agent"); got != "soci-test" {
+		t.Fatalf("global header lost: got %q", got)
+	}
+}
+
+// With no custom headers, Do must behave exactly as before (nil-safe).
+func TestCustomHeadersAbsent(t *testing.T) {
+	rt := &captureRoundTripper{}
+	ac := SimpleMockAuthClient(rt, http.Header{})
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example/blob", nil)
+	if _, err := ac.Do(req); err != nil {
+		t.Fatal(err)
+	}
+	if got := rt.got.Get("x-request-id"); got != "" {
+		t.Fatalf("unexpected x-request-id: %q", got)
+	}
+}
+
+// Do must drop a reserved header even when it is put on the context directly,
+// bypassing the label parser. This is the defense-in-depth guarantee at the sink.
+func TestCustomHeadersReservedDroppedAtSink(t *testing.T) {
+	rt := &captureRoundTripper{}
+	ac := SimpleMockAuthClient(rt, http.Header{})
+
+	custom := http.Header{}
+	custom.Set("x-request-id", "caller-123")
+	custom.Set(HeaderRange, "bytes=999-999") // reserved
+	custom.Set(HeaderAccept, "text/plain")   // reserved (set by oras-go)
+	ctx := WithCustomHeaders(context.Background(), custom)
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example/blob", nil)
+	if _, err := ac.Do(req); err != nil {
+		t.Fatal(err)
+	}
+	if got := rt.got.Get("x-request-id"); got != "caller-123" {
+		t.Fatalf("non-reserved header lost: got %q", got)
+	}
+	if got := rt.got.Get(HeaderRange); got != "" {
+		t.Fatalf("reserved Range must be dropped at the sink: got %q", got)
+	}
+	if got := rt.got.Get(HeaderAccept); got != "" {
+		t.Fatalf("reserved Accept must be dropped at the sink: got %q", got)
+	}
+}
+
+// Do must keep every value of a multi-value custom header, not just the last.
+func TestCustomHeadersMultiValue(t *testing.T) {
+	rt := &captureRoundTripper{}
+	ac := SimpleMockAuthClient(rt, http.Header{})
+
+	custom := http.Header{}
+	custom.Add("X-Trace", "a")
+	custom.Add("X-Trace", "b")
+	ctx := WithCustomHeaders(context.Background(), custom)
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example/blob", nil)
+	if _, err := ac.Do(req); err != nil {
+		t.Fatal(err)
+	}
+	if got := rt.got.Values("X-Trace"); len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("multi-value header not preserved: got %v", got)
+	}
+}
+
+// One shared, daemon-global AuthClient must attach each caller's own request id,
+// with no cross-wiring between concurrent requests. Run under -race.
+func TestCustomHeadersConcurrentIsolation(t *testing.T) {
+	ac := SimpleMockAuthClient(echoRoundTripper{}, http.Header{})
+
+	const n = 50
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("id-%d", i)
+			custom := http.Header{}
+			custom.Set("x-request-id", id)
+			ctx := WithCustomHeaders(context.Background(), custom)
+			req, _ := http.NewRequestWithContext(ctx, "GET", "http://example/blob", nil)
+			resp, err := ac.Do(req)
+			if err != nil {
+				errs <- fmt.Errorf("goroutine %d: %w", i, err)
+				return
+			}
+			if got := resp.Header.Get("x-seen-id"); got != id {
+				errs <- fmt.Errorf("goroutine %d saw request id %q, want %q", i, got, id)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}

--- a/service/resolver/client.go
+++ b/service/resolver/client.go
@@ -46,7 +46,7 @@ var userAgent = fmt.Sprintf("soci-snapshotter/%s", version.Version)
 // to all requests.
 func globalHeaders() http.Header {
 	header := http.Header{}
-	header.Set("User-Agent", userAgent)
+	header.Set(socihttp.HeaderUserAgent, userAgent)
 	return header
 }
 


### PR DESCRIPTION
# Add support for custom HTTP request headers via snapshot labels

## Summary

Adding support for custom HTTP request headers via snapshot label `containerd.io/snapshot/remote/soci.header.<name> = <value>` which adds the header `<name>: <value>` to the registry requests that the snapshotter
makes. 

This covers byte-range fetches, liveness checks, URL refreshes, and
index/zTOC fetches. Two labels add two headers.

Example: 

`containerd.io/snapshot/remote/soci.header.x-request-id=1234 `
would turn into:
 `x-request-id` :`1234`

## Why

Example use case: Callers of the snapshotter may want to identify or correlate their requests. 
The snapshotter fetches layer content on its own connection, separate from the
containerd pull. A caller cannot tag that traffic today. For example, a caller
cannot attach a request id. This change adds that ability.

## How

`source.HeadersFromLabels` reads the labels. `fs.fs` puts the headers on the
context with `socihttp.WithCustomHeaders` at each mount entry point:
`Mount`, `MountParallel`, and `MountLocal`. `Mount` also seeds them in the
neighboring-layer pre-resolution loop. `preloadAllLayers` copies them from the
parent context into the premount context.

Each `httpFetcher` reads the headers once when the snapshotter creates it. It
re-attaches them on every `fetch`, `check`, and `refreshURL`. `AuthClient.Do`
sets them on the request. The SOCI index and zTOC fetches use the same
`AuthClient`, so they carry the headers too.

The fetcher reads the headers once, at creation. The fetcher cache key is
ref+digest and holds no header. A cached fetcher reuses the first caller's
headers. So a per-request header cannot identify a single caller after two pulls
share a layer.

## RFC basis

- **Validation** — `golang.org/x/net/http/httpguts` checks each name as a
  `token` (RFC 9110 §5.6.2) and each value as a `field-value` (§5.5). The value
  check rejects CR and LF. This blocks header injection and request splitting
  (§11.1). The snapshotter drops an invalid name or value with a WARN.
- **Reserved headers** — the snapshotter or a shared library sets Range,
  Accept-Encoding, Accept, Content-Type, Content-Length, Authorization,
  User-Agent, and Referer. The snapshotter drops a label that names one of
  these with a WARN. The parser and the sink both drop it. The match is
  case-insensitive (§5.1).

## Testing

Unit tests: `internal/http/headers_test.go`, `fs/source/source_test.go`, and
`fs/remote/resolver_test.go`. They cover attach, absent, reserved dropped,
invalid dropped, multiple values, concurrent isolation, and a real httptest
server.

End-to-end test — **PENDING**. Build the snapshotter from this branch. Run a
client that passes `soci.header.x-amzn-requestid`.

```
Before (no label):  PENDING  PASTE
After  (label set): PENDING  PASTE
Reserved/invalid:   PENDING PASTE
```

The snapshotter behaves the same as before when no `soci.header.` label is
present.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
