### PR TITLE
parallel-pull: improve concurrency and fix daemon crash

### DIFF
--- a/fs/adaptive_fetch_image_layers.go
+++ b/fs/adaptive_fetch_image_layers.go
@@ -178,13 +178,10 @@ func checkParallelPullUnpack(cfg *config.Parallel) error {
 	return err
 }
 
-// GetOrAddImageJob adds the requisite image job to unpackJobs.
-// If the job already exists, return nil.
+// getOrAddImageJob adds the requisite image job to unpackJobs.
+// If the job already exists, return it.
 // Else, return the newly created imageUnpackJob.
-func (jobs *unpackJobs) GetOrAddImageJob(imageDigest string, cancel context.CancelCauseFunc) *imageUnpackJob {
-	jobs.mu.Lock()
-	defer jobs.mu.Unlock()
-
+func (jobs *unpackJobs) getOrAddImageJob(imageDigest string) *imageUnpackJob {
 	if jobs.imageExists(imageDigest) {
 		return jobs.images[imageDigest]
 	}
@@ -194,18 +191,18 @@ func (jobs *unpackJobs) GetOrAddImageJob(imageDigest string, cancel context.Canc
 		withImageUnpacksLimit(jobs.imagePullCfg.MaxConcurrentUnpacksPerImage),
 		withGlobalConcurrentDownloadsLimiter(jobs.globalConcurrentDownloadsLimiter),
 		withGlobalConcurrentUnpacksLimiter(jobs.globalConcurrentUnpacksLimiter),
-		withCancelFunc(cancel),
 	)
 
 	return jobs.images[imageDigest]
 }
 
 // AddLayerJob both adds the job to the in-memory store and creates the requisite folder on disk
-func (jobs *unpackJobs) AddLayerJob(imageJob *imageUnpackJob, layerDigest string) (*layerUnpackJob, error) {
+func (jobs *unpackJobs) AddLayerJob(imageDigest, layerDigest string, cancel context.CancelCauseFunc) (*layerUnpackJob, error) {
 	jobs.mu.Lock()
 	defer jobs.mu.Unlock()
 
-	layerJob, err := newLayerUnpackJob(layerDigest, jobs.storage, withImageUnpackJob(imageJob))
+	imageJob := jobs.getOrAddImageJob(imageDigest)
+	layerJob, err := newLayerUnpackJob(layerDigest, jobs.storage, withImageUnpackJob(imageJob), withCancelCauseFunc(cancel))
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +395,6 @@ type unpackJobsSnapshot struct {
 }
 
 type layerUnpackJobSnapshot struct {
-	imageID           string
 	creationTimestamp int64
 }
 
@@ -415,7 +411,6 @@ func (jobs *unpackJobs) Snapshot(ctx context.Context) (*unpackJobsSnapshot, erro
 		for _, layerJobs := range image.layers {
 			for _, v := range layerJobs {
 				snapshot.inMemory[v.layerUnpackID] = &layerUnpackJobSnapshot{
-					imageID:           v.imageDigest,
 					creationTimestamp: v.creationTimestamp,
 				}
 			}
@@ -436,29 +431,76 @@ func (jobs *unpackJobs) Snapshot(ctx context.Context) (*unpackJobsSnapshot, erro
 // successful or otherwise.
 // This will only remove cancelled or claimed jobs.
 // If no available jobs meet this criteria, it will return an error.
-func (jobs *unpackJobs) Remove(job *layerUnpackJob, cause error) error {
+func (jobs *unpackJobs) Remove(job *layerUnpackJob) error {
 	jobs.mu.Lock()
 	defer jobs.mu.Unlock()
 
-	return jobs.remove(job, cause)
+	return jobs.remove(job)
 }
 
-func (jobs *unpackJobs) RemoveImageWithError(imageDigest string, cause error) error {
+// ForceRemoveWithID cancels the context associated with the layerJob
+// before removing it. This is really only meant to be used with the
+// garbage collector.
+func (jobs *unpackJobs) ForceRemoveWithID(layerUnpackID string) error {
 	jobs.mu.Lock()
 	defer jobs.mu.Unlock()
 
+	for _, img := range jobs.images {
+		for _, layer := range img.layers {
+			for _, job := range layer {
+				if job.layerUnpackID == layerUnpackID {
+					job.Cancel(ErrImageUnpackJobExpired)
+					return jobs.remove(job)
+				}
+			}
+		}
+	}
+
+	return ErrLayerJobNotFound
+}
+
+// CleanCancelledLayerJobs will only remove image jobs that have a cancelled context
+func (jobs *unpackJobs) CleanCancelledLayerJobs(imageDigest string) error {
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+
+	return jobs.cleanLayerJobs(imageDigest, false)
+}
+
+// CleanImage will remove all layer jobs associated with an image,
+// regardless of if they are in flight or not
+func (jobs *unpackJobs) CleanImage(imageDigest string) error {
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+
+	return jobs.cleanLayerJobs(imageDigest, true)
+}
+
+// cleanImageJobs removes all layer jobs with cancelled contexts with given image digest
+// If force is true, remove regardless of their status
+func (jobs *unpackJobs) cleanLayerJobs(imageDigest string, force bool) error {
 	imageJob, ok := jobs.images[imageDigest]
 	if !ok {
 		return fmt.Errorf("%w: %s", ErrImageUnpackJobNotFound, imageDigest)
 	}
 
-	// Cancelling an image will cancel all layer unpack jobs.
-	imageJob.Cancel(cause)
-	delete(jobs.images, imageDigest)
+	for _, layers := range imageJob.layers {
+		for i := len(layers) - 1; i >= 0; i-- {
+			layerJob := layers[i]
+			if force {
+				layerJob.Cancel(context.Canceled)
+			}
+			err := jobs.removeWithLayerUnpackID(imageJob.imageDigest, layerJob.layerDigest, layerJob.layerUnpackID, i)
+			if err != nil && !errors.Is(err, ErrLayerJobCannotBeCleaned) {
+				return fmt.Errorf("error removing layer jobs: %w", err)
+			}
+		}
+	}
+
 	return nil
 }
 
-func (jobs *unpackJobs) remove(job *layerUnpackJob, cause error) error {
+func (jobs *unpackJobs) remove(job *layerUnpackJob) error {
 	imageDigest := job.imageDigest
 	layerDigest := job.layerDigest
 	layerUnpackID := job.layerUnpackID
@@ -469,36 +511,34 @@ func (jobs *unpackJobs) remove(job *layerUnpackJob, cause error) error {
 
 	for i, status := range jobs.images[imageDigest].layers[layerDigest] {
 		if status.layerUnpackID == layerUnpackID {
-			// Proceed only if status is claimed or cancelled
-			switch status.status.Load() {
-			case LayerUnpackJobClaimed:
-			case LayerUnpackJobCancelled:
-			default:
-				return fmt.Errorf("%w: %s", ErrLayerJobCannotBeCleaned, layerUnpackID)
-			}
-
-			jobs.images[imageDigest].layers[layerDigest] = slices.Delete(jobs.images[imageDigest].layers[layerDigest], i, i+1)
-			if len(jobs.images[imageDigest].layers[layerDigest]) == 0 {
-				delete(jobs.images[imageDigest].layers, layerDigest)
-			}
-			if len(jobs.images[imageDigest].layers) == 0 {
-				// Call cancel to avoid context leak
-				jobs.images[imageDigest].cancel(cause)
-				delete(jobs.images, imageDigest)
-			}
-			return nil
+			return jobs.removeWithLayerUnpackID(imageDigest, layerDigest, layerUnpackID, i)
 		}
 	}
 
 	return ErrLayerJobNotFound
 }
 
-type imageUnpackJob struct {
-	ctx    context.Context
-	cancel context.CancelCauseFunc
+func (jobs *unpackJobs) removeWithLayerUnpackID(imageDigest, layerDigest, layerUnpackID string, pos int) error {
+	// Proceed only if status is claimed or cancelled
+	switch jobs.images[imageDigest].layers[layerDigest][pos].status.Load() {
+	case LayerUnpackJobClaimed:
+	case LayerUnpackJobCancelled:
+	default:
+		return fmt.Errorf("%w: %s", ErrLayerJobCannotBeCleaned, layerUnpackID)
+	}
 
-	imageDigest       string
-	creationTimestamp int64
+	jobs.images[imageDigest].layers[layerDigest] = slices.Delete(jobs.images[imageDigest].layers[layerDigest], pos, pos+1)
+	if len(jobs.images[imageDigest].layers[layerDigest]) == 0 {
+		delete(jobs.images[imageDigest].layers, layerDigest)
+	}
+	if len(jobs.images[imageDigest].layers) == 0 {
+		delete(jobs.images, imageDigest)
+	}
+	return nil
+}
+
+type imageUnpackJob struct {
+	imageDigest string
 
 	globalConcurrentDownloadsLimiter *SemaphoreWithNil
 	globalConcurrentUnpacksLimiter   *SemaphoreWithNil
@@ -542,23 +582,13 @@ func withGlobalConcurrentUnpacksLimiter(smp *SemaphoreWithNil) imageUnpackOption
 	}
 }
 
-func withCancelFunc(cancel context.CancelCauseFunc) imageUnpackOption {
-	return func(job *imageUnpackJob) {
-		job.cancel = cancel
-	}
-}
-
 var now = func() time.Time {
 	return time.Now()
 }
 
 func newImageUnpackJob(imageDigest string, opts ...imageUnpackOption) *imageUnpackJob {
-	ctx, cancel := context.WithCancelCause(context.Background())
 	job := &imageUnpackJob{
-		ctx:                              ctx,
-		cancel:                           cancel,
 		imageDigest:                      imageDigest,
-		creationTimestamp:                now().UnixNano(),
 		globalConcurrentDownloadsLimiter: NewSemaphoreWithNil(unlimited),
 		globalConcurrentUnpacksLimiter:   NewSemaphoreWithNil(unlimited),
 		concurrentDownloadsLimiter:       NewSemaphoreWithNil(unlimited),
@@ -572,10 +602,6 @@ func newImageUnpackJob(imageDigest string, opts ...imageUnpackOption) *imageUnpa
 	}
 
 	return job
-}
-
-func (job *imageUnpackJob) Cancel(cause error) {
-	job.cancel(cause)
 }
 
 type layerUnpackJobStatus int
@@ -605,33 +631,37 @@ type layerUnpackJobOption func(*layerUnpackJob)
 type layerUnpackJob struct {
 	// Inherit fields from parent via withImageUnpackJob
 	imageDigest                      string
-	cancel                           context.CancelCauseFunc
 	globalConcurrentDownloadsLimiter *SemaphoreWithNil
 	globalConcurrentUnpacksLimiter   *SemaphoreWithNil
 	concurrentDownloadsLimiter       *SemaphoreWithNil
 	concurrentUnpacksLimiter         *SemaphoreWithNil
-	creationTimestamp                int64
 	bufferPool                       *bufferPool
 
 	// Unique to layerUnpackJob struct
-	layerUnpackID string
-	layerDigest   string
-	ingestPath    string
-	upperPath     string
-	errCh         chan error
-	status        atomic.Value
+	creationTimestamp int64
+	layerUnpackID     string
+	layerDigest       string
+	ingestPath        string
+	upperPath         string
+	errCh             chan error
+	status            atomic.Value
+	cancel            context.CancelCauseFunc
 }
 
 func withImageUnpackJob(image *imageUnpackJob) layerUnpackJobOption {
 	return func(luj *layerUnpackJob) {
 		luj.imageDigest = image.imageDigest
-		luj.cancel = image.cancel
 		luj.globalConcurrentDownloadsLimiter = image.globalConcurrentDownloadsLimiter
 		luj.globalConcurrentUnpacksLimiter = image.globalConcurrentUnpacksLimiter
 		luj.concurrentDownloadsLimiter = image.concurrentDownloadsLimiter
 		luj.concurrentUnpacksLimiter = image.concurrentUnpacksLimiter
-		luj.creationTimestamp = image.creationTimestamp
 		luj.bufferPool = image.bufferPool
+	}
+}
+
+func withCancelCauseFunc(cancel context.CancelCauseFunc) layerUnpackJobOption {
+	return func(job *layerUnpackJob) {
+		job.cancel = cancel
 	}
 }
 
@@ -649,12 +679,13 @@ func newLayerUnpackJob(layerDigest string, storage LayerUnpackJobStorage, opts .
 	}
 
 	luj := &layerUnpackJob{
-		layerUnpackID: id,
-		layerDigest:   layerDigest,
-		ingestPath:    filepath.Join(path, layerDigest),
-		upperPath:     filepath.Join(path, layerUnpackDir),
-		status:        atomic.Value{},
-		errCh:         make(chan error, 1),
+		creationTimestamp: now().UnixNano(),
+		layerUnpackID:     id,
+		layerDigest:       layerDigest,
+		ingestPath:        filepath.Join(path, layerDigest),
+		upperPath:         filepath.Join(path, layerUnpackDir),
+		status:            atomic.Value{},
+		errCh:             make(chan error, 1),
 	}
 
 	for _, opt := range opts {
@@ -793,19 +824,17 @@ type memoryGarbageCollectionPolicy interface {
 type garbageCollectIfExpired struct {
 	expiryTime time.Duration
 
-	// cancelImageUnpack still cancel all layer unpack jobs associated with an image unpack.
-	cancelImageUnpack func(string) error
+	// cancelLayerUnpack will cancel that layer unpack job.
+	cancelLayerUnpack func(string) error
 }
 
 // MarkAndSweep marks all in-progress jobs which that were created before the expiry time for garbage collection.
 func (p garbageCollectIfExpired) MarkAndSweep(ctx context.Context, jobs *unpackJobsSnapshot) {
 	logger := log.G(ctx).WithField("policy", "Expired")
-	cancelledImages := map[string]struct{}{}
+	cancelledLayers := map[string]struct{}{}
 
 	maps.DeleteFunc(jobs.inMemory, func(id string, layer *layerUnpackJobSnapshot) bool {
-		// All layers from the same image share the creation timestamp. Cancelling one layer will cancel all of them.
-		// So just remove the layer from the snapshot if it has already been cancelled.
-		if _, ok := cancelledImages[layer.imageID]; ok {
+		if _, ok := cancelledLayers[id]; ok {
 			return true
 		}
 
@@ -813,11 +842,11 @@ func (p garbageCollectIfExpired) MarkAndSweep(ctx context.Context, jobs *unpackJ
 			jobCtxLogger := logger.WithField("id", id)
 			jobCtxLogger.Trace("Marked for cleanup")
 
-			if err := p.cancelImageUnpack(layer.imageID); err != nil {
+			if err := p.cancelLayerUnpack(id); err != nil {
 				jobCtxLogger.WithError(err).Error("Failed to cancel job")
 				return false
 			}
-			cancelledImages[layer.imageID] = struct{}{}
+			cancelledLayers[id] = struct{}{}
 
 			jobCtxLogger.Trace("Reclaimed memory")
 			return true
@@ -843,8 +872,8 @@ func newGarbageCollector(interval time.Duration, jobs *unpackJobs, storage Layer
 		unusedMemory: []memoryGarbageCollectionPolicy{
 			garbageCollectIfExpired{
 				expiryTime: garbageCollectionJobExpiration,
-				cancelImageUnpack: func(id string) error {
-					return jobs.RemoveImageWithError(id, ErrImageUnpackJobExpired)
+				cancelLayerUnpack: func(id string) error {
+					return jobs.ForceRemoveWithID(id)
 				},
 			},
 		},

--- a/fs/adaptive_fetch_image_layers_test.go
+++ b/fs/adaptive_fetch_image_layers_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/awslabs/soci-snapshotter/config"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 )
 
@@ -136,14 +137,14 @@ func TestSystemResourcesAreGarbageCollectedForCompletedJobs(t *testing.T) {
 func TestInProgressJobsAreNotGarbageCollected(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	testCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	testCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
 
 	disk := newVirtualDisk()
 	disk.CreateCompletedImageUnpackJobs(3 * jobs)
 
 	inProgressJobs, _ := newUnpackJobs(testCtx, newEnableParallelPullConfig(), disk)
-	createEphemeralInProgressImageUnpackJob(t, inProgressJobs)
+	createEphemeralInProgressImageUnpackJob(t, inProgressJobs, cancel)
 	await(3 * ticks)
 
 	disk.AssertAllUsedResourcesHaveNotBeenGarbageCollected(t, inProgressJobs)
@@ -155,16 +156,78 @@ func TestInProgressJobsAreNotGarbageCollected(t *testing.T) {
 func TestExpiredJobsAreGarbageCollected(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	testCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	testCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
 
 	disk := newVirtualDisk()
 	inProgressJobs, _ := newUnpackJobs(testCtx, newEnableParallelPullConfig(), disk)
-	createExpiredInProgressImageUnpackJob(t, inProgressJobs)
+	createExpiredInProgressImageUnpackJob(t, inProgressJobs, cancel)
 
 	await(3 * ticks)
 
 	disk.AssertAllUnusedResourcesHaveBeenGarbageCollected(t, inProgressJobs)
+}
+
+// TestConcurrentRequestsAreIndependent covers an edge case
+// where an imageUnpackJob has two layers from separate requests,
+// and we want to ensure they do not conflict with each other
+func TestConcurrentRequestsAreIndependent(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	dummyDigest := "sha256:dummydigest"
+	dummyLayer := "sha256:dummylayer"
+
+	testCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+
+	disk := newVirtualDisk()
+	inProgressJobs, _ := newUnpackJobs(testCtx, newEnableParallelPullConfig(), disk)
+
+	progressCtx, progressCancelFunc := context.WithCancelCause(context.Background())
+	defer progressCancelFunc(context.Canceled)
+	_, stopCancelFunc := context.WithCancelCause(context.Background())
+	defer stopCancelFunc(context.Canceled)
+	disk.CreateCompletedImageUnpackJobs(3 * jobs)
+
+	_, err := inProgressJobs.AddLayerJob(dummyDigest, dummyLayer, progressCancelFunc)
+	assert.Nil(t, err)
+	_, err = inProgressJobs.AddLayerJob(dummyDigest, dummyLayer, stopCancelFunc)
+	assert.Nil(t, err)
+	stopCancelFunc(context.Canceled)
+	await(3 * ticks)
+
+	assert.Nil(t, progressCtx.Err())
+	disk.AssertAllUsedResourcesHaveNotBeenGarbageCollected(t, inProgressJobs)
+}
+
+// TestCleanImage checks behavior of CleanImage and related functions
+func TestCleanImage(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+
+	disk := newVirtualDisk()
+	inProgressJobs, _ := newUnpackJobs(ctx, newEnableParallelPullConfig(), disk)
+
+	_, err := inProgressJobs.AddLayerJob(helloWorldImageDigest, helloWorldLayerDigest, cancel)
+	assert.Nil(t, err)
+
+	err = inProgressJobs.CleanCancelledLayerJobs(helloWorldImageDigest)
+	assert.Nil(t, err)
+	assert.NotZero(t, len(inProgressJobs.images))
+
+	cancel(context.Canceled)
+	err = inProgressJobs.CleanImage(helloWorldImageDigest)
+	assert.Nil(t, err)
+
+	job, err := inProgressJobs.AddLayerJob(helloWorldImageDigest, helloWorldLayerDigest, cancel)
+	assert.Nil(t, err)
+	err = inProgressJobs.ForceRemoveWithID(job.layerUnpackID)
+	assert.Nil(t, err)
+	assert.Zero(t, len(inProgressJobs.images))
+
+	disk.AssertAllUsedResourcesHaveNotBeenGarbageCollected(t, inProgressJobs)
 }
 
 const (
@@ -184,15 +247,14 @@ func await(numberOfTicks int) {
 	}
 }
 
-func createEphemeralInProgressImageUnpackJob(t testing.TB, inProgressJobs *unpackJobs) {
-	imageJob := inProgressJobs.GetOrAddImageJob(helloWorldImageDigest, func(cause error) {})
-	_, err := inProgressJobs.AddLayerJob(imageJob, helloWorldLayerDigest)
+func createEphemeralInProgressImageUnpackJob(t testing.TB, inProgressJobs *unpackJobs, cancel context.CancelCauseFunc) {
+	_, err := inProgressJobs.AddLayerJob(helloWorldImageDigest, helloWorldLayerDigest, cancel)
 	if err != nil {
 		t.Fatalf("Failed to create ephemeral in-progress image unpack job: %v", err)
 	}
 }
 
-func createExpiredInProgressImageUnpackJob(t testing.TB, inProgressJobs *unpackJobs) {
+func createExpiredInProgressImageUnpackJob(t testing.TB, inProgressJobs *unpackJobs, cancel context.CancelCauseFunc) {
 	originalNow := now
 	defer func() {
 		now = originalNow
@@ -203,8 +265,7 @@ func createExpiredInProgressImageUnpackJob(t testing.TB, inProgressJobs *unpackJ
 		return time.Now().Add(-1 * garbageCollectionJobExpiration)
 	}
 
-	imageJob := inProgressJobs.GetOrAddImageJob(helloWorldImageDigest, func(cause error) {})
-	_, err := inProgressJobs.AddLayerJob(imageJob, helloWorldLayerDigest)
+	_, err := inProgressJobs.AddLayerJob(helloWorldImageDigest, helloWorldLayerDigest, cancel)
 	if err != nil {
 		t.Fatalf("Failed to create ephemeral in-progress image unpack job: %v", err)
 	}
@@ -479,15 +540,15 @@ func TestLayerUnpackDiskStorage(t *testing.T) {
 func TestLayerUnpackJob(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	testCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	testCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
 
 	disk := newVirtualDisk()
 	inProgressJobs, err := newUnpackJobs(testCtx, newEnableParallelPullConfig(), disk)
 	if err != nil {
 		t.Fatalf("Expected no setup error, got %v", err)
 	}
-	createEphemeralInProgressImageUnpackJob(t, inProgressJobs)
+	createEphemeralInProgressImageUnpackJob(t, inProgressJobs, cancel)
 
 	ephemeralJob, err := inProgressJobs.Claim(helloWorldImageDigest, helloWorldLayerDigest)
 	if err != nil {
@@ -556,5 +617,4 @@ func TestParallelStructCreation(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -552,9 +552,7 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 
 	premountCtx, cancel := context.WithCancelCause(context.Background())
 	premountCtx = namespaces.WithNamespace(premountCtx, ns)
-	imageJob := fs.inProgressImageUnpacks.GetOrAddImageJob(imageDigest, cancel)
 
-	// If we fail anywhere after making the image job, we must remove the associated image job
 	premountAll := func() error {
 		// We only want to premount all layers that don't exist yet.
 		// Since layer order is deterministic, we can safely assume that
@@ -574,7 +572,7 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 					}
 				}
 				if startPremounting {
-					layerJob, err := fs.inProgressImageUnpacks.AddLayerJob(imageJob, l.Digest.String())
+					layerJob, err := fs.inProgressImageUnpacks.AddLayerJob(imageDigest, l.Digest.String(), cancel)
 					if err != nil {
 						return fmt.Errorf("error adding layer job: %w", err)
 					}
@@ -586,7 +584,7 @@ func (fs *filesystem) preloadAllLayers(ctx context.Context, desc ocispec.Descrip
 	}
 
 	if err := premountAll(); err != nil {
-		fs.inProgressImageUnpacks.RemoveImageWithError(imageDigest, err)
+		cancel(err)
 	}
 	return err
 }
@@ -601,7 +599,8 @@ func (fs *filesystem) premount(ctx context.Context, desc ocispec.Descriptor, ref
 			err = cErr
 		}
 		if err != nil {
-			fs.inProgressImageUnpacks.RemoveImageWithError(layerJob.imageDigest, err)
+			layerJob.Cancel(err)
+			fs.inProgressImageUnpacks.Remove(layerJob)
 		}
 		layerJob.errCh <- err
 		close(layerJob.errCh)
@@ -643,16 +642,14 @@ func (fs *filesystem) premount(ctx context.Context, desc ocispec.Descriptor, ref
 func (fs *filesystem) rebase(ctx context.Context, dgst digest.Digest, imageDigest, mountpoint string) error {
 	layerJob, err := fs.inProgressImageUnpacks.Claim(imageDigest, dgst.String())
 	if err != nil {
-		fs.inProgressImageUnpacks.RemoveImageWithError(imageDigest, err)
 		return fmt.Errorf("error attempting to claim job to rebase: %w", err)
 	}
+
 	defer func() {
 		if err != nil {
 			layerJob.Cancel(err)
-			fs.inProgressImageUnpacks.RemoveImageWithError(layerJob.imageDigest, err)
-		} else {
-			fs.inProgressImageUnpacks.Remove(layerJob, err)
 		}
+		fs.inProgressImageUnpacks.Remove(layerJob)
 	}()
 
 	log.G(ctx).WithField("digest", dgst).Debug("claimed layer")
@@ -773,7 +770,7 @@ func (fs *filesystem) CleanImage(ctx context.Context, imgDigest string) error {
 		return nil
 	}
 
-	err := fs.inProgressImageUnpacks.RemoveImageWithError(imgDigest, context.Canceled)
+	err := fs.inProgressImageUnpacks.CleanImage(imgDigest)
 	if !errors.Is(err, ErrImageUnpackJobNotFound) && err != nil {
 		return fmt.Errorf("error removing image: %w", err)
 	}


### PR DESCRIPTION


**Issue #, if available:**
Fixes #2036 
Closes #2076 as an alternative

**Description of changes:**
This is a slight redesign of the parallel pull workflow, where the crux of the issue lies in a nil dereference between when an image is getting ready for a pull operation, and when it starts to premount. As there's no lock that stays in place between premounting and getting an image layer job, there was a race that would cause it to panic.

This specific fix is solvable enough via better locking mechanisms, which this does fix, however there's a lot of messy contention here, in particular with pulling the same image. We operate off the assumption that the same diffID will never be in-flight in SOCI (CRI has an option for this), but it doesn't stop separate requests from being de-duplicated, which is why we have a layerJob array instead of just a singular one per image pull. Solving this means separating out contexts to each request instead of just the one per image job, which required a whole restructuring. This should hopefully allow concurrent operations to both attempt an image pull, instead of one failure killing the whole image operation.

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
